### PR TITLE
feature/enhancement: YOLO mode, harness fallback, /security panel rew…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent"
-version = "0.1.1"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "base64",

--- a/src-agent/Cargo.toml
+++ b/src-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src-agent/src/app/awareness.rs
+++ b/src-agent/src/app/awareness.rs
@@ -109,3 +109,87 @@ pub async fn summarize(
         Err(_) => None,
     }
 }
+
+/// Like [`summarize`] but retries once with a fallback connection/model/provider
+/// when the primary call fails (i.e. the model call itself errored, not a disabled
+/// flag or missing docs). Only retries when the fallback differs from the primary
+/// (`fallback_model != model` OR `fallback_conn.endpoint != conn.endpoint`).
+///
+/// All early-return `None` cases (disabled, no docs) are preserved unchanged.
+/// The fallback is only attempted when the primary network/parse call actually
+/// errored, so a no-docs `None` is never retried.
+#[allow(clippy::too_many_arguments)]
+pub async fn summarize_with_fallback(
+    client: &OpenRouterClient,
+    settings: &Settings,
+    conn: Conn<'_>,
+    model: &str,
+    provider: &str,
+    workdir: &std::path::Path,
+    fallback_conn: Conn<'_>,
+    fallback_model: &str,
+    fallback_provider: &str,
+) -> Option<String> {
+    if !settings.awareness_enabled {
+        return None;
+    }
+
+    // Gather the docs corpus (same as `summarize`).
+    let mut corpus = String::new();
+    for name in DOC_FILES {
+        if corpus.len() >= CORPUS_CAP {
+            break;
+        }
+        let path = workdir.join(name);
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let body = cap_chars(raw.trim(), PER_FILE_CAP);
+        if body.trim().is_empty() {
+            continue;
+        }
+        let section = format!("## {name}\n{body}\n\n");
+        let remaining = CORPUS_CAP - corpus.len();
+        corpus.push_str(&cap_chars(&section, remaining));
+    }
+
+    let corpus = corpus.trim();
+    if corpus.is_empty() {
+        return None; // no docs — nothing to retry
+    }
+
+    let messages = vec![
+        ChatMessage::new(Role::System, SUMMARY_SYSTEM),
+        ChatMessage::new(Role::User, corpus),
+    ];
+
+    // Primary attempt.
+    match client.complete_with(conn, model, provider, messages.clone()).await {
+        Ok(s) => {
+            let s = s.trim();
+            if s.is_empty() {
+                None
+            } else {
+                Some(s.to_string())
+            }
+        }
+        Err(_) => {
+            // Primary call failed. Retry with the fallback route when it is
+            // meaningfully different (avoids a guaranteed-duplicate failure).
+            let same =
+                fallback_model == model && fallback_conn.endpoint == conn.endpoint;
+            if !same {
+                if let Ok(s) = client
+                    .complete_with(fallback_conn, fallback_model, fallback_provider, messages)
+                    .await
+                {
+                    let s = s.trim();
+                    if !s.is_empty() {
+                        return Some(s.to_string());
+                    }
+                }
+            }
+            None
+        }
+    }
+}

--- a/src-agent/src/app/harness.rs
+++ b/src-agent/src/app/harness.rs
@@ -293,9 +293,13 @@ async fn classify(
     if !route.is_routable() {
         return unavailable("safeguard provider not wired (Anthropic)".to_string());
     }
+    // Resolve the Main route now so we can fall back to it when the Safeguard call
+    // fails. Done unconditionally (cheap — no I/O) before the first attempt so the
+    // owned route is available in both branches of the match below.
+    let main_route = resolve_role(config, settings, ModelRole::Main);
     match tokio::time::timeout(
         CLASSIFY_TIMEOUT,
-        client.classify_with(route.conn(), &route.model_id, route.provider(), messages),
+        client.classify_with(route.conn(), &route.model_id, route.provider(), messages.clone()),
     )
     .await
     {
@@ -303,7 +307,35 @@ async fn classify(
             Some(v) => v,
             None => unavailable(format!("unparseable verdict: {}", truncate(&reply, 100))),
         },
-        Ok(Err(e)) => unavailable(format!("classifier error: {}", truncate(&e.to_string(), 100))),
+        Ok(Err(primary_err)) => {
+            // The Safeguard call failed. Retry ONCE with the Main route when it is
+            // meaningfully different (different model_id OR different endpoint). If
+            // Main resolves to the same route (same model + endpoint) the retry would
+            // fail the same way, so skip it. When Main is absent or equal, fall
+            // through to the unavailable verdict as before.
+            let should_retry = main_route.as_ref().is_some_and(|m| {
+                m.model_id != route.model_id || m.endpoint != route.endpoint
+            });
+            if let (true, Some(m)) = (should_retry, main_route.as_ref()) {
+                if let Ok(Ok(reply)) = tokio::time::timeout(
+                    CLASSIFY_TIMEOUT,
+                    client.classify_with(m.conn(), &m.model_id, m.provider(), messages),
+                )
+                .await
+                {
+                    match parse_verdict(&reply) {
+                        Some(v) => return v,
+                        None => {
+                            return unavailable(format!(
+                                "unparseable verdict (main fallback): {}",
+                                truncate(&reply, 100)
+                            ))
+                        }
+                    }
+                }
+            }
+            unavailable(format!("classifier error: {}", truncate(&primary_err.to_string(), 100)))
+        }
         Err(_) => unavailable("classifier timeout".to_string()),
     }
 }

--- a/src-agent/src/app/mode/mod.rs
+++ b/src-agent/src/app/mode/mod.rs
@@ -34,7 +34,7 @@ pub mod bash;
 
 pub use agents::{AgentEditField, AgentScope, AgentSubMode, AgentsState};
 pub use mcp::{McpEditField, McpState, McpSubMode};
-pub use security::SecurityState;
+pub use security::{SecSel, SecurityState};
 pub use bash::BashState;
 // `HelpEntry` is part of the module's public surface and will be consumed by the
 // daemon Help projection (follow-up); re-exported now so that lands without

--- a/src-agent/src/app/mode/security/mod.rs
+++ b/src-agent/src/app/mode/security/mod.rs
@@ -6,6 +6,26 @@
 
 use crate::app::sec::{InstallHealthEntry, SecStatus};
 
+/// One navigable row in the TOOLS pane.
+///
+/// The pane is a single flat list the cursor walks, but it mixes three kinds of row: the
+/// daemon-running checkbox at the very top, then the YOLO-arm checkbox, then the tool
+/// inventory grouped by domain. This enum names which kind a given cursor position is so
+/// render and nav agree on the layout. `Tool(usize)` carries an index into `status.tools`
+/// (the flat storage vector), NOT a position in the rendered list — the position is the
+/// index into [`SecurityState::tool_items`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecSel {
+    /// The daemon start/stop checkbox row (always rendered first). Toggling it starts the
+    /// daemon when stopped, stops it when running — folding the old s/x/t keybinds into a
+    /// navigable checkbox.
+    Daemon,
+    /// The YOLO-arm checkbox row (rendered second, after the daemon checkbox).
+    Yolo,
+    /// A tool row; the `usize` indexes into `status.tools`.
+    Tool(usize),
+}
+
 /// Working state for the `/security` daemon control panel.
 ///
 /// Holds a snapshot of the daemon status (refreshed on open + after each control key),
