### PR TITLE
session hub: global /resume + project labels + animated working marke…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "base64",

--- a/src-agent/Cargo.toml
+++ b/src-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src-agent/src/app/mode/session_hub.rs
+++ b/src-agent/src/app/mode/session_hub.rs
@@ -71,6 +71,12 @@ pub struct CookingEntry {
     // the swapper that consumes it lands next commit. Allow until then.
     #[allow(dead_code)]
     pub session_id: Option<String>,
+    /// Basename of the session's working directory, used as a label in the cooking pane.
+    pub dir_label: String,
+    /// Whether the session's working directory matches the current process's working directory.
+    /// Populated for future use; cooking pane currently uses `is_foreground` for emphasis.
+    #[allow(dead_code)]
+    pub is_current_dir: bool,
 }
 
 /// One row in the HISTORY pane: an on-disk session not currently live.
@@ -83,6 +89,10 @@ pub struct HistoryEntry {
     pub name: String,
     /// Last-active time (the registry `updated_at`), shown as a relative age.
     pub last_active: SystemTime,
+    /// Basename of the session's working directory, shown as a label in the history pane.
+    pub dir_label: String,
+    /// Whether the session's working directory matches the current process's working directory.
+    pub is_current_dir: bool,
 }
 
 /// State for the two-pane session hub.

--- a/src-agent/src/app/runtime/client/swapper.rs
+++ b/src-agent/src/app/runtime/client/swapper.rs
@@ -73,6 +73,10 @@ pub(crate) fn build_local_hub(current_session_id: Option<&str>) -> SessionHub {
 /// blocking [`manage::list_live_sessions`] sweep; [`apply_snapshot`] wraps this to
 /// PRESERVE the user's position across a live rebuild.
 fn hub_from_snapshot(live: Vec<SessionStatus>, current_session_id: Option<&str>) -> SessionHub {
+    // Compute the current directory hash once — this runs in the CLIENT process,
+    // so current_dir() is the user's launch dir, which is the correct reference.
+    let cur_hash = store::pwd_hash(&std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")));
+
     // The set of LIVE session UUIDs, used to hide already-live sessions from the
     // HISTORY pane. `SessionStatus::session_id` and `SessionMeta::id` are the SAME
     // UUID namespace (both the on-disk session dir name / socket key), so a string
@@ -91,10 +95,14 @@ fn hub_from_snapshot(live: Vec<SessionStatus>, current_session_id: Option<&str>)
         working: false,
         is_foreground: false,
         session_id: None,
+        dir_label: String::new(),
+        is_current_dir: false,
     });
     for status in live {
         // Compute the foreground flag BEFORE moving the id/name out of `status`.
         let is_foreground = current_session_id == Some(status.session_id.as_str());
+        let is_current_dir = store::pwd_hash(std::path::Path::new(&status.pwd)) == cur_hash;
+        let dir_label = store::dir_basename(&status.pwd);
         cooking.push(CookingEntry {
             idx: usize::MAX,
             kind: SessionKind::Session,
@@ -102,12 +110,14 @@ fn hub_from_snapshot(live: Vec<SessionStatus>, current_session_id: Option<&str>)
             working: status.working,
             is_foreground,
             session_id: Some(status.session_id),
+            dir_label,
+            is_current_dir,
         });
     }
 
-    // HISTORY pane: on-disk sessions MINUS the live ones (dedup by UUID). A listing
+    // HISTORY pane: on-disk sessions (all dirs) MINUS the live ones (dedup by UUID). A listing
     // failure shouldn't block the hub — show an empty history pane.
-    let history: Vec<HistoryEntry> = match store::list_sessions() {
+    let mut history: Vec<HistoryEntry> = match store::list_all_sessions() {
         Ok(metas) => metas
             .into_iter()
             .filter(|m| !live_ids.contains(&m.id))
@@ -115,10 +125,14 @@ fn hub_from_snapshot(live: Vec<SessionStatus>, current_session_id: Option<&str>)
                 path: m.path,
                 name: m.name,
                 last_active: m.modified,
+                dir_label: store::dir_basename(&m.workdir),
+                is_current_dir: m.pwd_hash == cur_hash,
             })
             .collect(),
         Err(_) => Vec::new(),
     };
