### PR TITLE
composer: stage clipboard images mid-turn + drop attachment when its …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/src-agent/Cargo.toml
+++ b/src-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src-agent/src/app/runtime/actions/chat.rs
+++ b/src-agent/src/app/runtime/actions/chat.rs
@@ -51,7 +51,9 @@ pub(super) fn handle_submit(
     // Move the staged composer attachments (from path-paste / @-picker) AND the
     // scan-backstop attachments onto THIS user message. Ingested bytes are already
     // on disk under `<session>/images/`; the wire builder re-reads at send time.
-    let mut attachments = state.rest.take_attachments();
+    // Pass the finalised `text` so a deleted / broken `[Image #N]` marker drops its
+    // staged attachment instead of shipping a marker-less image.
+    let mut attachments = state.rest.take_attachments(&text);
     attachments.extend(scan_attachments);
     let had_image = !attachments.is_empty();
     let history = {

--- a/src-agent/src/app/state/input.rs
+++ b/src-agent/src/app/state/input.rs
@@ -81,10 +81,11 @@ impl AppStateRest {
         self.palette_sel = 0;
     }
 
-    /// Move the staged composer attachments out for the message being submitted.
-    /// See [`super::SessionRuntime::take_attachments`].
-    pub fn take_attachments(&mut self) -> Vec<crate::dto::chat::Attachment> {
-        self.fg_mut().take_attachments()
+    /// Move the staged composer attachments out for the message being submitted,
+    /// reconciled against `submitted_text` (the composer `input` is already empty
+    /// at submit). See [`super::SessionRuntime::take_attachments`].
+    pub fn take_attachments(&mut self, submitted_text: &str) -> Vec<crate::dto::chat::Attachment> {
+        self.fg_mut().take_attachments(submitted_text)
     }
 
     /// Ingest the image file at `path` into the active session's `images/` dir,

--- a/src-agent/src/app/state/runtime.rs
+++ b/src-agent/src/app/state/runtime.rs
@@ -558,6 +558,9 @@ impl SessionRuntime {
         let at = self.byte_at(self.cursor);
         self.input.remove(at);
         self.hist_idx = None;
+        // A backspace may have deleted (part of) an `[Image #N]` marker; drop any
+        // staged attachment whose marker is now gone so the card can't outlive it.
+        self.reconcile_attachments();
     }
 
     /// Delete the char AT the caret (forward delete, the Delete key); no-op at the
@@ -569,6 +572,9 @@ impl SessionRuntime {
         let at = self.byte_at(self.cursor);
         self.input.remove(at);
         self.hist_idx = None;
+        // Mirror `backspace`: a forward-delete may have removed (part of) an
+        // `[Image #N]` marker, so re-sync the staged attachments to the text.
+        self.reconcile_attachments();
     }
 
     /// Move the caret one char left (no-op at the start).
@@ -675,11 +681,64 @@ impl SessionRuntime {
         self.hist_idx = None;
     }
 
+    /// Re-sync `pending_attachments` to the `[Image #N]` markers still present in
+    /// `input`: drop any staged attachment whose marker number no longer appears
+    /// in the composer text. Called from the char-removal paths (`backspace` /
+    /// `delete_forward`) so deleting an `[Image #N]` token live-drops its
+    /// attachment card.
+    ///
+    /// Deliberately NOT called from insert paths (`push_char` / `insert_marker` /
+    /// the attach helpers): an image's [`Attachment`] record is pushed a beat
+    /// AFTER its marker is inserted, so reconciling on insert could drop a
+    /// just-staged image before its record lands.
+    pub fn reconcile_attachments(&mut self) {
+        if self.pending_attachments.is_empty() {
+            return; // nothing staged → nothing to drop (skips the scan on every keystroke)
+        }
+        let present = Self::marker_numbers(&self.input);
+        self.pending_attachments
+            .retain(|a| present.contains(&a.marker_n));
+    }
+
+    /// Collect the set of `N` values from every literal `[Image #N]` token in
+    /// `text` — the exact format produced by `model::attachment`
+    /// (`format!("[Image #{n}]")`). A run of ASCII digits sitting between the
+    /// `[Image #` prefix and a closing `]` counts; a broken / half-typed marker
+    /// matches nothing, so its attachment reconciles away.
+    fn marker_numbers(text: &str) -> std::collections::HashSet<usize> {
+        const PREFIX: &str = "[Image #";
+        let mut out = std::collections::HashSet::new();
+        for (i, _) in text.match_indices(PREFIX) {
+            let after_prefix = &text[i + PREFIX.len()..];
+            let digits: String = after_prefix
+                .chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect();
+            if digits.is_empty() || !after_prefix[digits.len()..].starts_with(']') {
+                continue;
+            }
+            if let Ok(n) = digits.parse::<usize>() {
+                out.insert(n);
+            }
+        }
+        out
+    }
+
     /// Move the staged composer attachments out for the message being submitted,
     /// leaving `pending_attachments` empty. Called at submit, paired with
     /// `take_input()`, so the markers and their attachment records travel
     /// together onto the user message.
-    pub fn take_attachments(&mut self) -> Vec<crate::dto::chat::Attachment> {
+    ///
+    /// `submitted_text` is the text being sent (the composer `input` has already
+    /// been emptied by `take_input` at this point, so we reconcile against the
+    /// SUBMITTED text, not `self.input`). This is the send-time backstop: an
+    /// attachment whose `[Image #N]` marker did not survive into the sent message
+    /// — a marker broken by mid-token typing, or dropped by a history-recall
+    /// replace — is discarded here so a marker-less image can never ship.
+    pub fn take_attachments(&mut self, submitted_text: &str) -> Vec<crate::dto::chat::Attachment> {
+        let present = Self::marker_numbers(submitted_text);
+        self.pending_attachments
+            .retain(|a| present.contains(&a.marker_n));
         std::mem::take(&mut self.pending_attachments)
     }
 

--- a/src-agent/src/controller/input/chat.rs
+++ b/src-agent/src/controller/input/chat.rs
@@ -235,13 +235,13 @@ pub fn handle_chat(rest: &mut AppStateRest, key: KeyEvent) -> Action {
     // Ctrl+V: paste image from the OS clipboard (Wayland / X11). Shells out to
     // `wl-paste --type image/png` or `xclip` on a background thread (non-blocking);
     // the result lands in `rest.clipboard_rx` and is drained by the event loop on
-    // the next tick. No-op when a fetch is already in flight or when waiting for a
-    // model response (to avoid attaching images mid-turn).
+    // the next tick. NOT gated on `waiting`: staging an image is composer input and,
+    // like bracketed text-paste, must work mid-turn / mid-subagent — the cooking turn
+    // already took its attachments at submit, so a freshly pasted image just stages
+    // for the NEXT message. Only SUBMITTING a turn is gated by cooking, never staging.
     if is_ctrl(&key, 'v') {
-        if !rest.fg().waiting {
-            super::request_clipboard_image(rest);
-            rest.fg_mut().set_toast_info("reading image from clipboard…".to_string());
-        }
+        super::request_clipboard_image(rest);
+        rest.fg_mut().set_toast_info("reading image from clipboard…".to_string());
         return Action::None;
     }
     // Ctrl+E: toggle internet mode (Simple <-> Full), persist, and set status.

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.2.1",
-  "message": "The command palette (/) and @ mentions — plus screens like /settings, /bash, /mcp, /security, /agents and the /resume swapper — now open even while a turn or subagent is still cooking, instead of being silently swallowed. And the /task subagent panel no longer traps your keystrokes: pressing / or @ closes it and opens the palette, so those stay reachable."
+  "version": "0.2.2",
+  "message": "Clipboard image paste (Ctrl+V) now works while a turn or subagent is still cooking, instead of being silently swallowed — staging an image is composer input, so a mid-turn paste just attaches to your next message. And deleting an [Image #N] token now removes its attachment: the image card disappears and that picture is no longer sent, so a stray marker can't ship an image you meant to drop."
 }


### PR DESCRIPTION
…marker is deleted

Bug 1 - Ctrl+V clipboard image paste was gated behind `!waiting`, so it was silently swallowed while a turn or subagent was cooking. Staging composer input is never gated by cooking (only submitting a turn is), matching the v0.2.1 input-independence fix. Dropped the `waiting` guard so a mid-turn paste just stages for the next message.

Bug 2 - deleting the `[Image #N]` text left its Attachment in `pending_attachments`, so the image still shipped at send. Added `reconcile_attachments()` (scans the composer text for `[Image #N]` tokens and retains only attachments whose marker survives), called from `backspace()` / `delete_forward()` for a live drop, plus a send-time backstop in `take_attachments()` that reconciles against the submitted text (the composer `input` is already emptied by `take_input` at submit).

version 0.2.1 -> 0.2.2.