### PR TITLE
revert the 0.2.7 history() trailing-assistant strip (bump 0.2.8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "base64",

--- a/src-agent/Cargo.toml
+++ b/src-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src-agent/src/model/conversation.rs
+++ b/src-agent/src/model/conversation.rs
@@ -173,16 +173,6 @@ impl Conversation {
                 _ => out.push(m.clone()),
             }
         }
-
-        // Never end the request on an assistant message: a trailing role=assistant is
-        // an "assistant prefill", which strict OpenAI-compatible backends (llama.cpp,
-        // vLLM, LiteLLM) reject (a 400, esp. with thinking enabled). No-op in the
-        // normal case (history ends on user/tool); only fires on the orphaned-assistant
-        // edge (e.g. an interrupted tool round).
-        while out.last().is_some_and(|m| m.role == Role::Assistant) {
-            out.pop();
-        }
-
         out
     }
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.2.7",
-  "message": "session hub: /resume is now global — it lists sessions from every directory (current dir first), each labelled with its project; the working marker animates like a running sub-agent and the current session's title is italic+underlined."
+  "version": "0.2.8",
+  "message": "revert the 0.2.7 history() trailing-assistant strip: it did not fix the prefill 400 on strict backends (llama.cpp/vLLM) and it degraded reasoning continuity, since the assistant-prefill is load-bearing for thinking models; a backend-aware fix is pending."
 }


### PR DESCRIPTION
The trailing-assistant pop from 0.2.7 (ca2c12a) was wrong on both counts: it did NOT fix the "assistant response prefill is incompatible with enable_thinking" 400 on strict backends (llama.cpp/vLLM) — that prefill is injected outside history() — and it degraded reasoning continuity on all backends, because the assistant-prefill is load-bearing for thinking models, not an accidental orphan. Reverting to restore thinking; a backend-aware fix for the strict-backend prefill conflict is pending.