+    // Sort: current-dir sessions first, then newest within each group.
+    history.sort_by(|a, b| b.is_current_dir.cmp(&a.is_current_dir).then(b.last_active.cmp(&a.last_active)));
 
     // History starts fully visible: identity filter, empty query.
     let history_filtered: Vec<usize> = (0..history.len()).collect();

--- a/src-agent/src/app/runtime/client_shadow/modes.rs
+++ b/src-agent/src/app/runtime/client_shadow/modes.rs
@@ -97,6 +97,8 @@ pub(crate) fn shadow_session_hub(h: SessionHubSnapshot) -> SessionHub {
             path: std::path::PathBuf::new(), // daemon-side load target; not rendered
             name: e.name,
             last_active: std::time::UNIX_EPOCH + Duration::from_secs(e.last_active_secs),
+            dir_label: String::new(),  // not projected over the wire; labels shown on daemon side
+            is_current_dir: false,
         })
         .collect();
     // The projected history is already filtered → identity filter over it.
@@ -119,6 +121,8 @@ pub(crate) fn shadow_session_hub(h: SessionHubSnapshot) -> SessionHub {
                 // own index, not by id). The client swapper sources its addressing
                 // id from `build_local_hub`/discovery, never from this path.
                 session_id: None,
+                dir_label: String::new(),  // not projected over the wire
+                is_current_dir: false,
             })
             .collect(),
         history,
@@ -288,6 +292,8 @@ pub(crate) fn shadow_picker(p: PickerSnapshot) -> PickerState {
                 modified: std::time::UNIX_EPOCH + Duration::from_secs(m.modified_secs),
                 message_count: m.message_count,
                 locked: m.locked,
+                workdir: String::new(),  // not projected over the wire
+                pwd_hash: String::new(),
             })
             .collect(),
         filtered_idx: p.filtered_idx,