@@ -16,41 +36,128 @@ use crate::app::sec::{InstallHealthEntry, SecStatus};
 pub struct SecurityState {
     /// Latest status snapshot from the daemon manager (or a default when no manager).
     pub status: SecStatus,
-    /// Selected index into `status.tools` (the tool-inventory cursor).
+    /// Tool-pane cursor: an index into [`SecurityState::tool_items`] (the navigable rows
+    /// in RENDER order — the daemon checkbox, then the YOLO checkbox, then tools grouped by
+    /// domain), NOT into the flat `status.tools` vector. This is what keeps nav order ==
+    /// render order: both
+    /// the renderer and the move/clamp logic walk the same `tool_items()` list, so the
+    /// highlight always lands on the row visually below/above.
     pub selected: usize,
     /// Tool names the user has disabled (the inactive set), mirrored from
     /// `state.rest.sec_inactive`. Empty = every tool active. The view dims a row whose
     /// name is in this set; the toggle actions flip membership on `state.rest` and
     /// refresh this copy.
     pub inactive: std::collections::HashSet<String>,
+    /// YOLO-mode arm flag, mirrored from `state.rest.yolo_armed` (like `inactive`).
+    /// The panel renders the YOLO checkbox row from this; toggling that row (Space/Enter
+    /// while it is selected) flips `state.rest.yolo_armed` and refreshes this copy.
+    pub yolo_armed: bool,
     /// Per-dependency install-health, fetched once on panel open (and re-fetched after
     /// an install). Empty when the daemon is stopped / no health data is available.
     pub install_health: Vec<InstallHealthEntry>,
     /// Which body pane is showing: `false` = tools (default), `true` = dependencies.
     pub health_view: bool,
-    /// Selected index into `install_health` (the dependency-pane cursor).
+    /// Dependency-pane cursor: an index into [`SecurityState::health_items`] (the
+    /// install-health rows in tier-grouped RENDER order), NOT into the flat
+    /// `install_health` vector — same nav/render-sync trick as `selected`.
     pub health_selected: usize,
+    /// `true` while a NON-BLOCKING health probe is in flight (the receiver lives in
+    /// `state.rest.sec_health_rx`). Drives the loading spinner on the daemon info line;
+    /// cleared by `service_global` when the probe lands. Projected to the thin client so
+    /// it shows the same "checking dependencies…" state.
+    pub health_fetching: bool,
+    /// Braille spinner frame counter for the in-flight health probe, advanced each tick
+    /// by `service_global` while `state.rest.sec_health_rx` is `Some`. Projected so the
+    /// client animates the spinner from this counter (it owns no manager / receiver of
+    /// its own).
+    pub health_frame: u64,
 }
 
 impl SecurityState {
-    /// Build from a live status snapshot + the disabled-tool set + the install-health
-    /// list, both cursors at the top, showing the tools pane by default.
+    /// Build from a live status snapshot, the disabled-tool set, the YOLO arm flag, and
+    /// the install-health list, both cursors at the top, showing the tools pane by
+    /// default.
     pub fn new(
         status: SecStatus,
         inactive: std::collections::HashSet<String>,
+        yolo_armed: bool,
         install_health: Vec<InstallHealthEntry>,
     ) -> Self {
         Self {
             status,
             selected: 0,
             inactive,
+            yolo_armed,
             install_health,
             health_view: false,
             health_selected: 0,
+            health_fetching: false,
+            health_frame: 0,
         }
     }
 
-    /// Move the cursor up by one (saturating at 0) in the ACTIVE pane.
+    /// The navigable rows of the TOOLS pane, IN RENDER ORDER — the single source of truth
+    /// shared by the renderer and the cursor logic (so nav order can never desync from
+    /// what is on screen).
+    ///
+    /// Order: the daemon checkbox first (`SecSel::Daemon`), then the YOLO checkbox
+    /// (`SecSel::Yolo`), then the tools grouped by domain. Domains are taken in first-seen
+    /// (insertion) order, exactly as the renderer groups them; within each domain the tools
+    /// keep their `status.tools` iteration order. The returned `usize` in each
+    /// `SecSel::Tool(i)` indexes back into `status.tools`.
+    pub fn tool_items(&self) -> Vec<SecSel> {
+        let mut items = vec![SecSel::Daemon, SecSel::Yolo];
+        // Distinct domains in first-seen order (matches the renderer's grouping).
+        let mut domains: Vec<&str> = Vec::new();
+        for t in &self.status.tools {
+            if !domains.iter().any(|d| *d == t.domain) {
+                domains.push(&t.domain);
+            }
+        }
+        for domain in &domains {
+            for (i, t) in self.status.tools.iter().enumerate() {
+                if t.domain == *domain {
+                    items.push(SecSel::Tool(i));
+                }
+            }
+        }
+        items
+    }
+
+    /// The navigable rows of the DEPENDENCIES pane, IN RENDER ORDER: indices into
+    /// `install_health`, grouped by tier (distinct tiers ascending, then each entry of
+    /// that tier in `install_health` order) — matching `render_deps`. The dependency
+    /// counterpart of [`SecurityState::tool_items`].
+    pub fn health_items(&self) -> Vec<usize> {
+        let mut tiers: Vec<u8> = Vec::new();
+        for e in &self.install_health {
+            if !tiers.contains(&e.tier) {
+                tiers.push(e.tier);
+            }
+        }
+        tiers.sort_unstable();
+        let mut items: Vec<usize> = Vec::new();
+        for tier in &tiers {
+            for (i, e) in self.install_health.iter().enumerate() {
+                if e.tier == *tier {
+                    items.push(i);
+                }
+            }
+        }
+        items
+    }
+
+    /// The currently-selected tool-pane row, resolved through `tool_items()` so it always
+    /// reflects render order. `None` only when the list is somehow empty (it never is —
+    /// the daemon + YOLO rows are always present — but the bounds-checked `get` keeps it
+    /// total).
+    pub fn selected_sec(&self) -> Option<SecSel> {
+        self.tool_items().get(self.selected).copied()
+    }
+
+    /// Move the cursor up by one (saturating at 0) in the ACTIVE pane. `selected` /
+    /// `health_selected` are positions in the respective `*_items()` list, so plain
+    /// saturating decrement walks the rendered rows.
     pub fn move_up(&mut self) {
         if self.health_view {
             self.health_selected = self.health_selected.saturating_sub(1);
@@ -59,15 +166,16 @@ impl SecurityState {
         }
     }
 
-    /// Move the cursor down by one in the ACTIVE pane (clamped to that pane's last row).
+    /// Move the cursor down by one in the ACTIVE pane, clamped to that pane's last
+    /// navigable row (the last index into the active `*_items()` list).
     pub fn move_down(&mut self) {
         if self.health_view {
-            let max = self.install_health.len().saturating_sub(1);
+            let max = self.health_items().len().saturating_sub(1);
             if self.health_selected < max {
                 self.health_selected += 1;
             }
         } else {
-            let max = self.status.tools.len().saturating_sub(1);
+            let max = self.tool_items().len().saturating_sub(1);
             if self.selected < max {
                 self.selected += 1;
             }
@@ -81,33 +189,42 @@ impl SecurityState {
         self.clamp_cursors();
     }
 
-    /// Replace the status snapshot + disabled-tool set (called after start/stop/restart
-    /// or a tool/domain toggle to reflect the new state without re-opening the panel).
+    /// Replace the status snapshot + disabled-tool set + YOLO arm flag (called after
+    /// start/stop/restart, a tool/domain toggle, or the YOLO arm toggle to reflect the
+    /// new state without re-opening the panel).
     ///
     /// PRESERVES `install_health` (carried from `&self`): re-fetching it is a heavy IPC
     /// round-trip, so a plain lifecycle refresh must not pay it. The install path seeds
     /// fresh health out-of-band (see `refresh_security_state`).
-    pub fn refresh(&mut self, status: SecStatus, inactive: std::collections::HashSet<String>) {
+    pub fn refresh(
+        &mut self,
+        status: SecStatus,
+        inactive: std::collections::HashSet<String>,
+        yolo_armed: bool,
+    ) {
         self.status = status;
         self.inactive = inactive;
+        self.yolo_armed = yolo_armed;
         // `install_health` is intentionally untouched here — it is carried across refreshes.
         self.clamp_cursors();
     }
 
-    /// Clamp BOTH pane cursors against their current row counts (called after any change
-    /// that could shrink a list — daemon stopped → 0 tools, or a refreshed health list).
+    /// Clamp BOTH pane cursors against their current navigable-row counts (called after
+    /// any change that could shrink a list — daemon stopped → tools vanish, or a refreshed
+    /// health list). Cursors index the `*_items()` lists, so clamp against those, not the
+    /// raw vectors.
     fn clamp_cursors(&mut self) {
-        let tool_max = self.status.tools.len().saturating_sub(1);
-        if self.status.tools.is_empty() {
+        let tool_len = self.tool_items().len();
+        if tool_len == 0 {
             self.selected = 0;
-        } else if self.selected > tool_max {
-            self.selected = tool_max;
+        } else if self.selected >= tool_len {
+            self.selected = tool_len - 1;
         }
-        let health_max = self.install_health.len().saturating_sub(1);
-        if self.install_health.is_empty() {
+        let health_len = self.health_items().len();
+        if health_len == 0 {
             self.health_selected = 0;
-        } else if self.health_selected > health_max {
-            self.health_selected = health_max;
+        } else if self.health_selected >= health_len {
+            self.health_selected = health_len - 1;
         }
     }
 }

--- a/src-agent/src/app/runtime/actions/mod.rs
+++ b/src-agent/src/app/runtime/actions/mod.rs
@@ -191,18 +191,9 @@ pub(in crate::app::runtime) fn apply_action(
             security::handle_close_security(state)?;
         }
 
-        Action::SecurityToggle => {
-            security::handle_security_toggle(state)?;
-        }
-
-        Action::SecurityStart => {
-            security::handle_security_start(state)?;
-        }
-
-        Action::SecurityStop => {
-            security::handle_security_stop(state)?;
-        }
-
+        // Daemon start/stop/toggle no longer have their own Actions — the Daemon checkbox
+        // (handled inside `SecurityToggleTool`) starts/stops the daemon directly, calling
+        // `handle_security_start` / `handle_security_stop`. Only restart keeps a key (`r`).
         Action::SecurityRestart => {
             security::handle_security_restart(state)?;
         }

--- a/src-agent/src/app/runtime/actions/security.rs
+++ b/src-agent/src/app/runtime/actions/security.rs
@@ -2,13 +2,16 @@
 //!
 //! Actions:
 //! - `CloseSecurity`        — return to Chat.
-//! - `SecurityToggle`       — flip `security_enabled`; start or stop the daemon accordingly.
-//! - `SecurityStart`        — start the daemon (no-op when already running).
-//! - `SecurityStop`         — stop the daemon (no-op when not running).
-//! - `SecurityRestart`      — stop then start the daemon.
-//! - `SecurityToggleTool`   — toggle the selected tool's active state (membership in
-//!   `state.rest.sec_inactive`).
-//! - `SecurityToggleDomain` — toggle every tool sharing the selected tool's domain.
+//! - `SecurityRestart`      — stop then start the daemon (`r`; the only daemon-lifecycle
+//!   action with its own key — start/stop/toggle fold into the Daemon checkbox).
+//! - `SecurityToggleTool`   — toggle the SELECTED row. The tools pane mixes the daemon
+//!   checkbox (row 0) and the YOLO checkbox (row 1) with the tool inventory, so this
+//!   branches on the selected [`SecSel`]: `Daemon` starts/stops the daemon; `Yolo`
+//!   arms/disarms the Layer-1 YOLO flag (gated on the daemon running; disarming while in
+//!   Yolo drops `agent_mode` back to Auto); `Tool(i)` flips that tool's membership in
+//!   `state.rest.sec_inactive`.
+//! - `SecurityToggleDomain` — toggle every tool sharing the selected tool's domain
+//!   (no-op when the daemon or YOLO checkbox is selected — it has no domain).
 //! - `SecurityInstall`      — install/repair one dependency, then re-fetch install-health.
 //!
 //! After every lifecycle action the open `Mode::Security` state is refreshed from
@@ -18,9 +21,9 @@
 
 use anyhow::Result;
 
-use crate::app::mode::Mode;
+use crate::app::mode::{Mode, SecSel};
 use crate::app::sec::InstallHealthEntry;
-use crate::app::state::AppState;
+use crate::app::state::{AgentMode, AppState};
 
 /// Handle `Action::CloseSecurity`: return to Chat.
 pub(super) fn handle_close_security(state: &mut AppState) -> Result<()> {
@@ -29,29 +32,8 @@ pub(super) fn handle_close_security(state: &mut AppState) -> Result<()> {
     Ok(())
 }
 
-/// Handle `Action::SecurityToggle`: flip `security_enabled`.
-///
-/// If now enabled → start the daemon (or no-op when already running).
-/// If now disabled → stop the daemon.
-/// Refreshes the open panel's status snapshot after the state change.
-pub(super) fn handle_security_toggle(state: &mut AppState) -> Result<()> {
-    state.rest.security_enabled = !state.rest.security_enabled;
-    if state.rest.security_enabled {
-        if let Some(m) = state.rest.sec_manager.as_ref() {
-            m.start(state.rest.sec_token.clone());
-        }
-        state.rest.status = "security: enabling daemon…".into();
-    } else {
-        if let Some(m) = state.rest.sec_manager.as_ref() {
-            m.stop();
-        }
-        state.rest.status = "security: daemon stopped".into();
-    }
-    refresh_security_state(state, None);
-    Ok(())
-}
-
-/// Handle `Action::SecurityStart`: start the daemon.
+/// Start the daemon. Called when the Daemon checkbox is toggled ON (from
+/// `handle_security_toggle_tool`).
 ///
 /// Sets `security_enabled` to true so subsequent turns advertise sec_ tools.
 pub(super) fn handle_security_start(state: &mut AppState) -> Result<()> {
@@ -64,53 +46,157 @@ pub(super) fn handle_security_start(state: &mut AppState) -> Result<()> {
     Ok(())
 }
 
-/// Handle `Action::SecurityStop`: stop the daemon.
+/// Stop the daemon. Called when the Daemon checkbox is toggled OFF (from
+/// `handle_security_toggle_tool`).
 ///
-/// Clears `security_enabled` so sec_ tools are no longer advertised.
+/// Clears `security_enabled` so sec_ tools are no longer advertised. ENFORCES the
+/// "YOLO requires a running daemon" invariant: stopping the daemon always disarms YOLO
+/// (and drops out of `Yolo` agent mode) so a harness-bypass can never outlive the daemon.
 pub(super) fn handle_security_stop(state: &mut AppState) -> Result<()> {
     state.rest.security_enabled = false;
     if let Some(m) = state.rest.sec_manager.as_ref() {
         m.stop();
     }
+    disarm_yolo_for_stop(state);
     state.rest.status = "security: daemon stopped".into();
     refresh_security_state(state, None);
     Ok(())
 }
 
+/// Disarm YOLO when the daemon is stopped (any stop route: the Daemon checkbox, the stop
+/// handler, or the stop portion of a restart). Keeps "YOLO requires a running daemon" true:
+/// clears `rest.yolo_armed`, and if currently sitting in `Yolo` agent mode, falls back to
+/// `Auto` so the bypass turns off the instant the daemon goes down.
+fn disarm_yolo_for_stop(state: &mut AppState) {
+    if state.rest.yolo_armed {
+        state.rest.yolo_armed = false;
+        if state.rest.agent_mode == AgentMode::Yolo {
+            state.rest.agent_mode = AgentMode::Auto;
+        }
+    }
+}
+
 /// Handle `Action::SecurityRestart`: stop then start the daemon.
 ///
-/// Keeps `security_enabled = true` so sec_ tools remain advertised after restart.
+/// Keeps `security_enabled = true` so sec_ tools remain advertised after restart. The
+/// stop portion of a restart still enforces the YOLO invariant — restarting disarms YOLO
+/// (acceptable: the user re-arms after the daemon is back up).
 pub(super) fn handle_security_restart(state: &mut AppState) -> Result<()> {
     state.rest.security_enabled = true;
     if let Some(m) = state.rest.sec_manager.as_ref() {
         m.restart(state.rest.sec_token.clone());
     }
+    disarm_yolo_for_stop(state);
     state.rest.status = "security: restarting daemon…".into();
     refresh_security_state(state, None);
     Ok(())
 }
 
-/// Handle `Action::SecurityToggleTool`: flip the currently-selected tool's active
-/// state by toggling its name in `state.rest.sec_inactive`.
+/// What `Action::SecurityToggleTool` resolved the selected row to, lifted out of the
+/// panel before any `rest` mutation so the borrow is released. Mirrors [`SecSel`] but
+/// carries the tool's resolved *name* (not its index) for the tool case.
+enum ToggleTarget {
+    /// The daemon checkbox: start the daemon if stopped, stop it if running.
+    Daemon,
+    /// The YOLO checkbox: arm/disarm (gated on the daemon running).
+    Yolo,
+    /// A tool row, resolved to its name.
+    Tool(String),
+}
+
+/// Handle `Action::SecurityToggleTool`: toggle whatever row is selected in the tools
+/// pane. The pane mixes the daemon checkbox (row 0) and the YOLO checkbox (row 1) with the
+/// tool inventory, so this reads the selected [`SecSel`] (resolved through the panel's
+/// render-ordered item list) and branches:
 ///
-/// The selected tool is `status.tools[selected]`. If it is currently active (not in
-/// the set) it is disabled (inserted); if disabled it is re-enabled (removed). A no-op
-/// when there is no selected tool (empty inventory). Refreshes the panel after.
+/// - `SecSel::Daemon` → toggle the daemon: STOP it when running, START it when stopped,
+///   reusing the existing stop/start handlers (so the stop path also enforces the
+///   YOLO-disarm invariant).
+/// - `SecSel::Yolo` → flip the Layer-1 YOLO arm flag (the checkbox), GATED on the daemon
+///   running: refused (no state change) when the daemon is stopped. When running, arming
+///   merely UNLOCKS the `Yolo` agent mode (the user still switches in via `/mode yolo` /
+///   Shift+Tab); disarming while currently in `Yolo` drops `agent_mode` back to `Auto` so
+///   the harness-bypass can never outlive its arm.
+/// - `SecSel::Tool(i)` → flip `status.tools[i]`'s membership in `state.rest.sec_inactive`
+///   (active → disabled, disabled → active).
+///
+/// A no-op when nothing is selected. Refreshes the panel after.
 pub(super) fn handle_security_toggle_tool(state: &mut AppState) -> Result<()> {
-    // Resolve the selected tool's name out of the open panel, then mutate `rest`.
-    let name = if let Mode::Security(s) = &state.mode {
-        s.status.tools.get(s.selected).map(|t| t.name.clone())
+    // Resolve the selected row (and, for a tool, its name) out of the open panel BEFORE
+    // mutating `rest` — `selected_sec()` walks the same render-ordered list the cursor and
+    // view use, so this targets exactly the highlighted row.
+    let target = if let Mode::Security(s) = &state.mode {
+        match s.selected_sec() {
+            Some(SecSel::Daemon) => Some(ToggleTarget::Daemon),
+            Some(SecSel::Yolo) => Some(ToggleTarget::Yolo),
+            Some(SecSel::Tool(i)) => s
+                .status
+                .tools
+                .get(i)
+                .map(|t| ToggleTarget::Tool(t.name.clone())),
+            None => None,
+        }
     } else {
         None
     };
-    if let Some(name) = name {
-        if state.rest.sec_inactive.contains(&name) {
-            state.rest.sec_inactive.remove(&name);
-            state.rest.status = format!("security: {name} enabled");
-        } else {
-            state.rest.sec_inactive.insert(name.clone());
-            state.rest.status = format!("security: {name} disabled");
+
+    match target {
+        // Daemon checkbox row: toggle the daemon via the existing start/stop handlers.
+        // Branch on the LIVE manager running flag (authoritative), not the mode-state copy.
+        // The stop handler enforces the YOLO-disarm invariant; both handlers refresh the
+        // panel, so the trailing refresh below is just belt-and-suspenders.
+        Some(ToggleTarget::Daemon) => {
+            let running = state
+                .rest
+                .sec_manager
+                .as_ref()
+                .map(|m| m.status().running)
+                .unwrap_or(false);
+            if running {
+                handle_security_stop(state)?;
+            } else {
+                handle_security_start(state)?;
+            }
+            return Ok(());
         }
+        // YOLO checkbox row: arm/disarm — GATED on the daemon running.
+        Some(ToggleTarget::Yolo) => {
+            let running = state
+                .rest
+                .sec_manager
+                .as_ref()
+                .map(|m| m.status().running)
+                .unwrap_or(false);
+            if !running {
+                // Daemon stopped: refuse the arm (YOLO requires a running daemon). Leave
+                // `yolo_armed` untouched and tell the user what to do.
+                state.rest.status = "yolo locked — start the daemon first".into();
+            } else {
+                state.rest.yolo_armed = !state.rest.yolo_armed;
+                if state.rest.yolo_armed {
+                    state.rest.status = "yolo armed — switch with /mode yolo or Shift+Tab".into();
+                } else {
+                    // Disarmed: if we're sitting in Yolo right now, fall straight back to
+                    // Auto so the bypass turns off the instant it's disarmed.
+                    if state.rest.agent_mode == AgentMode::Yolo {
+                        state.rest.agent_mode = AgentMode::Auto;
+                    }
+                    state.rest.status = "yolo disarmed".into();
+                }
+            }
+        }
+        // Tool row: flip its active state.
+        Some(ToggleTarget::Tool(name)) => {
+            if state.rest.sec_inactive.contains(&name) {
+                state.rest.sec_inactive.remove(&name);
+                state.rest.status = format!("security: {name} enabled");
+            } else {
+                state.rest.sec_inactive.insert(name.clone());
+                state.rest.status = format!("security: {name} disabled");
+            }
+        }
+        // Tool row whose index didn't resolve (stale cursor), or nothing selected: no-op.
+        None => {}
     }
     refresh_security_state(state, None);
     Ok(())
@@ -120,22 +206,29 @@ pub(super) fn handle_security_toggle_tool(state: &mut AppState) -> Result<()> {
 /// tool's domain.
 ///
 /// If ALL tools in that domain are currently active, disable them all; otherwise (any
-/// already disabled) enable them all. A no-op when there is no selected tool. Refreshes
-/// the panel after.
+/// already disabled) enable them all. Resolves the selected row through the panel's
+/// render-ordered item list and acts ONLY on a `SecSel::Tool(i)` (using `status.tools[i]`
+/// for the domain); when the daemon or YOLO checkbox is selected it has no domain, so this
+/// is a no-op with an explanatory status. Refreshes the panel after.
 pub(super) fn handle_security_toggle_domain(state: &mut AppState) -> Result<()> {
-    // Resolve the selected tool's domain + every tool name in it out of the panel.
+    // Resolve the selected tool's domain + every tool name in it out of the panel. Only a
+    // tool row has a domain; the daemon and YOLO checkboxes resolve to `None` here.
     let domain_tools: Option<(String, Vec<String>)> = if let Mode::Security(s) = &state.mode {
-        s.status.tools.get(s.selected).map(|sel| {
-            let domain = sel.domain.clone();
-            let names = s
-                .status
-                .tools
-                .iter()
-                .filter(|t| t.domain == domain)
-                .map(|t| t.name.clone())
-                .collect::<Vec<_>>();
-            (domain, names)
-        })
+        match s.selected_sec() {
+            Some(SecSel::Tool(i)) => s.status.tools.get(i).map(|sel| {
+                let domain = sel.domain.clone();
+                let names = s
+                    .status
+                    .tools
+                    .iter()
+                    .filter(|t| t.domain == domain)
+                    .map(|t| t.name.clone())
+                    .collect::<Vec<_>>();
+                (domain, names)
+            }),
+            // Daemon/YOLO checkbox (or nothing) selected: no domain to toggle.
+            _ => None,
+        }
     } else {
         None
     };
@@ -154,6 +247,9 @@ pub(super) fn handle_security_toggle_domain(state: &mut AppState) -> Result<()> 
             }
             state.rest.status = format!("security: domain [{domain}] enabled");
         }
+    } else {
+        // No tool row selected (the YOLO checkbox has no domain).
+        state.rest.status = "security: no domain selected".into();
     }
     refresh_security_state(state, None);
     Ok(())
@@ -205,12 +301,13 @@ fn refresh_security_state(state: &mut AppState, fresh_health: Option<Vec<Install
         .map(|m| m.status())
         .unwrap_or_default();
     let inactive = state.rest.sec_inactive.clone();
+    let yolo_armed = state.rest.yolo_armed;
     if let Mode::Security(s) = &mut state.mode {
         // `refresh` preserves `install_health`; overwrite it only when the install path
         // handed us a fresh probe. `refresh` re-clamps both cursors afterwards.
         if let Some(health) = fresh_health {
             s.install_health = health;
         }
-        s.refresh(status, inactive);
+        s.refresh(status, inactive, yolo_armed);
     }
 }

--- a/src-agent/src/app/runtime/client/shadow.rs
+++ b/src-agent/src/app/runtime/client/shadow.rs
@@ -148,8 +148,11 @@ pub(super) fn apply_snapshot(shadow: &mut AppState, snap: StateSnapshot) {
     shadow.rest.config.theme = shadow_theme(&global.theme);
     shadow.rest.config.accent = global.accent;
     // Agent mode: decode from the wire token so the header reflects the current mode.
+    // "yolo" must be decoded explicitly — falling to the `_ => Auto` default would
+    // silently drop the loud-red Yolo header on the thin client.
     shadow.rest.agent_mode = match global.agent_mode.as_str() {
         "normal" => AgentMode::Normal,
+        "yolo"   => AgentMode::Yolo,
         _        => AgentMode::Auto,
     };
     // The shadow `AppConfig`'s registered-model + provider catalogue is populated

--- a/src-agent/src/app/runtime/client_shadow/modes.rs
+++ b/src-agent/src/app/runtime/client_shadow/modes.rs
@@ -587,11 +587,17 @@ pub(crate) fn shadow_security(s: SecuritySnapshot) -> SecurityState {
         // The projected inactive set rides as a sorted Vec; rebuild the HashSet the
         // view + render path read from.
         inactive: s.inactive.into_iter().collect(),
+        // YOLO arm flag rides verbatim so the client's panel renders the armed row.
+        yolo_armed: s.yolo_armed,
         // Install-health + the pane toggle + its cursor ride verbatim so the client
         // renders the same dependency pane the daemon would.
         install_health: s.install_health,
         health_view: s.health_view,
         health_selected: s.health_selected,
+        // Spinner state rides verbatim — the client renders + animates the
+        // "checking dependencies…" line from the daemon's projected frame counter.
+        health_fetching: s.health_fetching,
+        health_frame: s.health_frame,
     }
 }
 

--- a/src-agent/src/app/runtime/commands/misc.rs
+++ b/src-agent/src/app/runtime/commands/misc.rs
@@ -4,13 +4,42 @@
 use anyhow::Result;
 
 use crate::app::mode::{AgentsState, HelpState, Mode, SettingsState};
-use crate::app::state::AppState;
+use crate::app::state::{AgentMode, AppState};
 use crate::app::version;
 use crate::model::store;
 
-/// Handle the `/mode` command: toggle chat ↔ agentic mode.
-pub(super) fn handle_mode(state: &mut AppState) -> Result<()> {
-    state.rest.agent_mode = state.rest.agent_mode.toggled();
+/// Handle the `/mode` command.
+///
+/// `arg` (the token after `/mode`, already lowercased):
+/// - `None` → armed-aware CYCLE (Auto→Normal→[Yolo when armed]→Auto), the same
+///   transition as Shift+Tab.
+/// - `Some("auto")` / `Some("normal")` → explicitly set that mode (always allowed).
+/// - `Some("yolo")` → enter YOLO **only when armed** (Layer 2). When NOT armed it
+///   REFUSES: the mode is left unchanged and the status explains how to unlock it.
+/// - any other token → leave the mode unchanged and report the bad argument.
+pub(super) fn handle_mode(state: &mut AppState, arg: Option<String>) -> Result<()> {
+    match arg.as_deref() {
+        None => {
+            // Bare `/mode`: armed-aware cycle (identical to the Shift+Tab toggle).
+            state.rest.agent_mode = state.rest.agent_mode.cycle(state.rest.yolo_armed);
+        }
+        Some("auto") => state.rest.agent_mode = AgentMode::Auto,
+        Some("normal") => state.rest.agent_mode = AgentMode::Normal,
+        Some("yolo") => {
+            // Layer-2 gate: only an ARMED YOLO may be entered. Unarmed → refuse and
+            // leave the mode untouched.
+            if state.rest.yolo_armed {
+                state.rest.agent_mode = AgentMode::Yolo;
+            } else {
+                state.rest.status = "yolo locked — enable it in /security first".into();
+                return Ok(());
+            }
+        }
+        Some(other) => {
+            state.rest.status = format!("unknown mode: {other} (auto | normal | yolo)");
+            return Ok(());
+        }
+    }
     state.rest.status = format!("mode: {}", state.rest.agent_mode.label());
     Ok(())
 }

--- a/src-agent/src/app/runtime/commands/mod.rs
+++ b/src-agent/src/app/runtime/commands/mod.rs
@@ -19,7 +19,10 @@ pub(crate) mod internet;
 mod mcp;
 mod misc;
 pub(crate) mod new_session;
-mod security;
+// `pub(crate)` so the shared `kick_off_health_probe` helper is reachable from BOTH the
+// `/security` command (panel open) and the input-path self-heal (controller), which must
+// start the non-blocking health probe with identical semantics.
+pub(crate) mod security;
 mod task;
 
 /// Apply a parsed slash command. Like [`apply_action`], it mutates state and
@@ -33,7 +36,7 @@ pub(super) fn apply_slash(
     match cmd {
         Command::Compact => compact::handle_compact(state, client, handle)?,
         Command::New(mode) => new_session::handle_new(state, client, handle, mode)?,
-        Command::Mode => misc::handle_mode(state)?,
+        Command::Mode(arg) => misc::handle_mode(state, arg)?,
         Command::Effort => effort::handle_effort(state, client)?,
         Command::Rename(name) => new_session::handle_rename(state, name)?,
         Command::Settings => misc::handle_settings(state)?,

--- a/src-agent/src/app/runtime/commands/security.rs
+++ b/src-agent/src/app/runtime/commands/security.rs
@@ -3,7 +3,34 @@
 use anyhow::Result;
 
 use crate::app::mode::{Mode, SecurityState};
-use crate::app::state::AppState;
+use crate::app::state::{AppState, AppStateRest};
+
+/// Kick off a NON-BLOCKING per-dependency health probe if one is warranted, stashing the
+/// receiver in `rest.sec_health_rx` for `service_global` to drain. Returns `true` iff a
+/// probe was actually started (so the caller can flip `SecurityState::health_fetching`).
+///
+/// The single place that starts a probe, so panel-open and the input-path self-heal share
+/// identical kick-off semantics. A probe is started only when:
+/// - a daemon manager exists (`rest.sec_manager` is `Some`), AND
+/// - the daemon is running (a stopped daemon has no health to report — `health()` would
+///   just error), AND
+/// - no probe is already in flight (`rest.sec_health_rx.is_none()` — don't double-fire).
+///
+/// `health_async` returns immediately (the blocking IPC runs on a blocking-pool thread),
+/// so this never blocks the UI/input thread.
+pub(crate) fn kick_off_health_probe(rest: &mut AppStateRest) -> bool {
+    if rest.sec_health_rx.is_some() {
+        return false;
+    }
+    let Some(mgr) = rest.sec_manager.as_ref() else {
+        return false;
+    };
+    if !mgr.is_running() {
+        return false;
+    }
+    rest.sec_health_rx = Some(mgr.health_async());
+    true
+}
 
 /// Handle the `/security` command: open the security daemon control panel.
 ///
@@ -24,17 +51,20 @@ pub(super) fn handle_security(state: &mut AppState) -> Result<()> {
         .as_ref()
         .map(|m| m.status())
         .unwrap_or_default();
-    // Fetch the per-dependency install-health ONCE on open. `health()` is a heavy IPC
-    // round-trip, so it is fetched here (and after an install) and carried thereafter —
-    // never on a plain refresh. `Err` / no manager / daemon stopped → empty vec, and
-    // the panel still opens (the deps pane just shows "no health data").
-    let install_health = state
-        .rest
-        .sec_manager
-        .as_ref()
-        .and_then(|m| m.health().ok())
-        .unwrap_or_default();
-    let st = SecurityState::new(status, state.rest.sec_inactive.clone(), install_health);
+    // Per-dependency install-health is fetched NON-BLOCKING. `health()` is a cold ~1-2s
+    // IPC round-trip; running it here on the UI thread froze the panel on first open.
+    // Instead open with an EMPTY list and kick off the async probe (when the daemon is
+    // running) — `service_global` drains the result into `install_health` and clears the
+    // spinner. A stopped daemon / no manager starts no probe (the deps pane shows
+    // "no health data" until it is started, exactly as before).
+    let fetching = kick_off_health_probe(&mut state.rest);
+    let mut st = SecurityState::new(
+        status,
+        state.rest.sec_inactive.clone(),
+        state.rest.yolo_armed,
+        Vec::new(),
+    );
+    st.health_fetching = fetching;
     state.mode = Mode::Security(Box::new(st));
     Ok(())
 }

--- a/src-agent/src/app/runtime/event_loop/drains.rs
+++ b/src-agent/src/app/runtime/event_loop/drains.rs
@@ -99,19 +99,40 @@ pub(super) fn apply_compaction_result(
     if let Some((c, config, settings, workdir)) = aware_inputs {
         // Resolve the Awareness role (endpoint + key + model + upstream-route slug)
         // for the summary call; Awareness always resolves, but guard defensively.
+        // Also resolve the Main route as a fallback: when the Awareness model call
+        // itself fails (e.g. bad/typo'd model name) we retry once on the trusted
+        // Main route before giving up.
         if let Some(r) = crate::app::resolve::resolve_role(
             &config,
             &settings,
             crate::model::app_config::ModelRole::Awareness,
         ) {
-            let s = handle.block_on(crate::app::awareness::summarize(
-                &c,
+            let main_route = crate::app::resolve::resolve_role(
+                &config,
                 &settings,
-                r.conn(),
-                &r.model_id,
-                r.provider(),
-                &workdir,
-            ));
+                crate::model::app_config::ModelRole::Main,
+            );
+            let s = match main_route {
+                Some(ref m) => handle.block_on(crate::app::awareness::summarize_with_fallback(
+                    &c,
+                    &settings,
+                    r.conn(),
+                    &r.model_id,
+                    r.provider(),
+                    &workdir,
+                    m.conn(),
+                    &m.model_id,
+                    m.provider(),
+                )),
+                None => handle.block_on(crate::app::awareness::summarize(
+                    &c,
+                    &settings,
+                    r.conn(),
+                    &r.model_id,
+                    r.provider(),
+                    &workdir,
+                )),
+            };
             state.rest.fg_mut().awareness_summary = s;
         }
     }

--- a/src-agent/src/app/runtime/event_loop/global.rs
+++ b/src-agent/src/app/runtime/event_loop/global.rs
@@ -112,6 +112,47 @@ pub(super) fn service_global(
         state.rest.version_rx = Some(vrx);
     }
 
+    // Drain the NON-BLOCKING security health probe (mirrors the `version_rx` drain). A
+    // `SecDaemonManager::health_async` fetch sends exactly one result: Ok(entries) on a
+    // successful probe, Ok(Err(msg)) when the daemon reported/timed-out an error. Fold a
+    // success into the OPEN `/security` panel's `install_health` and clear the spinner;
+    // toast an error. Take() the receiver so the arms can mutate `state.mode`; put it back
+    // only while still Empty (a delivered result OR a closed channel ends the probe). On
+    // any terminal outcome the spinner flag is cleared so a panel that is open stops
+    // animating. Non-blocking (try_recv).
+    if let Some(mut hrx) = state.rest.sec_health_rx.take() {
+        match hrx.try_recv() {
+            Ok(Ok(health)) => {
+                if let Mode::Security(s) = &mut state.mode {
+                    s.install_health = health;
+                    s.health_fetching = false;
+                }
+                // Receiver consumed (one-shot result delivered) → don't put it back.
+                dirty = true;
+            }
+            Ok(Err(e)) => {
+                state.rest.set_toast(format!("security health probe failed: {e}"));
+                if let Mode::Security(s) = &mut state.mode {
+                    s.health_fetching = false;
+                }
+                // Receiver consumed → don't put it back.
+                dirty = true;
+            }
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                // Still in flight — keep the receiver for the next tick.
+                state.rest.sec_health_rx = Some(hrx);
+            }
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                // Sender dropped without sending (shouldn't happen — the spawn always
+                // sends — but stay clean): end the probe, clear the spinner.
+                if let Mode::Security(s) = &mut state.mode {
+                    s.health_fetching = false;
+                }
+                dirty = true;
+            }
+        }
+    }
+
     // Drain the startup-warming channel. Fully independent of streaming: the
     // background catalogue + awareness tasks each send one [`WarmEvent`]. ALWAYS
     // fold the result into `state.rest.*` (the cache / summary) regardless of the
@@ -351,16 +392,30 @@ pub(super) fn service_global(
         _ => {}
     }
 
+    // ADVANCE the security health-probe spinner while a probe is in flight. Mirrors the
+    // loading-splash frame advance: bump the frame counter each tick on the OPEN panel so
+    // the braille frames actually cycle, paired with the force-dirty below so the loop
+    // redraws even though no events arrive during the cold IPC round-trip.
+    if state.rest.sec_health_rx.is_some() {
+        if let Mode::Security(s) = &mut state.mode {
+            s.health_frame = s.health_frame.wrapping_add(1);
+            dirty = true;
+        }
+    }
+
     // While a compaction animation is in flight, mark every tick dirty so the
     // spinner/elapsed/bar actually advance (rendering is otherwise only
     // event-driven). The same applies while the comet shimmer is active: it must
     // keep travelling even when NO stream events arrive (first-token latency, tool
     // exec, the summarizer fold), so force a redraw each tick then too. Similarly,
     // while any sub-agent is running (background `/task` agents that don't set
-    // `waiting`), force redraws so the in-chat spinner animates.
+    // `waiting`), force redraws so the in-chat spinner animates. And while a security
+    // health probe is pending, force redraws so its "checking dependencies…" spinner
+    // keeps cycling until the result lands.
     if state.rest.compact_anim_start.is_some()
         || shimmer_active
         || has_running_subagents(state)
+        || state.rest.sec_health_rx.is_some()
     {
         dirty = true;
     }

--- a/src-agent/src/app/runtime/session_mgmt.rs
+++ b/src-agent/src/app/runtime/session_mgmt.rs
@@ -106,19 +106,43 @@ pub(crate) fn warm_session(
     // Awareness task: read the depth-1 docs + summarize on the resolved Awareness
     // route. Move the owned route + the cloned settings/workdir in; `summarize`
     // returns `None` on no docs / failure, which the drain renders as the
-    // appropriate terminal step.
+    // appropriate terminal step. Also resolve the Main route as a fallback: when
+    // the Awareness model call itself fails (e.g. bad/typo'd model name) we retry
+    // once on the trusted Main route before giving up.
     if let (Some(c), Some(route)) = (client.as_ref(), aware_route) {
         let c = Arc::clone(c);
+        // Resolve the Main route for fallback; cheap (no I/O). `None` is safe —
+        // `summarize_with_fallback` skips the retry when the routes are equal or
+        // Main is unavailable.
+        let main_route = resolve_role(&config, &settings, ModelRole::Main);
         handle.spawn(async move {
-            let summary = crate::app::awareness::summarize(
-                &c,
-                &settings,
-                route.conn(),
-                &route.model_id,
-                route.provider(),
-                &workdir,
-            )
-            .await;
+            let summary = match main_route {
+                Some(ref m) => {
+                    crate::app::awareness::summarize_with_fallback(
+                        &c,
+                        &settings,
+                        route.conn(),
+                        &route.model_id,
+                        route.provider(),
+                        &workdir,
+                        m.conn(),
+                        &m.model_id,
+                        m.provider(),
+                    )
+                    .await
+                }
+                None => {
+                    crate::app::awareness::summarize(
+                        &c,
+                        &settings,
+                        route.conn(),
+                        &route.model_id,
+                        route.provider(),
+                        &workdir,
+                    )
+                    .await
+                }
+            };
             let _ = tx.send(WarmEvent::WarmAwareness(summary));
         });
     }

--- a/src-agent/src/app/runtime/stream/spawn.rs
+++ b/src-agent/src/app/runtime/stream/spawn.rs
@@ -130,14 +130,34 @@ pub(crate) fn apply_workspace_change(
         )
         .filter(|r| r.is_routable())
         {
-            let summary = handle.block_on(crate::app::awareness::summarize(
-                &c,
+            // Also resolve the Main route as a fallback for when the Awareness
+            // model call itself errors (e.g. bad/typo'd model name). Cheap — no I/O.
+            let main_route = crate::app::resolve::resolve_role(
+                &config,
                 &settings,
-                route.conn(),
-                &route.model_id,
-                route.provider(),
-                &new_cwd,
-            ));
+                crate::model::app_config::ModelRole::Main,
+            );
+            let summary = match main_route {
+                Some(ref m) => handle.block_on(crate::app::awareness::summarize_with_fallback(
+                    &c,
+                    &settings,
+                    route.conn(),
+                    &route.model_id,
+                    route.provider(),
+                    &new_cwd,
+                    m.conn(),
+                    &m.model_id,
+                    m.provider(),
+                )),
+                None => handle.block_on(crate::app::awareness::summarize(
+                    &c,
+                    &settings,
+                    route.conn(),
+                    &route.model_id,
+                    route.provider(),
+                    &new_cwd,
+                )),
+            };
             state.rest.sessions[sess_idx].awareness_summary = summary;
         }
     }

--- a/src-agent/src/app/runtime/stream/tools/approval.rs
+++ b/src-agent/src/app/runtime/stream/tools/approval.rs
@@ -443,7 +443,23 @@ pub(crate) fn process_tools(
         // authorization to test their own target, so the TAC classifier (built to
         // block unrequested mutations) would only block legit offensive steps. The
         // tool's `risk` metadata is still shown in the /security panel as a label.
-        if tool_is_risky(&call.function.name) {
+        //
+        // YOLO mode bypasses the harness ENTIRELY: a risky call skips the classifier
+        // network call AND every `y/n` prompt, running inline exactly as Auto does on
+        // a definite-allow. Only the classifier + prompts are bypassed — the
+        // deterministic workspace path guard (WC) inside the tools still applies, so
+        // writes stay in the project dir. Gate it FIRST so no `tac_inputs` /
+        // `block_on(classify_toolcall)` ever fires in Yolo; clear any stale approval
+        // reason and fall through to the dispatch block below (which advances
+        // `tool_idx`). The classifier/approval branches below are reached only for the
+        // Auto/Normal modes.
+        // Yolo + risky: explicit no-op gate. Clear any stale approval reason and fall
+        // straight through to dispatch (no classifier, no prompt). Kept as its own
+        // branch so the bypass is unmistakable in the control flow.
+        if tool_is_risky(&call.function.name) && mode == AgentMode::Yolo {
+            state.rest.sessions[sess_idx].approval_reason = None;
+        }
+        if tool_is_risky(&call.function.name) && mode != AgentMode::Yolo {
             match tac_inputs(state, sess_idx, client) {
                 // Classifier enabled → run TAC in both modes and act on its verdict.
                 Some((c, config, settings)) => {

--- a/src-agent/src/app/sec/mod.rs
+++ b/src-agent/src/app/sec/mod.rs
@@ -433,6 +433,27 @@ impl SecDaemonManager {
             .map_err(|e| format!("failed to parse health response: {e}"))
     }
 
+    /// Kick off [`Self::health`] on a blocking-pool thread and deliver the result over an
+    /// unbounded channel. NON-BLOCKING — returns immediately; the caller drains the
+    /// receiver in the event loop (mirrors the `version_rx` / `warm_rx` async-result
+    /// pattern) so the `/security` panel never freezes on the cold first probe.
+    ///
+    /// `spawn_blocking` (NOT `spawn`) is mandatory: `health()` calls `request()`, which
+    /// blocks the calling thread on a synchronous `recv_timeout` — running that on an
+    /// async worker thread would stall the runtime. `self.handle` is the manager's private
+    /// tokio [`Handle`], accessible here as this is an inherent method on the same type.
+    pub fn health_async(
+        self: &Arc<Self>,
+    ) -> mpsc::UnboundedReceiver<Result<Vec<InstallHealthEntry>, String>> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let me = Arc::clone(self);
+        self.handle.spawn_blocking(move || {
+            // A dropped receiver (panel closed before the probe finished) makes this a no-op.
+            let _ = tx.send(me.health());
+        });
+        rx
+    }
+
     /// Install/repair a single dependency by manifest key; returns the daemon's status
     /// string.
     pub fn install(&self, key: &str) -> Result<String, String> {

--- a/src-agent/src/app/state/rest.rs
+++ b/src-agent/src/app/state/rest.rs
@@ -102,6 +102,15 @@ pub struct AppStateRest {
     /// `/security` panel. Starts `false` so the daemon stays off by default even when
     /// installed. The panel's toggle key (`t`) flips this and starts/stops the daemon.
     pub security_enabled: bool,
+    /// Layer-1 ARM flag for YOLO mode. `false` by default: until the user explicitly
+    /// arms YOLO from the `/security` panel (its "Enable YOLO mode" checkbox row, toggled
+    /// with Space/Enter), the `Yolo` agent mode is unreachable — Shift+Tab / `/mode` cycle
+    /// Auto<->Normal only. While armed, the user may then ENTER `Yolo` (Layer 2) via
+    /// `/mode yolo` or the toggle. Disarming it while currently in `Yolo` drops
+    /// `agent_mode` back to `Auto` (see `handle_security_toggle_tool`'s YOLO branch).
+    /// Mirrors `security_enabled`'s lifecycle; rides to the thin client in the
+    /// `/security` panel's snapshot like `sec_inactive`.
+    pub yolo_armed: bool,
     /// Tool names the user has explicitly DISABLED from the `/security` panel (the
     /// inactive set). Empty by default = every tool active, so the stream's
     /// advertise-fold behaves byte-identically to before this feature when nothing has
@@ -251,6 +260,15 @@ pub struct AppStateRest {
     /// loop (alongside `warm_rx`/`endpoints_rx`). Each `try_recv`'d `VersionInfo` is
     /// stored into `latest_version`. Non-blocking: never awaited.
     pub version_rx: Option<tokio::sync::mpsc::UnboundedReceiver<crate::app::version::VersionInfo>>,
+    /// Receiver for an in-flight NON-BLOCKING security health probe. `Some` while a
+    /// `SecDaemonManager::health_async` fetch is pending; drained each tick in
+    /// `service_global` and folded into the open [`crate::app::mode::SecurityState`]
+    /// (`install_health`), then cleared. Mirrors `version_rx`. `None` when no probe is
+    /// in flight. Kept out of the IPC snapshot — only the daemon owns the manager, so
+    /// only the daemon ever drives a probe; the client animates from the projected
+    /// `health_fetching` / `health_frame` instead.
+    pub sec_health_rx:
+        Option<tokio::sync::mpsc::UnboundedReceiver<Result<Vec<crate::app::sec::InstallHealthEntry>, String>>>,
 }
 
 impl Default for AppStateRest {
@@ -293,6 +311,7 @@ impl AppStateRest {
             sec_manager: None,
             sec_token: String::new(),
             security_enabled: false,
+            yolo_armed: false,
             sec_inactive: std::collections::HashSet::new(),
             select_pending: false,
             select_active: false,
@@ -321,6 +340,7 @@ impl AppStateRest {
             latest_version: None,
             version_tx: Some(vtx),
             version_rx: Some(vrx),
+            sec_health_rx: None,
         }
     }
 

--- a/src-agent/src/app/state/types.rs
+++ b/src-agent/src/app/state/types.rs
@@ -1,6 +1,6 @@
 //! Auxiliary types used by [`super::AppStateRest`] and the rest of the app.
 //!
-//! - [`AgentMode`]       – tool-approval policy (auto vs. normal)
+//! - [`AgentMode`]       – tool-approval policy (auto / normal / yolo)
 //! - [`ToastKind`]       – visual style of a transient toast box
 //! - [`TranscriptCache`] – per-frame rendered-lines cache
 //! - [`CataloguePending`] – debounced model-catalogue fetch request
@@ -14,6 +14,11 @@ use crate::view::theme::Palette;
 ///   behaviour.
 /// - `Normal`: *risky* tools (write/delete) pause the turn for a `y/n` user
 ///   approval; *safe* tools (read/dir_list/dir_cache_update) still run inline.
+/// - `Yolo`: *risky* tools run inline with NO classifier call and NO `y/n`
+///   prompt — the harness is fully bypassed. The deterministic workspace path
+///   guard (WC) still applies, so writes stay inside the project. This mode is
+///   double-gated: it can only be ENTERED while `yolo_armed` is set (armed from
+///   the `/security` panel), so it can never be reached by accident.
 ///
 /// Toggled with Shift+Tab or `/mode`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -21,6 +26,7 @@ pub enum AgentMode {
     #[default]
     Auto,
     Normal,
+    Yolo,
 }
 
 impl AgentMode {
@@ -29,13 +35,30 @@ impl AgentMode {
         match self {
             AgentMode::Auto => "auto",
             AgentMode::Normal => "normal",
+            AgentMode::Yolo => "yolo",
         }
     }
-    /// The opposite mode (for the toggle key / command).
-    pub fn toggled(self) -> Self {
-        match self {
-            AgentMode::Auto => AgentMode::Normal,
-            AgentMode::Normal => AgentMode::Auto,
+    /// Advance to the next mode for the interactive toggle (Shift+Tab / bare
+    /// `/mode`), respecting the YOLO arm gate.
+    ///
+    /// - `yolo_armed == true`:  Auto → Normal → Yolo → Auto (full three-way cycle).
+    /// - `yolo_armed == false`: Auto → Normal → Auto (Yolo is skipped). If `self`
+    ///   is somehow `Yolo` while unarmed (shouldn't happen — disarming drops the
+    ///   mode), it folds straight back to Auto so the user can never linger there.
+    pub fn cycle(self, yolo_armed: bool) -> Self {
+        if yolo_armed {
+            match self {
+                AgentMode::Auto => AgentMode::Normal,
+                AgentMode::Normal => AgentMode::Yolo,
+                AgentMode::Yolo => AgentMode::Auto,
+            }
+        } else {
+            match self {
+                AgentMode::Auto => AgentMode::Normal,
+                AgentMode::Normal => AgentMode::Auto,
+                // Unarmed + Yolo (defensive): drop back to Auto.
+                AgentMode::Yolo => AgentMode::Auto,
+            }
         }
     }
 }

--- a/src-agent/src/controller/command.rs
+++ b/src-agent/src/controller/command.rs
@@ -94,8 +94,10 @@ pub enum Command {
     /// Spawn a fresh PARALLEL session. `NewMode` controls whether the previous
     /// foreground is kept running (`Swap`) or tombstoned (`Kill`).
     New(NewMode),
-    /// Toggle the tool-approval policy between Normal and Auto.
-    Mode,
+    /// Set or cycle the tool-approval policy. `None` = armed-aware cycle
+    /// (Auto→Normal→[Yolo when armed]→Auto); `Some(token)` explicitly sets the
+    /// named mode (`auto` / `normal` / `yolo`). `yolo` is refused unless armed.
+    Mode(Option<String>),
     /// Open the reasoning/thinking-effort picker for the current model.
     Effort,
     /// Rename the current session.  Holds the new name string.
@@ -166,7 +168,12 @@ pub fn parse(line: &str) -> Command {
             };
             Command::New(mode)
         }
-        "mode" => Command::Mode,
+        "mode" => {
+            // Bare `/mode` cycles (None); `/mode <token>` sets explicitly. The token
+            // is lowercased; `handle_mode` validates it (and gates `yolo` on armed).
+            let arg = rest.split_whitespace().next();
+            Command::Mode(arg.map(|s| s.to_lowercase()))
+        }
         "effort" => Command::Effort,
         "settings" | "config" => Command::Settings,
         "agents" | "agent" => Command::Agents,

--- a/src-agent/src/controller/input/action.rs
+++ b/src-agent/src/controller/input/action.rs
@@ -152,22 +152,21 @@ pub enum Action {
     // --- Security daemon control panel actions ---
     /// Esc from the `/security` panel — return to Chat.
     CloseSecurity,
-    /// `t` in the `/security` panel — toggle the security-enabled flag: if now enabled,
-    /// start the daemon; if now disabled, stop it. Refreshes the panel status.
-    SecurityToggle,
-    /// `s` in the `/security` panel — start the daemon (no-op when already running).
-    SecurityStart,
-    /// `x` in the `/security` panel — stop the daemon (no-op when not running).
-    SecurityStop,
-    /// `r` in the `/security` panel — restart the daemon (stop then start).
+    /// `r` in the `/security` panel — restart the daemon (stop then start). Daemon
+    /// start/stop/toggle no longer have their own keys/Actions: the top `[x] Daemon
+    /// running` checkbox owns them (toggled via `SecurityToggleTool`).
     SecurityRestart,
-    /// `Enter`/`Space` in the `/security` panel — toggle the currently-selected tool's
-    /// active state (flip its membership in `state.rest.sec_inactive`). A disabled tool
-    /// is no longer advertised to the model; re-enabling restores it. Refreshes the panel.
+    /// `Enter`/`Space` in the `/security` panel — toggle the currently-SELECTED row. The
+    /// tools pane mixes the daemon checkbox (row 0) and the YOLO checkbox (row 1) with the
+    /// tool inventory: the daemon checkbox starts/stops the daemon; the YOLO checkbox
+    /// arms/disarms the Layer-1 YOLO flag (`state.rest.yolo_armed`, gated on the daemon
+    /// running; disarming while in `Yolo` drops `agent_mode` back to `Auto`); a tool row
+    /// flips its membership in `state.rest.sec_inactive` (a disabled tool is no longer
+    /// advertised to the model). Refreshes the panel.
     SecurityToggleTool,
     /// `d` in the `/security` panel — toggle every tool sharing the selected tool's
     /// domain: if all of that domain are currently active, disable them all; otherwise
-    /// enable them all. Refreshes the panel.
+    /// enable them all. A no-op when the YOLO checkbox is selected. Refreshes the panel.
     SecurityToggleDomain,
     /// `i` in the `/security` panel's DEPENDENCY pane — install/repair the selected
     /// dependency. Inner string is its manifest key (the argument to

--- a/src-agent/src/controller/input/chat.rs
+++ b/src-agent/src/controller/input/chat.rs
@@ -451,10 +451,12 @@ pub fn handle_chat(rest: &mut AppStateRest, key: KeyEvent) -> Action {
             }
             Action::None
         }
-        // Shift+Tab toggles the tool-approval mode (Auto <-> Normal). Crossterm
-        // reports Shift+Tab as BackTab, so it never collides with plain Tab.
+        // Shift+Tab cycles the tool-approval mode. Crossterm reports Shift+Tab as
+        // BackTab, so it never collides with plain Tab. The cycle is ARMED-AWARE:
+        // unarmed it's Auto<->Normal (identical to before); only once YOLO is armed
+        // from the /security panel does the cycle include Yolo (Auto→Normal→Yolo→Auto).
         KeyCode::BackTab => {
-            rest.agent_mode = rest.agent_mode.toggled();
+            rest.agent_mode = rest.agent_mode.cycle(rest.yolo_armed);
             rest.status = format!("mode: {}", rest.agent_mode.label());
             Action::None
         }

--- a/src-agent/src/controller/input/security.rs
+++ b/src-agent/src/controller/input/security.rs
@@ -10,12 +10,14 @@
 //! - `Down`     → move cursor down in the ACTIVE pane (tools or deps)
 //! - `h`/`H`    → toggle the body pane (tools ⇄ dependencies); mode-state only
 //! - `i`/`I`    → (deps pane only) `Action::SecurityInstall` the selected dependency
-//! - `t`        → `Action::SecurityToggle` (enable/disable + start/stop)
-//! - `s`        → `Action::SecurityStart`
-//! - `x`        → `Action::SecurityStop`
 //! - `r`        → `Action::SecurityRestart`
-//! - `Enter`/`Space` → `Action::SecurityToggleTool` (toggle the selected tool active)
+//! - `Enter`/`Space` → `Action::SecurityToggleTool` (toggle the SELECTED row: the daemon
+//!   checkbox starts/stops the daemon; the YOLO checkbox arms/disarms Layer-1 YOLO (only
+//!   when the daemon is running); a tool row flips that tool's active state)
 //! - `d`        → `Action::SecurityToggleDomain` (toggle every tool in the selected tool's domain)
+//!
+//! Daemon start/stop/toggle no longer have dedicated keys (s/x/t removed) — the daemon is
+//! now the top `[x] Daemon running` checkbox, toggled with Space like any other row.
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
 
@@ -32,10 +34,30 @@ pub fn handle_security(s: &mut SecurityState, rest: &mut AppStateRest, key: KeyE
     if let Some(m) = rest.sec_manager.as_ref() {
         s.status = m.status();
     }
+    // Self-heal install-health: it is normally seeded once on panel open, but the daemon
+    // starts ASYNCHRONOUSLY — if the panel opened before the daemon was ready (or the
+    // daemon was started from inside the panel), the open-time probe never ran and no
+    // other path re-probes. Kick off a NON-BLOCKING probe here once the daemon is up.
+    // Gated on `is_empty()` (health() returns the full manifest, never an empty list, so a
+    // delivered result sticks) and on `sec_health_rx.is_none()` inside the helper, so the
+    // probe fires exactly once. NO blocking `health()` runs on the input path any more —
+    // `service_global` drains the receiver and clears `health_fetching`.
+    // Short-circuit `&&`: the side-effecting kick-off only fires when the panel actually
+    // needs a probe (empty health, daemon up) — and the helper itself no-ops when one is
+    // already in flight, so this stays exactly-once.
+    if s.install_health.is_empty()
+        && s.status.running
+        && crate::app::runtime::commands::security::kick_off_health_probe(rest)
+    {
+        s.health_fetching = true;
+    }
     // Keep the mode-state's inactive mirror in step with the authoritative set on
     // `rest` (the action handlers mutate `rest.sec_inactive` then refresh, but a
     // re-entry into the panel reads this on each key).
     s.inactive = rest.sec_inactive.clone();
+    // Same for the YOLO arm flag — mirror the authoritative `rest.yolo_armed` so the
+    // checkbox row reflects the live state on every key.
+    s.yolo_armed = rest.yolo_armed;
     if is_ctrl(&key, 'c') {
         return Action::Quit;
     }
@@ -59,10 +81,15 @@ pub fn handle_security(s: &mut SecurityState, rest: &mut AppStateRest, key: KeyE
             Action::None
         }
         // Install/repair the selected dependency — ONLY in the dependency pane, and only
-        // when a row is actually selected.
+        // when a row is actually selected. `health_selected` indexes `health_items()`
+        // (render order), so resolve through it to find the underlying entry.
         KeyCode::Char('i') | KeyCode::Char('I') => {
             if s.health_view {
-                match s.install_health.get(s.health_selected) {
+                match s
+                    .health_items()
+                    .get(s.health_selected)
+                    .and_then(|&idx| s.install_health.get(idx))
+                {
                     Some(e) => Action::SecurityInstall(e.key.clone()),
                     None => Action::None,
                 }
@@ -70,9 +97,6 @@ pub fn handle_security(s: &mut SecurityState, rest: &mut AppStateRest, key: KeyE
                 Action::None
             }
         }
-        KeyCode::Char('t') | KeyCode::Char('T') => Action::SecurityToggle,
-        KeyCode::Char('s') | KeyCode::Char('S') => Action::SecurityStart,
-        KeyCode::Char('x') | KeyCode::Char('X') => Action::SecurityStop,
         KeyCode::Char('r') | KeyCode::Char('R') => Action::SecurityRestart,
         _ => Action::None,
     }

--- a/src-agent/src/ipc/proto/snapshot.rs
+++ b/src-agent/src/ipc/proto/snapshot.rs
@@ -499,6 +499,11 @@ pub struct SecuritySnapshot {
     /// model's advertised tools.
     #[serde(default)]
     pub inactive: Vec<String>,
+    /// Layer-1 YOLO arm flag, mirrored from `state.rest.yolo_armed` so the thin client's
+    /// panel renders the ARMED/locked status row faithfully. `#[serde(default)]` keeps
+    /// an older client decoding a newer daemon (and vice-versa) safe (defaults false).
+    #[serde(default)]
+    pub yolo_armed: bool,
     /// Per-dependency install-health, carried VERBATIM from the open mode state (NOT
     /// re-fetched at snapshot time — `health()` is a heavy IPC round-trip and the
     /// projection runs every frame). Empty when the daemon is stopped.
@@ -510,6 +515,16 @@ pub struct SecuritySnapshot {
     /// Selected index into `install_health` (the dependency-pane cursor).
     #[serde(default)]
     pub health_selected: usize,
+    /// `true` while a non-blocking health probe is in flight on the daemon. Projected so
+    /// the thin client renders the same "checking dependencies…" spinner state on the
+    /// daemon info line. `#[serde(default)]` keeps version-skewed peers safe (false).
+    #[serde(default)]
+    pub health_fetching: bool,
+    /// Braille spinner frame counter for the in-flight probe. MUST be projected (it is
+    /// advanced daemon-side every tick) so the client's spinner actually animates rather
+    /// than sitting on a single frame. `#[serde(default)]` keeps version-skewed peers safe.
+    #[serde(default)]
+    pub health_frame: u64,
 }
 
 /// A serde-safe projection of ONE background bash job for the `/bash` panel.

--- a/src-agent/src/ipc/snapshot/projection/core.rs
+++ b/src-agent/src/ipc/snapshot/projection/core.rs
@@ -179,6 +179,7 @@ pub fn global_snapshot_with_mode(state: &AppState, mode: ModeSnapshot) -> Global
         agent_mode: match state.rest.agent_mode {
             crate::app::state::AgentMode::Auto => "auto",
             crate::app::state::AgentMode::Normal => "normal",
+            crate::app::state::AgentMode::Yolo => "yolo",
         }
         .to_string(),
     }

--- a/src-agent/src/ipc/snapshot/projection/modes.rs
+++ b/src-agent/src/ipc/snapshot/projection/modes.rs
@@ -551,11 +551,19 @@ pub fn security_snapshot(s: &SecurityState, state: &AppState) -> SecuritySnapsho
         status,
         selected: s.selected,
         inactive,
+        // YOLO arm flag is authoritative on `state.rest`; carry it so the client's panel
+        // renders the same armed/locked status row.
+        yolo_armed: state.rest.yolo_armed,
         // Install-health is carried straight from the mode state — NEVER re-fetched
         // here. `health()` is a heavy IPC round-trip and this projection runs on every
         // frame; the mode seeds it once on open and after an install.
         install_health: s.install_health.clone(),
         health_view: s.health_view,
         health_selected: s.health_selected,
+        // Spinner state for the in-flight health probe — projected so the client renders
+        // the same "checking dependencies…" line and ANIMATES it from `health_frame`
+        // (the daemon advances the frame every tick; the client owns no probe of its own).
+        health_fetching: s.health_fetching,
+        health_frame: s.health_frame,
     }
 }

--- a/src-agent/src/view/chat/header.rs
+++ b/src-agent/src/view/chat/header.rs
@@ -14,11 +14,13 @@ use super::helpers::truncate_chars;
 
 /// Render the header line ("koma" + mode indicator) into `chunk`.
 ///
-/// Mode colours are fixed regardless of theme: Normal = green, Auto = yellow.
+/// Mode colours are fixed regardless of theme: Normal = green, Auto = yellow,
+/// Yolo = LOUD red (harness bypassed — make it unmistakable).
 pub(super) fn render_header(frame: &mut Frame, chunk: Rect, rest: &AppStateRest, palette: &Palette) {
     let (mode_icon, mode_label, mode_color) = match rest.agent_mode {
         crate::app::state::AgentMode::Normal => ("●", "normal", Color::Rgb(80, 220, 80)),
         crate::app::state::AgentMode::Auto   => ("»", "auto",   Color::Rgb(255, 210, 60)),
+        crate::app::state::AgentMode::Yolo   => ("!", "yolo",   Color::Rgb(255, 60, 60)),
     };
     // Build the right-side text ("● normal" or "» auto") so we can
     // measure it and pad the gap between brand and mode.

--- a/src-agent/src/view/security/mod.rs
+++ b/src-agent/src/view/security/mod.rs
@@ -2,7 +2,9 @@
 //!
 //! A full-screen status panel in the house border style:
 //! - Header: label "security" with BOTTOM border only.
-//! - Status block: daemon running / installed / mode (enabled/disabled) flags.
+//! - Control block: a navigable `[x] Daemon running` checkbox (Space starts/stops the
+//!   daemon), a compact dim `installed: yes · N tools` info line, then the YOLO checkbox
+//!   (gated — locked until the daemon is running).
 //! - Body (toggled by `h`): one of TWO panes —
 //!   - TOOLS (default): tools grouped by domain, each row `name  [compute]  risk?`,
 //!     greyed when the daemon is not running or not installed.
@@ -16,7 +18,11 @@
 //! ```text
 //!  security
 //! ─────────────────────────────────────────────────────────
-//!  daemon: running  ·  installed: yes  ·  mode: enabled
+//!  [x] Daemon running
+//!  installed: yes · 12 tools
+//!
+//!  [ ] Enable YOLO mode
+//!  YOLO mode disabled — harness active
 //!
 //!  [web]
 //!    sec_http        [light]   risky
@@ -25,19 +31,27 @@
 //!  [network]
 //!    sec_portscan    [heavy]   risky
 //!
-//!  t toggle · s start · x stop · r restart · ↑/↓ · Esc close
+//!  ↑↓ move · Space toggle · d domain · h deps · r restart · Esc
 //! ```
 
 use ratatui::{
     layout::{Constraint, Direction, Layout, Margin},
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
     Frame,
 };
 
-use crate::app::mode::SecurityState;
+use crate::app::mode::{SecSel, SecurityState};
+use crate::app::sec::InstallHealthEntry;
 use crate::view::theme::Palette;
+
+/// LOUD red used for the armed/enabled YOLO state (checkbox + warning). Bright enough to
+/// read as a real danger marker against the panel, matching the house "no box, loud text"
+/// convention for warnings.
+const YOLO_RED: Color = Color::Rgb(255, 60, 60);
+/// GREEN used for the ARMED/active YOLO checkbox indicator — distinct from the red warning line.
+const YOLO_GREEN: Color = Color::Rgb(0, 200, 83);
 
 /// Render the `/security` control panel for `st` using the given colour `palette`.
 pub fn draw(frame: &mut Frame, st: &SecurityState, palette: &Palette) {
@@ -76,81 +90,154 @@ pub fn draw(frame: &mut Frame, st: &SecurityState, palette: &Palette) {
 
     let mut lines: Vec<Line> = Vec::new();
 
-    // Status line: daemon running/stopped, installed yes/no, mode enabled/disabled.
-    let running_label = if st.status.running { "running" } else { "stopped" };
-    let installed_label = if st.status.installed { "yes" } else { "no" };
-    let mode_label = if st.status.running { "enabled" } else { "disabled" };
-
-    let running_style = if st.status.running {
-        Style::default().fg(palette.accent)
-    } else {
-        Style::default().fg(palette.dim)
-    };
-    let installed_style = if st.status.installed {
-        Style::default().fg(palette.fg)
-    } else {
-        Style::default().fg(palette.dim)
-    };
-
-    lines.push(Line::from(vec![
-        Span::styled("daemon: ", Style::default().fg(palette.dim)),
-        Span::styled(running_label, running_style),
-        Span::styled("  ·  installed: ", Style::default().fg(palette.dim)),
-        Span::styled(installed_label, installed_style),
-        Span::styled("  ·  mode: ", Style::default().fg(palette.dim)),
-        Span::styled(mode_label, Style::default().fg(palette.dim)),
-    ]));
-    lines.push(Line::from(""));
-
+    // The daemon running-state is now the navigable `SecSel::Daemon` checkbox at the top of
+    // the tools-pane item loop (rendered below), not a standalone status line. The compact
+    // `installed: N tools` info line is emitted right under that checkbox, inside the loop.
     let active = st.status.running && st.status.installed;
     let dim_style = Style::default().fg(palette.dim);
 
     if !st.health_view {
-        // ── TOOLS PANE (default) — tool inventory, greyed when daemon not running. ──
+        // ── TOOLS PANE (default): the YOLO checkbox, then tool inventory by domain. ──
+        //
+        // Walk `tool_items()` — the SAME ordered list the cursor navigates — and highlight
+        // purely on `pos == st.selected`. There is no separate flat-index path any more, so
+        // the highlight can never land on a different on-screen row than the one below the
+        // cursor (the bug this rewrite fixes). `pos` is the index into `tool_items()`.
         let tool_style = if active {
             Style::default().fg(palette.fg)
         } else {
             Style::default().fg(palette.dim)
         };
+        let sel_style = Style::default()
+            .fg(palette.sel_fg)
+            .bg(palette.sel_bg)
+            .add_modifier(Modifier::BOLD);
 
-        if st.status.tools.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "no tools — daemon stopped",
-                dim_style,
-            )));
-        } else {
-            // Group tools by domain, preserving insertion order.
-            let mut domains: Vec<String> = Vec::new();
-            for t in &st.status.tools {
-                if !domains.contains(&t.domain) {
-                    domains.push(t.domain.clone());
+        let items = st.tool_items();
+        // Track the last-rendered tool's domain so we emit a `[domain]` header (and the
+        // blank-line spacing) only when the domain changes between consecutive tool rows.
+        let mut last_domain: Option<&str> = None;
+        for (pos, item) in items.iter().enumerate() {
+            let is_selected = pos == st.selected;
+            match item {
+                SecSel::Daemon => {
+                    // Daemon start/stop checkbox — checked = running. Toggling it (Space)
+                    // starts the daemon when stopped, stops it when running. Selection
+                    // highlight is NOT gated on daemon state: it must stay navigable while
+                    // stopped so the user can start it from here.
+                    let (box_label, base_style) = if st.status.running {
+                        // Running indicator reuses the active-green (same green as armed YOLO).
+                        ("[x] Daemon running", Style::default().fg(YOLO_GREEN).add_modifier(Modifier::BOLD))
+                    } else {
+                        ("[ ] Daemon stopped", Style::default().fg(palette.fg))
+                    };
+                    let row_style = if is_selected { sel_style } else { base_style };
+                    lines.push(Line::from(Span::styled(box_label, row_style)));
+
+                    // Compact dim info line under the checkbox: installed flag + tool count,
+                    // with ONE inline trailing segment so the loading spinner / missing-dep
+                    // legend reads as part of this line rather than a separate checkbox-like
+                    // row. (Replaces the old `daemon: … · mode: …` status block; the `mode`
+                    // fragment is gone — the checkbox above is the running state.)
+                    let installed_label = if st.status.installed { "yes" } else { "no" };
+                    let mut info_spans = vec![Span::styled(
+                        format!("installed: {} · {} tools", installed_label, st.status.tools.len()),
+                        dim_style,
+                    )];
+                    if st.health_fetching {
+                        // Health probe in flight — animated braille spinner from the frame
+                        // counter `service_global` advances each tick.
+                        const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+                        let spinner = SPINNER[(st.health_frame % 10) as usize];
+                        info_spans.push(Span::styled(" · ", dim_style));
+                        info_spans.push(Span::styled(
+                            format!("{spinner} checking dependencies…"),
+                            Style::default().fg(palette.accent),
+                        ));
+                    } else if st
+                        .status
+                        .tools
+                        .iter()
+                        .any(|tool| missing_dep_for(tool.name.as_str(), &st.install_health))
+                    {
+                        // At least one tool has a missing dep — inline [!!] legend (no
+                        // separate row, so it stops looking like another checkbox).
+                        info_spans.push(Span::styled(" · ", dim_style));
+                        info_spans.push(Span::styled(
+                            "[!!]",
+                            Style::default()
+                                .fg(Color::Rgb(255, 200, 0))
+                                .add_modifier(Modifier::BOLD),
+                        ));
+                        info_spans.push(Span::styled(" dependency not installed", dim_style));
+                    }
+                    lines.push(Line::from(info_spans));
+
+                    lines.push(Line::from(""));
                 }
-            }
+                SecSel::Yolo => {
+                    // YOLO arm checkbox — GATED on the daemon running, because YOLO bypasses
+                    // the harness and that only means anything with a live daemon.
+                    if !st.status.running {
+                        // LOCKED: render dim with a "(start daemon first)" hint and no
+                        // armed/enabled state (it can't be armed). Still navigable so the
+                        // cursor can rest here, but toggling it is refused in the handler.
+                        let row_style = if is_selected { sel_style } else { dim_style };
+                        lines.push(Line::from(vec![
+                            Span::styled("[ ] Enable YOLO mode", row_style),
+                            Span::styled("   (start daemon first)", dim_style),
+                        ]));
+                    } else {
+                        // Daemon is running: original behaviour. Checked = armed. Selection
+                        // highlight is NOT gated on `active`.
+                        let (box_label, base_style) = if st.yolo_armed {
+                            ("[x] Enable YOLO mode", Style::default().fg(YOLO_GREEN).add_modifier(Modifier::BOLD))
+                        } else {
+                            ("[ ] Enable YOLO mode", Style::default().fg(palette.fg))
+                        };
+                        let row_style = if is_selected { sel_style } else { base_style };
+                        lines.push(Line::from(Span::styled(box_label, row_style)));
 
-            for domain in &domains {
-                // Domain header.
-                let domain_label = if domain.is_empty() { "other" } else { domain.as_str() };
-                lines.push(Line::from(Span::styled(
-                    format!("[{domain_label}]"),
-                    dim_style,
-                )));
+                        // Non-navigable warning directly below the checkbox. LOUD red when
+                        // enabled (harness bypassable), dim reassurance when disabled.
+                        if st.yolo_armed {
+                            lines.push(Line::from(Span::styled(
+                                "! YOLO MODE ENABLED",
+                                Style::default().fg(YOLO_RED).add_modifier(Modifier::BOLD),
+                            )));
+                        } else {
+                            lines.push(Line::from(Span::styled(
+                                "YOLO mode disabled — harness active",
+                                dim_style,
+                            )));
+                        }
+                    }
+                    lines.push(Line::from(""));
+                }
+                SecSel::Tool(i) => {
+                    let t = &st.status.tools[*i];
 
-                // Tools in this domain.
-                for (idx, t) in st.status.tools.iter().enumerate() {
-                    if &t.domain != domain {
-                        continue;
+                    // Domain header on every domain change (including the first tool).
+                    if last_domain != Some(t.domain.as_str()) {
+                        // Blank-line spacing before a NEW group, but not before the very
+                        // first group (the YOLO block already emitted a trailing blank).
+                        if last_domain.is_some() {
+                            lines.push(Line::from(""));
+                        }
+                        let domain_label = if t.domain.is_empty() { "other" } else { t.domain.as_str() };
+                        lines.push(Line::from(Span::styled(
+                            format!("[{domain_label}]"),
+                            dim_style,
+                        )));
+                        last_domain = Some(t.domain.as_str());
                     }
 
-                    let is_selected = idx == st.selected;
                     // A tool the user disabled in this panel renders dim with an "  off"
                     // suffix; active tools render as before. The selection highlight still
                     // applies on top so the cursor stays visible over a disabled row.
                     let is_inactive = st.inactive.contains(&t.name);
                     let name_style = if is_selected && active {
-                        Style::default()
-                            .fg(palette.sel_fg)
-                            .bg(palette.sel_bg)
-                            .add_modifier(Modifier::BOLD)
+                        sel_style
                     } else if is_inactive {
                         dim_style
                     } else {
@@ -179,16 +266,29 @@ pub fn draw(frame: &mut Frame, st: &SecurityState, palette: &Palette) {
                         Span::raw("")
                     };
 
+                    // Not-installed marker — yellow bold [!!] when ANY dependency backing
+                    // this tool is absent. Visible even on dimmed/inactive rows.
+                    let missing_dep = missing_dep_for(t.name.as_str(), &st.install_health);
+                    let mark_span = if missing_dep {
+                        Span::styled(
+                            "  [!!]",
+                            Style::default()
+                                .fg(Color::Rgb(255, 200, 0))
+                                .add_modifier(Modifier::BOLD),
+                        )
+                    } else {
+                        Span::raw("")
+                    };
+
                     lines.push(Line::from(vec![
                         Span::raw("  "),
                         Span::styled(format!("{:<20}", t.name), name_style),
                         compute_span,
                         risk_span,
                         off_span,
+                        mark_span,
                     ]));
                 }
-
-                lines.push(Line::from(""));
             }
         }
     } else {
@@ -205,9 +305,9 @@ pub fn draw(frame: &mut Frame, st: &SecurityState, palette: &Palette) {
     let footer_rect = outer[2];
     if footer_rect.width > 0 {
         let hint = if st.health_view {
-            "i install · h tools · ↑/↓ · Esc close"
+            "↑↓ move · i install · h tools · r restart · Esc"
         } else {
-            "Enter toggle · d domain · t toggle · s start · x stop · r restart · ↑/↓ · h deps · Esc close"
+            "↑↓ move · Space toggle · d domain · h deps · r restart · Esc"
         };
         let bar_style = Style::default()
             .fg(palette.sel_fg)
@@ -223,6 +323,12 @@ pub fn draw(frame: &mut Frame, st: &SecurityState, palette: &Palette) {
             footer_rect,
         );
     }
+}
+
+/// Returns `true` if ANY dependency entry whose `tools` list contains `tool_name` is absent
+/// (`present == false`). Used by both the per-row [!!] marker and the header legend.
+fn missing_dep_for(tool_name: &str, health: &[InstallHealthEntry]) -> bool {
+    health.iter().any(|d| d.tools.iter().any(|t| t == tool_name) && !d.present)
 }
 
 /// Fixed parenthetical label for a tier header (the install *strategy* for that tier),
@@ -243,7 +349,11 @@ fn tier_label(tier: u8) -> &'static str {
 /// Each row: `name` (left-padded) · a present/missing marker · the install `method`,
 /// with optional dim secondary lines (`needs:` hint, `enables:` backing tools). Present
 /// rows render in the accent colour with an `ok` marker; missing rows render dim with a
-/// `missing` marker. The row at `health_selected` is highlighted (sel_fg/sel_bg bold).
+/// `missing` marker. The selected row is highlighted (sel_fg/sel_bg bold).
+///
+/// Like the tools pane, this walks `health_items()` — the SAME tier-grouped order the
+/// cursor navigates — and highlights on `pos == st.health_selected`, where `pos` is the
+/// index into that list. Tier headers are emitted on tier change.
 fn render_deps(lines: &mut Vec<Line>, st: &SecurityState, palette: &Palette) {
     let dim_style = Style::default().fg(palette.dim);
 
@@ -255,72 +365,71 @@ fn render_deps(lines: &mut Vec<Line>, st: &SecurityState, palette: &Palette) {
         return;
     }
 
-    // Distinct tiers in ascending order (preserves any unexpected tier values too).
-    let mut tiers: Vec<u8> = Vec::new();
-    for e in &st.install_health {
-        if !tiers.contains(&e.tier) {
-            tiers.push(e.tier);
-        }
-    }
-    tiers.sort_unstable();
+    let items = st.health_items();
+    // Track the last-rendered entry's tier so we emit a tier header (and the blank-line
+    // spacing) only when the tier changes between consecutive rows.
+    let mut last_tier: Option<u8> = None;
+    for (pos, idx) in items.iter().enumerate() {
+        let e = &st.install_health[*idx];
 
-    for tier in &tiers {
-        // Tier header — a top-down rule, house style (no box).
-        lines.push(Line::from(Span::styled(
-            format!("── tier {} ({}) ──", tier, tier_label(*tier)),
-            dim_style,
-        )));
-
-        for (idx, e) in st.install_health.iter().enumerate() {
-            if e.tier != *tier {
-                continue;
+        // Tier header on every tier change (including the first entry).
+        if last_tier != Some(e.tier) {
+            // Blank-line spacing before a NEW tier group, but not before the first.
+            if last_tier.is_some() {
+                lines.push(Line::from(""));
             }
-
-            let is_selected = idx == st.health_selected;
-
-            // Name style: selection wins; otherwise present → accent, missing → dim.
-            let name_style = if is_selected {
-                Style::default()
-                    .fg(palette.sel_fg)
-                    .bg(palette.sel_bg)
-                    .add_modifier(Modifier::BOLD)
-            } else if e.present {
-                Style::default().fg(palette.accent)
-            } else {
-                dim_style
-            };
-
-            // Present/missing marker — coloured to match the row's state.
-            let (marker, marker_style) = if e.present {
-                ("ok     ", Style::default().fg(palette.accent))
-            } else {
-                ("missing", dim_style)
-            };
-
-            lines.push(Line::from(vec![
-                Span::raw("  "),
-                Span::styled(format!("{:<18}", e.name), name_style),
-                Span::raw("  "),
-                Span::styled(marker, marker_style),
-                Span::styled(format!("  {}", e.method), dim_style),
-            ]));
-
-            // Secondary, dim hint lines (optional). `needs:` only when there is a hint;
-            // `enables:` only when this dep backs at least one tool.
-            if !e.hint.is_empty() {
-                lines.push(Line::from(Span::styled(
-                    format!("      needs: {}", e.hint),
-                    dim_style,
-                )));
-            }
-            if !e.tools.is_empty() {
-                lines.push(Line::from(Span::styled(
-                    format!("      enables: {}", e.tools.join(", ")),
-                    dim_style,
-                )));
-            }
+            lines.push(Line::from(Span::styled(
+                format!("── tier {} ({}) ──", e.tier, tier_label(e.tier)),
+                dim_style,
+            )));
+            last_tier = Some(e.tier);
         }
 
-        lines.push(Line::from(""));
+        let is_selected = pos == st.health_selected;
+
+        // Name style: selection wins; otherwise present → accent, missing → dim.
+        let name_style = if is_selected {
+            Style::default()
+                .fg(palette.sel_fg)
+                .bg(palette.sel_bg)
+                .add_modifier(Modifier::BOLD)
+        } else if e.present {
+            Style::default().fg(palette.accent)
+        } else {
+            dim_style
+        };
+
+        // Present/missing marker — coloured to match the row's state.
+        let (marker, marker_style) = if e.present {
+            ("ok     ", Style::default().fg(palette.accent))
+        } else {
+            ("missing", dim_style)
+        };
+
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(format!("{:<18}", e.name), name_style),
+            Span::raw("  "),
+            Span::styled(marker, marker_style),
+            Span::styled(format!("  {}", e.method), dim_style),
+        ]));
+
+        // Secondary, dim hint lines (optional). `needs:` only when there is a hint;
+        // `enables:` only when this dep backs at least one tool.
+        if !e.hint.is_empty() {
+            lines.push(Line::from(Span::styled(
+                format!("      needs: {}", e.hint),
+                dim_style,
+            )));
+        }
+        if !e.tools.is_empty() {
+            lines.push(Line::from(Span::styled(
+                format!("      enables: {}", e.tools.join(", ")),
+                dim_style,
+            )));
+        }
     }
+    // Trailing blank to match the prior layout's per-group spacing tail.
+    lines.push(Line::from(""));
 }
+

--- a/src-security/koma_sec_daemon/__main__.py
+++ b/src-security/koma_sec_daemon/__main__.py
@@ -24,7 +24,43 @@ import argparse
 import io
 
 
+def _augment_path() -> None:
+    """Append standard bin dirs to PATH so detection + tool subprocess calls find
+    binaries installed outside the daemon's inherited PATH (e.g. ~/.local/bin,
+    Homebrew). Only existing, not-already-present dirs are appended; existing PATH
+    order is preserved."""
+    home = os.path.expanduser("~")
+    if sys.platform == "darwin":
+        candidates = [
+            os.path.join(home, ".local", "bin"),
+            "/opt/homebrew/bin",
+            "/opt/homebrew/sbin",
+            "/usr/local/bin",
+            "/usr/local/sbin",
+            "/usr/bin",
+            "/bin",
+        ]
+    else:  # linux and other unix
+        candidates = [
+            os.path.join(home, ".local", "bin"),
+            "/usr/local/bin",
+            "/usr/local/sbin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin",
+        ]
+    path = os.environ.get("PATH", "")
+    existing = path.split(os.pathsep) if path else []
+    existing_set = set(existing)
+    additions = [d for d in candidates if os.path.isdir(d) and d not in existing_set]
+    if additions:
+        os.environ["PATH"] = os.pathsep.join(existing + additions)
+
+
 def main() -> None:
+    _augment_path()
+
     parser = argparse.ArgumentParser(
         description="koma security daemon — speak newline-delimited JSON on stdin/stdout",
         prog="python -m koma_sec_daemon",

--- a/src-security/koma_sec_daemon/install_manifest.py
+++ b/src-security/koma_sec_daemon/install_manifest.py
@@ -265,12 +265,22 @@ MANIFEST: list[dict] = [
         "method": "gem",
         "detect": "one_gadget",
         "detect_kind": "which",
-        "tools": ["sec_rop"],
+        "tools": ["sec_rop", "sec_triage"],
         "hint": "gem install one_gadget  (requires Ruby >= 2.6)",
         "gem": "one_gadget",
     },
     # ----------------------------------------------------------------- TIER 3
     # Heavy / system deps — detect only. install returns the manual hint.
+    {
+        "key": "file",
+        "name": "file",
+        "tier": 3,
+        "method": "manual",
+        "detect": "file",
+        "detect_kind": "which",
+        "tools": ["sec_triage"],
+        "hint": "apt install file  (usually preinstalled on Unix)",
+    },
     {
         "key": "sage",
         "name": "SageMath",

--- a/src-security/koma_sec_daemon/tools/http.py
+++ b/src-security/koma_sec_daemon/tools/http.py
@@ -17,7 +17,8 @@ DESCRIPTOR = {
     "name": "sec_http",
     "description": (
         "Perform a single HTTP request and return the status line, "
-        "response headers, and body (body capped at 100 000 chars)."
+        "response headers, and body (body capped at 100 000 chars). "
+        "TLS certificate verification is disabled, so self-signed certs are accepted."
     ),
     "parameters": {
         "type": "object",
@@ -57,6 +58,12 @@ DESCRIPTOR = {
 def _handler(args: dict, sessions) -> str:
     # Lazy import — keeps registry loadable without requests installed
     import requests  # noqa: PLC0415
+    import urllib3  # noqa: PLC0415
+
+    # Pentest targets (HTB/CTF boxes) are routinely self-signed, so TLS cert
+    # verification is intentionally disabled — accept any certificate. Silence the
+    # resulting urllib3 InsecureRequestWarning so it doesn't pollute the response.
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     url = args["url"]
     method = args.get("method", "GET").upper()
@@ -72,6 +79,7 @@ def _handler(args: dict, sessions) -> str:
             data=body.encode() if body else None,
             allow_redirects=follow_redirects,
             timeout=30,
+            verify=False,
         )
     except Exception as exc:
         return f"error: {exc}"

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.1.4",
-  "message": "Backspace now works in QEMU/serial consoles (^H); forward-Delete supported in the composer."
+  "version": "0.1.5",
+  "message": "YOLO agent mode (lossless harness bypass, two-layer armed from /security); harness falls back to the main model instead of failing open on a misconfigured classifier; /security panel reworked — vertical daemon + YOLO checkboxes, fixed list navigation, per-tool [!!] missing-dependency markers with a non-blocking animated health probe; sec_http accepts self-signed certs; daemon augments PATH with standard bin dirs (Linux/macOS) and maps each tool's real binaries."
 }


### PR DESCRIPTION
…ork, sec_http certs

Harness:
- classifier/awareness fall back to the Main agent route on failure instead of failing open — a misconfigured classifier model can no longer silently disable the gate (was: unknown model 400s -> unavailable -> Auto runs the tool anyway).

YOLO agent mode (two-layer, opt-in):
- new AgentMode::Yolo bypasses the TAC classifier + all approval prompts but keeps the workspace path guard. Armed only from the /security panel; reachable via /mode yolo or Shift+Tab solely once armed. Stopping the daemon disarms it.

/security panel:
- vertical control checkboxes (Daemon start/stop, Enable YOLO) toggled with Space; slimmed footer.
- fixed up/down navigation desync (cursor now walks the same grouped order the view renders, in both tools and deps panes).
- per-tool [!!] yellow marker when a backing binary/dep is missing; inlined the spinner/legend onto the daemon info line.
- non-blocking animated health probe (spawn_blocking + mpsc drained in service_global) so the panel no longer freezes on the first cold probe.

Security daemon (Python):
- sec_http sends verify=False (accept self-signed certs — HTB/CTF targets).
- augment PATH at startup with standard bin dirs (Linux + macOS/Homebrew) so detection + tool subprocess calls resolve binaries in ~/.local/bin etc.
- manifest maps each tool's real binaries (file + one_gadget -> sec_triage).

Bump version.json + src-agent to 0.1.5 and sync Cargo.lock.