### PR TITLE
/bash: kill background jobs with Ctrl+X (koma's kill convention), bum…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "base64",

--- a/src-agent/Cargo.toml
+++ b/src-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src-agent/src/controller/command.rs
+++ b/src-agent/src/controller/command.rs
@@ -49,6 +49,7 @@ pub const KEYBINDINGS: &[(&str, &str)] = &[
     ("Ctrl+E", "toggle internet mode (simple / full)"),
     ("Ctrl+J", "insert a newline"),
     ("Ctrl+V", "paste an image from the clipboard"),
+    ("Ctrl+X", "kill the selected bash job / sub-agent"),
     ("Esc", "interrupt while busy"),
     ("Esc Esc", "edit a previous message (rewind)"),
     ("Up/Down/wheel", "scroll the transcript"),

--- a/src-agent/src/controller/input/bash.rs
+++ b/src-agent/src/controller/input/bash.rs
@@ -9,7 +9,7 @@
 //! - `Ctrl+C`        → `Action::Quit`
 //! - `Up`            → move the LIST cursor up
 //! - `Down`          → move the LIST cursor down
-//! - `k`/`K`         → `Action::BashKillJob(id)` for the selected job, ONLY when
+//! - `Ctrl+X`        → `Action::BashKillJob(id)` for the selected job, ONLY when
 //!   it is still running (a no-op on a finished/killed/errored job)
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
@@ -36,6 +36,17 @@ pub fn handle_bash(s: &mut BashState, rest: &mut AppStateRest, key: KeyEvent) ->
         return Action::Quit;
     }
 
+    // Ctrl+X kills the selected running job — koma's kill convention (matches the
+    // sub-agent abort in chat, the session hub, etc.). No-op on a finished/killed/
+    // errored job (no signal, no toast). Checked before the keycode match because
+    // is_ctrl inspects modifiers.
+    if is_ctrl(&key, 'x') {
+        return match s.current() {
+            Some(job) if job.running => Action::BashKillJob(job.id),
+            _ => Action::None,
+        };
+    }
+
     match key.code {
         KeyCode::Esc => Action::CloseBash,
         KeyCode::Up => {
@@ -46,12 +57,6 @@ pub fn handle_bash(s: &mut BashState, rest: &mut AppStateRest, key: KeyEvent) ->
             s.move_down();
             Action::None
         }
-        // Kill the selected job — only meaningful while it is still running. On a
-        // finished/killed/errored job this is a no-op (no signal, no toast).
-        KeyCode::Char('k') | KeyCode::Char('K') => match s.current() {
-            Some(job) if job.running => Action::BashKillJob(job.id),
-            _ => Action::None,
-        },
         // Any other key closes the panel (mirrors the /task sub-agents overlay,
         // which dismisses on any non-navigation key so the next keystroke types).
         _ => Action::CloseBash,

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.1.6",
-  "message": "quit-confirm: removed the stale Phase-2/daemon note (accurate detach wording now), and the k/d/esc options are clickable buttons in addition to the keyboard shortcuts."
+  "version": "0.1.7",
+  "message": "background bash jobs are now killed with Ctrl+X (koma's standard kill key) instead of k; the /bash panel header stays clean and Ctrl+X is documented in /help."
 }


### PR DESCRIPTION
…p to 0.1.7

- Rebind the /bash panel kill from `k` to Ctrl+X, matching the kill/abort key used everywhere else (/task sub-agents, session hub, chat abort). `k` now just closes the panel like any other non-nav key.
- Keep the /bash panel header clean (no inline hint); document the kill key as a first-class Ctrl+X row in /help's keybindings list instead.
- Bump version.json + src-agent to 0.1.7, sync Cargo.lock.