### PR TITLE
conversation: never end history() on an assistant message (fixes pref…

### DIFF
--- a/src-agent/src/model/conversation.rs
+++ b/src-agent/src/model/conversation.rs
@@ -173,6 +173,16 @@ impl Conversation {
                 _ => out.push(m.clone()),
             }
         }
+
+        // Never end the request on an assistant message: a trailing role=assistant is
+        // an "assistant prefill", which strict OpenAI-compatible backends (llama.cpp,
+        // vLLM, LiteLLM) reject (a 400, esp. with thinking enabled). No-op in the
+        // normal case (history ends on user/tool); only fires on the orphaned-assistant
+        // edge (e.g. an interrupted tool round).
+        while out.last().is_some_and(|m| m.role == Role::Assistant) {
+            out.pop();
+        }
+
         out
     }
 


### PR DESCRIPTION
…ill 400 on strict backends)

The outbound request `messages` array is `history()` 1:1. An orphaned trailing assistant message (e.g. an interrupted tool round leaves an assistant with its tool_calls stripped and no following tool/user message) becomes an "assistant prefill" — which strict OpenAI-compatible backends (llama.cpp, vLLM, LiteLLM, local routers) reject with 400 "Assistant response prefill is incompatible with enable_thinking". OpenRouter tolerated it, which hid the bug.

Fix: strip any trailing assistant message(s) at the end of history(). No-op in the normal case (history ends on user/tool, including the entire agentic tool loop) and transient (the assistant is kept again the moment a real user turn follows it). Verified against a live llama.cpp endpoint: trailing-assistant request -> 400, same request with the trailing assistant stripped -> 200.