--- a/src-agent/src/app/runtime/commands/new_session.rs
+++ b/src-agent/src/app/runtime/commands/new_session.rs
@@ -230,6 +230,9 @@ pub(crate) fn apply_new_session_local(
 /// a surfaced error — the cooking pane is still useful, and the caller owns the
 /// status line.
 pub(crate) fn build_session_hub(state: &AppState) -> SessionHub {
+    // Compute the current directory hash once for dir-label comparisons.
+    let cur_hash = store::pwd_hash(&std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")));
+
     // COOKING pane: a synthetic "[+ new session]" row at index 0, then one row per
     // LIVE session with a non-empty Session that ISN'T tombstoned.
     let mut cooking: Vec<CookingEntry> = Vec::with_capacity(state.rest.sessions.len() + 1);
@@ -240,6 +243,8 @@ pub(crate) fn build_session_hub(state: &AppState) -> SessionHub {
         working: false,
         is_foreground: false,
         session_id: None,
+        dir_label: String::new(),
+        is_current_dir: false,
     });
     for (raw_idx, rt) in state.rest.sessions.iter().enumerate() {
         // Skip the initial empty placeholder AND any closed/tombstoned slot — the
@@ -248,6 +253,8 @@ pub(crate) fn build_session_hub(state: &AppState) -> SessionHub {
         if rt.session.is_none() || rt.is_closed() {
             continue;
         }
+        let workdir = rt.effective_cwd().display().to_string();
+        let is_current_dir = store::pwd_hash(std::path::Path::new(&workdir)) == cur_hash;
         cooking.push(CookingEntry {
             idx: raw_idx,
             kind: SessionKind::Session,
@@ -259,6 +266,8 @@ pub(crate) fn build_session_hub(state: &AppState) -> SessionHub {
             working: rt.is_working(),
             is_foreground: raw_idx == state.rest.foreground,
             session_id: Some(rt.id.clone()),
+            dir_label: store::dir_basename(&workdir),
+            is_current_dir,
         });
     }
 
@@ -274,8 +283,8 @@ pub(crate) fn build_session_hub(state: &AppState) -> SessionHub {
         .filter_map(|rt| rt.session.as_ref().map(|s| s.path.clone()))
         .collect();
 
-    // HISTORY pane: on-disk sessions MINUS the live ones (dedup).
-    let history: Vec<HistoryEntry> = match store::list_sessions() {
+    // HISTORY pane: on-disk sessions (all dirs) MINUS the live ones (dedup).
+    let mut history: Vec<HistoryEntry> = match store::list_all_sessions() {
         Ok(metas) => metas
             .into_iter()
             .filter(|m| !live_paths.contains(&m.path))
@@ -283,11 +292,15 @@ pub(crate) fn build_session_hub(state: &AppState) -> SessionHub {
                 path: m.path,
                 name: m.name,
                 last_active: m.modified,
+                dir_label: store::dir_basename(&m.workdir),
+                is_current_dir: m.pwd_hash == cur_hash,
             })
             .collect(),
         // A listing failure shouldn't block the hub — show an empty history pane.
         Err(_) => Vec::new(),
     };
+    // Sort: current-dir sessions first, then newest within each group.
+    history.sort_by(|a, b| b.is_current_dir.cmp(&a.is_current_dir).then(b.last_active.cmp(&a.last_active)));
 
     // Default the cooking cursor to the current foreground's row. Clamp defensively
     // (a closed foreground is filtered out, so its row may be absent → fall to 0).

--- a/src-agent/src/model/session_registry.rs
+++ b/src-agent/src/model/session_registry.rs
@@ -23,18 +23,15 @@ use rusqlite::{Connection, OptionalExtension};
 
 use crate::model::store::registry_path;
 
-/// One registry row as listed for a working directory. `pwd_hash` is implied by
-/// the query (`list_by_pwd` already filters on it), so it isn't repeated here.
+/// One registry row as listed for a working directory.
 ///
 /// Mirrors the selected columns one-to-one; `list_sessions` consumes `uuid`,
-/// `name`, and `updated_at`. `workdir` is carried for completeness (the
-/// effective workdir is read from the session's own settings) — hence the
-/// field-level `allow`.
+/// `name`, `pwd_hash`, `workdir`, and `updated_at`.
 #[derive(Debug, Clone)]
 pub struct RegRow {
     pub uuid: String,
+    pub pwd_hash: String,
     pub name: String,
-    #[allow(dead_code)] // selected for completeness; workdir is read from settings
     pub workdir: String,
     pub updated_at: i64,
 }
@@ -131,15 +128,38 @@ pub fn touch(uuid: &str) -> Result<()> {
 pub fn list_by_pwd(pwd_hash: &str) -> Result<Vec<RegRow>> {
     let conn = open()?;
     let mut stmt = conn.prepare(
-        "SELECT uuid, name, workdir, updated_at FROM sessions
+        "SELECT uuid, pwd_hash, name, workdir, updated_at FROM sessions
          WHERE pwd_hash = ?1 ORDER BY updated_at DESC",
     )?;
     let rows = stmt.query_map(rusqlite::params![pwd_hash], |r| {
         Ok(RegRow {
             uuid: r.get(0)?,
-            name: r.get(1)?,
-            workdir: r.get(2)?,
-            updated_at: r.get(3)?,
+            pwd_hash: r.get(1)?,
+            name: r.get(2)?,
+            workdir: r.get(3)?,
+            updated_at: r.get(4)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// All sessions across ALL working directories, most-recently updated first.
+pub fn list_all() -> Result<Vec<RegRow>> {
+    let conn = open()?;
+    let mut stmt = conn.prepare(
+        "SELECT uuid, pwd_hash, name, workdir, updated_at FROM sessions ORDER BY updated_at DESC",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok(RegRow {
+            uuid: r.get(0)?,
+            pwd_hash: r.get(1)?,
+            name: r.get(2)?,
+            workdir: r.get(3)?,
+            updated_at: r.get(4)?,
         })
     })?;
     let mut out = Vec::new();

--- a/src-agent/src/model/store.rs
+++ b/src-agent/src/model/store.rs
@@ -59,6 +59,10 @@ pub struct SessionMeta {
     /// so a stale lock from a crashed instance reads as unlocked. The picker
     /// shows a lock marker and refuses to enter a locked session.
     pub locked: bool,
+    /// The working directory this session was opened from (as stored in the registry).
+    pub workdir: String,
+    /// The pwd_hash bucket this session belongs to.
+    pub pwd_hash: String,
 }
 
 /// Returns `~/.koma/` (the application data root).
@@ -409,10 +413,68 @@ pub fn list_sessions_for(pwd_hash: &str) -> Result<Vec<SessionMeta>> {
             modified,
             message_count,
             locked,
+            workdir: row.workdir.clone(),
+            pwd_hash: pwd_hash.to_string(),
         });
     }
 
     Ok(metas)
+}
+
+/// List ALL sessions across every working-directory bucket, most-recently updated first.
+///
+/// Like [`list_sessions_for`] but without a pwd filter: every session in the registry
+/// is returned regardless of which directory it was opened from. Each `SessionMeta`
+/// carries `workdir` and `pwd_hash` so callers can label and sort by directory.
+pub fn list_all_sessions() -> Result<Vec<SessionMeta>> {
+    let rows = session_registry::list_all()?;
+    let mut metas: Vec<SessionMeta> = Vec::with_capacity(rows.len());
+
+    for row in rows {
+        // Use the stored pwd_hash directly — do NOT re-canonicalize/re-hash the
+        // workdir, which could differ on a machine where the path no longer exists.
+        let path = session_dir(&row.pwd_hash, &row.uuid)?;
+
+        let messages_path = path.join("messages.json");
+        let message_count = match std::fs::read(&messages_path) {
+            Ok(bytes) => serde_json::from_slice::<Vec<crate::dto::chat::ChatMessage>>(&bytes)
+                .map(|msgs| msgs.iter().filter(|m| m.role != crate::dto::chat::Role::System).count())
+                .unwrap_or(0),
+            Err(_) => 0,
+        };
+
+        let modified = row
+            .updated_at
+            .try_into()
+            .ok()
+            .map(|secs| SystemTime::UNIX_EPOCH + Duration::from_secs(secs))
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+
+        let locked = is_locked(&path);
+
+        metas.push(SessionMeta {
+            id: row.uuid,
+            name: row.name,
+            path,
+            modified,
+            message_count,
+            locked,
+            workdir: row.workdir,
+            pwd_hash: row.pwd_hash,
+        });
+    }
+
+    Ok(metas)
+}
+
+/// Return the last path segment (basename) of `workdir` as a display label.
+/// Returns an empty string if the path has no filename component.
+pub(crate) fn dir_basename(workdir: &str) -> String {
+    std::path::Path::new(workdir)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string()
 }
 
 /// Create a brand-new session with a UUID id, bucketed by the current working

--- a/src-agent/src/view/session_hub.rs
+++ b/src-agent/src/view/session_hub.rs
@@ -135,6 +135,14 @@ fn draw_cooking(frame: &mut Frame, area: Rect, hub: &SessionHub, palette: &Palet
     let inner = pane_inner(frame, area, &format!("cooking ({real_sessions})"), focused, palette);
     let inner_w = inner.width as usize;
 
+    // Animated spinner frame — ticks every 80ms.
+    const SA_SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let glyph = SA_SPINNER[((now_ms / 80) as usize) % SA_SPINNER.len()];
+
     let mut lines: Vec<Line> = Vec::new();
     for (i, entry) in hub.cooking.iter().enumerate() {
         let style = if focused && i == hub.cooking_selected {
@@ -147,18 +155,31 @@ fn draw_cooking(frame: &mut Frame, area: Rect, hub: &SessionHub, palette: &Palet
             Style::default().fg(palette.dim)
         };
 
-        let row = if entry.kind == SessionKind::NewSession {
-            entry.name.clone()
+        if entry.kind == SessionKind::NewSession {
+            lines.push(Line::styled(entry.name.clone(), style));
         } else {
-            let state_marker = if entry.working { "● working" } else { "○ ready  " };
-            let current = if entry.is_foreground { "(current)  " } else { "" };
-            let right = format!("{current}{state_marker}");
+            let marker = if entry.working {
+                format!("{glyph} working")
+            } else {
+                "○ ready  ".to_string()
+            };
+            let dir = truncate(&entry.dir_label, 14);
+            let right = if dir.is_empty() { marker.clone() } else { format!("{dir}  {marker}") };
             let name_w = inner_w.saturating_sub(right.chars().count() + 2).max(4);
             let name = truncate(&entry.name, name_w);
-            format!("{name:<name_w$}  {right}")
-        };
-
-        lines.push(Line::styled(row, style));
+            let name_style = if entry.is_foreground {
+                style.add_modifier(Modifier::ITALIC | Modifier::UNDERLINED)
+            } else {
+                style
+            };
+            let pad = name_w.saturating_sub(name.chars().count());
+            let line = Line::from(vec![
+                Span::styled(name, name_style),
+                Span::styled(" ".repeat(pad + 2), style),
+                Span::styled(right, style),
+            ]);
+            lines.push(line);
+        }
     }
 
     // Scroll so the selected row stays visible within this pane's height (only the
@@ -227,10 +248,12 @@ fn draw_history(frame: &mut Frame, area: Rect, hub: &SessionHub, palette: &Palet
             let Some(entry) = hub.history.get(real_idx) else {
                 continue;
             };
+            let dir = truncate(&entry.dir_label, 14);
             let age = fmt_age(entry.last_active);
-            let name_w = inner_w.saturating_sub(age.chars().count() + 2).max(4);
+            let right = if dir.is_empty() { age.clone() } else { format!("{dir}  {age}") };
+            let name_w = inner_w.saturating_sub(right.chars().count() + 2).max(4);
             let name = truncate(&entry.name, name_w);
-            let row = format!("{name:<name_w$}  {age:>}");
+            let row = format!("{name:<name_w$}  {right}");
 
             let style = if focused && i == hub.history_selected {
                 Style::default().fg(palette.sel_fg).bg(palette.sel_bg)

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.2.6",
-  "message": "add web_download: fetch a URL and save it to the session media directory, surfaced in @-autocomplete; downloads are capped at 500 MiB and the save path is traversal- and sentinel-validated."
+  "version": "0.2.7",
+  "message": "session hub: /resume is now global — it lists sessions from every directory (current dir first), each labelled with its project; the working marker animates like a running sub-agent and the current session's title is italic+underlined."
 }


### PR DESCRIPTION
…r (0.2.7)

- resume is now GLOBAL: drop the pwd_hash scope so /resume lists sessions from every directory, not just the launch dir. New session_registry::list_all() + store::list_all_sessions() (each SessionMeta now carries workdir + pwd_hash); both hub builders (daemon build_session_hub, client hub_from_snapshot) use it.
- each hub row is labelled with its project (basename of the session's workdir, truncated to 14), and the history pane sorts current-dir sessions first, then newest.
- the "working" marker now animates (braille spinner, reusing the sub-agent idiom); the current session is marked by an italic+underline title instead of a "(current)" text tag.