### PR TITLE
worktree: swap primary workspace root on enter/exit instead of append…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "base64",

--- a/src-agent/Cargo.toml
+++ b/src-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src-agent/src/app/runtime/stream/tools/approval.rs
+++ b/src-agent/src/app/runtime/stream/tools/approval.rs
@@ -439,9 +439,7 @@ pub(crate) fn process_tools(
                     let target_str = target.to_string();
                     {
                         if let Some(sess) = state.rest.sessions[sess_idx].session.as_mut() {
-                            if !sess.settings.workdir.contains(&target_str) {
-                                sess.settings.workdir.push(target_str.clone());
-                            }
+                            sess.settings.enter_worktree(target_str.clone());
                             let _ = sess.save();
                         }
                     }
@@ -466,14 +464,13 @@ pub(crate) fn process_tools(
                     // `enter` succeeded: target is the canonical path string.
                     let new_cwd = std::path::PathBuf::from(target);
                     let target_str = target.to_string();
-                    // Push the new root into settings.workdir if not already there,
-                    // then persist. Scoped so the mutable sess borrow ends before
-                    // we call apply_workspace_change (which also borrows state mut).
+                    // Swap slot [0] to the worktree root (stashing the current
+                    // primary root for restore on exit), then persist. Scoped so
+                    // the mutable sess borrow ends before we call
+                    // apply_workspace_change (which also borrows state mut).
                     {
                         if let Some(sess) = state.rest.sessions[sess_idx].session.as_mut() {
-                            if !sess.settings.workdir.contains(&target_str) {
-                                sess.settings.workdir.push(target_str.clone());
-                            }
+                            sess.settings.enter_worktree(target_str.clone());
                             let _ = sess.save();
                         }
                     }
@@ -482,15 +479,17 @@ pub(crate) fn process_tools(
                     );
                     format!("entered worktree: {}", new_cwd.display())
                 } else if result.starts_with(crate::tool::git_worktree::GIT_WT_EXIT_PREFIX) {
-                    // `exit`: return to the primary workdir (first workdir entry).
-                    // Extract the primary path in a scoped borrow, then call
-                    // apply_workspace_change outside it.
+                    // `exit`: restore the base primary root (swap slot [0] back) and return
+                    // to it. Extra roots in workdir[1..] are preserved. Mutate + save in a
+                    // scoped borrow, then call apply_workspace_change outside it.
                     let primary = {
-                        state.rest.sessions[sess_idx]
-                            .session
-                            .as_ref()
-                            .map(|sess| sess.workdir())
-                            .unwrap_or_else(|| std::path::PathBuf::from("."))
+                        if let Some(sess) = state.rest.sessions[sess_idx].session.as_mut() {
+                            sess.settings.exit_worktree();
+                            let _ = sess.save();
+                            sess.workdir()
+                        } else {
+                            std::path::PathBuf::from(".")
+                        }
                     };
                     super::super::spawn::apply_workspace_change(
                         state, sess_idx, primary.clone(), client, handle,
@@ -511,7 +510,20 @@ pub(crate) fn process_tools(
                     let primary;
                     {
                         if let Some(sess) = state.rest.sessions[sess_idx].session.as_mut() {
-                            sess.settings.workdir.retain(|p| p != &removed);
+                            // Removing the worktree we're standing in → restore the base
+                            // root (swap slot [0] back). Removing a different worktree/dir
+                            // by name → just drop it wherever it sits in the list.
+                            let in_removed = sess
+                                .settings
+                                .workdir
+                                .first()
+                                .map(|p| p == &removed)
+                                .unwrap_or(false);
+                            if in_removed {
+                                sess.settings.exit_worktree();
+                            } else {
+                                sess.settings.workdir.retain(|p| p != &removed);
+                            }
                             let _ = sess.save();
                             primary = sess.workdir();
                         } else {

--- a/src-agent/src/model/settings.rs
+++ b/src-agent/src/model/settings.rs
@@ -202,6 +202,14 @@ pub struct Settings {
     /// as `vec!["…"]`; arrays load verbatim. Always serialised as an array.
     #[serde(default, deserialize_with = "string_or_vec")]
     pub workdir: Vec<String>,
+
+    /// While inside a git_worktree (entered or created via the `git_worktree`
+    /// tool), holds the base PRIMARY root (`workdir[0]`) to restore on exit.
+    /// `None` = at the base root (not inside a worktree). Only slot `[0]` swaps
+    /// to the worktree; manually-added extra roots in `workdir[1..]` are
+    /// preserved across enter/exit.
+    #[serde(default)]
+    pub workdir_saved: Option<String>,
     /// Whether the project-awareness summary is generated and injected into the
     /// system prompt. When false, no secondary-model call is made.
     #[serde(default = "default_awareness_enabled")]
@@ -345,6 +353,7 @@ impl Default for Settings {
             provider: DEFAULT_PROVIDER.to_string(),
             effort: String::new(),
             workdir: Vec::new(),
+            workdir_saved: None,
             awareness_enabled: default_awareness_enabled(),
             awareness_inherit: default_awareness_inherit(),
             awareness_model: DEFAULT_AWARENESS_MODEL.to_string(),
@@ -364,6 +373,44 @@ impl Default for Settings {
 }
 
 impl Settings {
+    /// Enter a worktree: stash the current primary root once, then swap slot
+    /// `[0]` to `worktree`. Extra roots in `[1..]` are preserved (any lingering
+    /// duplicate of the worktree is dropped). Idempotent on `workdir_saved`:
+    /// entering a second worktree keeps the ORIGINAL base as the restore point.
+    pub fn enter_worktree(&mut self, worktree: String) {
+        if self.workdir_saved.is_none() {
+            self.workdir_saved = Some(self.workdir.first().cloned().unwrap_or_default());
+        }
+        if self.workdir.is_empty() {
+            self.workdir.push(worktree.clone());
+        } else {
+            self.workdir[0] = worktree.clone();
+        }
+        // Drop any duplicate of the worktree lingering in the extra roots.
+        let mut i = 1;
+        while i < self.workdir.len() {
+            if self.workdir[i] == worktree {
+                self.workdir.remove(i);
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    /// Exit a worktree: restore the stashed base primary root into slot `[0]`.
+    /// Extra roots in `[1..]` stay. No-op if not inside a worktree.
+    pub fn exit_worktree(&mut self) {
+        if let Some(root) = self.workdir_saved.take() {
+            if self.workdir.is_empty() {
+                if !root.is_empty() {
+                    self.workdir.push(root);
+                }
+            } else {
+                self.workdir[0] = root;
+            }
+        }
+    }
+
     /// Deserialise from a `settings.json` file at `path`.
     pub fn load(path: &Path) -> Result<Self> {
         let bytes = std::fs::read(path)?;

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.2.4",
-  "message": "koma now reads before it writes: the agent must have seen a file's current content in this conversation before it can edit it (or overwrite an existing file). If it hasn't read the file, the edit is held back with a nudge to read it first — so edits never fire blind against stale assumptions. Reading, writing, or a prior edit all count as having seen it, and creating a brand-new file needs no prior read."
+  "version": "0.2.5",
+  "message": "worktree enter/exit now swaps the primary workspace root (workdir[0]) instead of appending, so edits land in the worktree instead of the repo root; manually-added extra roots are preserved."
 }


### PR DESCRIPTION
…ing (0.2.5)

Entering/creating a git_worktree used to push the worktree onto settings.workdir, producing [repo_root, worktree]. resolve() always writes to workdir[0], so every bare-path edit landed in the repo root instead of the worktree — the wrong tree.

Now enter/create SWAP slot [0] to the worktree (stashing the original primary in a new Settings.workdir_saved field); exit/remove restore it. Only [0] swaps, so manually-added extra roots in workdir[1..] are preserved across enter/exit. Invariant: workdir is always [origin..] or [worktree..], never both — the wrong tree is never in the allow-set, so writes can't leak into it.