### PR TITLE
stream: robust thinking capture (0.2.9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "base64",

--- a/src-agent/Cargo.toml
+++ b/src-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src-agent/src/dto/openrouter/response.rs
+++ b/src-agent/src/dto/openrouter/response.rs
@@ -50,7 +50,7 @@ pub struct ResponseMessage {
     pub role: String,
     #[serde(default)]
     pub content: Option<String>,
-    #[serde(default)]
+    #[serde(default, alias = "reasoning_content", alias = "thinking")]
     pub reasoning: Option<String>,
 }
 
@@ -98,7 +98,7 @@ pub struct Delta {
     /// (via `/effort`). Accumulated into the assistant message's display-only
     /// reasoning block; never echoed back to the API. `None` on frames the model
     /// doesn't think on (and absent entirely for non-reasoning models).
-    #[serde(default)]
+    #[serde(default, alias = "reasoning_content", alias = "thinking")]
     pub reasoning: Option<String>,
     /// Incremental tool-call fragments. The model streams a tool call across
     /// several frames: the first carries the `id` + function `name`, subsequent

--- a/src-agent/src/service/openrouter/mod.rs
+++ b/src-agent/src/service/openrouter/mod.rs
@@ -26,6 +26,7 @@ mod helpers;
 mod stream;
 mod oneshot;
 mod catalogue;
+mod think_split;
 
 // Re-export the entire public surface so every external path is unchanged.
 pub use types::{Conn, EffortCaps};

--- a/src-agent/src/service/openrouter/stream.rs
+++ b/src-agent/src/service/openrouter/stream.rs
@@ -15,6 +15,7 @@ use crate::service::StreamEvent;
 use super::helpers::{clean_error, emit, provider_routing_for, reasoning_config, sanitize_tool_acc};
 use super::client::OpenRouterClient;
 use super::types::Conn;
+use super::think_split::{Emit as ThinkEmit, ThinkSplit};
 
 impl OpenRouterClient {
     /// Streaming chat completion over Server-Sent Events.
@@ -121,6 +122,10 @@ impl OpenRouterClient {
 
         let mut stream = resp.bytes_stream();
         let mut buf: Vec<u8> = Vec::new();
+        // Splits a leading <think>…</think> block out of delta.content, routing
+        // it to the Reasoning channel instead of the Token channel. One instance
+        // per stream call so state persists across all delta chunks of this turn.
+        let mut think = ThinkSplit::new();
         // Tool calls stream across many frames, one (or more) per `index`. Each
         // frame contributes the id / name once and appends argument fragments;
         // we merge them here and emit the assembled set at finalisation.
@@ -153,6 +158,20 @@ impl OpenRouterClient {
                     None => continue, // comments/keepalive
                 };
                 if data == "[DONE]" {
+                    // Flush any buffered think-tag tail (e.g. reasoning text
+                    // held back waiting for a partial closer, or a partial
+                    // opener that never completed).
+                    for e in think.finish() {
+                        match e {
+                            ThinkEmit::Content(s) if !s.is_empty() => {
+                                emit(&tx, StreamEvent::Token(s));
+                            }
+                            ThinkEmit::Reasoning(s) if !s.is_empty() => {
+                                emit(&tx, StreamEvent::Reasoning(s));
+                            }
+                            _ => {}
+                        }
+                    }
                     // Finalise: any accumulated tool calls go out just before
                     // Done so the runtime can run them. The `finished_tool_calls`
                     // flag (finish_reason == "tool_calls") is the protocol-level
@@ -180,8 +199,20 @@ impl OpenRouterClient {
                             finished_tool_calls = true;
                         }
                         if let Some(t) = &choice.delta.content {
-                            if !t.is_empty() {
-                                emit(&tx, StreamEvent::Token(t.clone()));
+                            // Route through the think-tag splitter so a leading
+                            // <think>…</think> block is emitted as Reasoning
+                            // rather than Token, even when the tag is split
+                            // across SSE chunks.
+                            for e in think.push(t) {
+                                match e {
+                                    ThinkEmit::Content(s) if !s.is_empty() => {
+                                        emit(&tx, StreamEvent::Token(s));
+                                    }
+                                    ThinkEmit::Reasoning(s) if !s.is_empty() => {
+                                        emit(&tx, StreamEvent::Reasoning(s));
+                                    }
+                                    _ => {}
+                                }
                             }
                         }
                         // Reasoning rides a separate delta channel (present only
@@ -239,9 +270,21 @@ impl OpenRouterClient {
                 // unparseable JSON (partial keepalive) is ignored
             }
         }
-        // Stream ended without an explicit [DONE]: same finalisation order —
-        // tool calls (if any), then Done. Same argument repair as the [DONE]
-        // path so a non-delta provider that never sends [DONE] is also covered.
+        // Stream ended without an explicit [DONE]: flush the think-tag buffer
+        // first (same as the [DONE] path), then tool calls, then Done.
+        for e in think.finish() {
+            match e {
+                ThinkEmit::Content(s) if !s.is_empty() => {
+                    emit(&tx, StreamEvent::Token(s));
+                }
+                ThinkEmit::Reasoning(s) if !s.is_empty() => {
+                    emit(&tx, StreamEvent::Reasoning(s));
+                }
+                _ => {}
+            }
+        }
+        // Same argument repair as the [DONE] path so a non-delta provider that
+        // never sends [DONE] is also covered.
         if !tool_acc.is_empty() || finished_tool_calls {
             sanitize_tool_acc(&mut tool_acc);
             emit(&tx, StreamEvent::ToolCalls(tool_acc.clone()));

--- a/src-agent/src/service/openrouter/think_split.rs
+++ b/src-agent/src/service/openrouter/think_split.rs
@@ -1,0 +1,175 @@
+//! Token-by-token `<think>…</think>` splitter for streaming responses.
+//!
+//! Some backends embed reasoning inside `delta.content` as a leading
+//! `<think>` (or `<thinking>` / `<thought>`) block rather than using a
+//! separate `delta.reasoning` field.  [`ThinkSplit`] peels that block out of
+//! the content stream and routes it to the reasoning channel, handling the
+//! case where tag markers are split across SSE chunks.
+//!
+//! **Key invariant:** the Pending → (Inside | Passthrough) decision is made
+//! exactly once per response.  Once the phase is `Passthrough`, it stays
+//! `Passthrough` for the entire stream — a `<think>` tag appearing mid-answer
+//! (e.g. inside a code block) is treated as literal content, not captured.
+
+/// Output item produced by [`ThinkSplit::push`] / [`ThinkSplit::finish`].
+pub enum Emit {
+    /// Text that should be routed to the reasoning/thinking channel.
+    Reasoning(String),
+    /// Text that should be routed to the normal content channel.
+    Content(String),
+}
+
+/// Tracks where in the stream we are relative to a leading think-tag.
+enum Phase {
+    /// Haven't seen a non-whitespace byte yet; waiting to decide.
+    Pending,
+    /// Inside the think block; `usize` is the index into [`TAG_PAIRS`] so we
+    /// know which closer to search for.
+    Inside(usize),
+    /// Past the decision point — emit everything as plain content.
+    Passthrough,
+}
+
+/// (opener, closer) tag pairs, tried in order, matched case-sensitively.
+const TAG_PAIRS: [(&str, &str); 3] = [
+    ("<think>",    "</think>"),
+    ("<thinking>", "</thinking>"),
+    ("<thought>",  "</thought>"),
+];
+
+/// State machine that splits a leading `<think>…</think>` block out of the
+/// content stream, routing it to the reasoning channel and the rest to the
+/// content channel.
+pub struct ThinkSplit {
+    buf:   String,
+    phase: Phase,
+}
+
+impl ThinkSplit {
+    /// Create a fresh instance (one per stream call / per turn).
+    pub fn new() -> Self {
+        ThinkSplit {
+            buf:   String::new(),
+            phase: Phase::Pending,
+        }
+    }
+
+    /// Feed the next `delta.content` chunk; returns zero or more [`Emit`]
+    /// values that should be forwarded to the appropriate channel.
+    ///
+    /// Calling `push("")` is always a safe no-op.
+    pub fn push(&mut self, content: &str) -> Vec<Emit> {
+        if content.is_empty() {
+            return Vec::new();
+        }
+        self.buf.push_str(content);
+        let mut out = Vec::new();
+        loop {
+            match &self.phase {
+                Phase::Pending => {
+                    // Count leading ASCII-whitespace bytes.
+                    let ws_len = self.buf
+                        .as_bytes()
+                        .iter()
+                        .take_while(|&&b| b == b' ' || b == b'\t' || b == b'\r' || b == b'\n')
+                        .count();
+                    let t = &self.buf[ws_len..];
+                    if t.is_empty() {
+                        // Only whitespace so far — wait for more.
+                        break;
+                    }
+                    // Check for a full opener match.
+                    let full_match = TAG_PAIRS.iter().enumerate().find(|(_, (open, _))| {
+                        t.starts_with(open)
+                    });
+                    if let Some((i, (open, _))) = full_match {
+                        // Consume leading whitespace + opener, enter Inside.
+                        self.buf.drain(..ws_len + open.len());
+                        self.phase = Phase::Inside(i);
+                        continue;
+                    }
+                    // Check whether `t` is a strict prefix of any opener (could
+                    // still become one once more bytes arrive).
+                    let is_prefix = TAG_PAIRS.iter().any(|(open, _)| {
+                        open.starts_with(t) && t.len() < open.len()
+                    });
+                    if is_prefix {
+                        // Ambiguous — wait for more input.
+                        break;
+                    }
+                    // Not an opener and not a prefix of one — passthrough.
+                    // DO NOT discard anything; leading whitespace is real content.
+                    self.phase = Phase::Passthrough;
+                    continue;
+                }
+
+                Phase::Inside(i) => {
+                    let closer = TAG_PAIRS[*i].1;
+                    if let Some(p) = self.buf.find(closer) {
+                        // Found the closing tag; flush reasoning up to it.
+                        if p > 0 {
+                            out.push(Emit::Reasoning(self.buf[..p].to_string()));
+                        }
+                        self.buf.drain(..p + closer.len());
+                        self.phase = Phase::Passthrough;
+                        continue;
+                    }
+                    // Closer not (fully) present yet; hold back any bytes that
+                    // could be the start of the closer split across chunks.
+                    let hold = prefix_holdback(&self.buf, closer);
+                    let safe = self.buf.len().saturating_sub(hold);
+                    if safe > 0 {
+                        out.push(Emit::Reasoning(self.buf[..safe].to_string()));
+                        self.buf.drain(..safe);
+                    }
+                    break;
+                }
+
+                Phase::Passthrough => {
+                    if !self.buf.is_empty() {
+                        out.push(Emit::Content(std::mem::take(&mut self.buf)));
+                    }
+                    break;
+                }
+            }
+        }
+        out
+    }
+
+    /// Flush any remaining buffered bytes at end-of-stream.
+    ///
+    /// Must be called once after the SSE loop finishes (normal completion or
+    /// `[DONE]`).  A leftover partial opener (e.g. `"<thi"`) flushes as
+    /// `Content` — we never silently discard real content.
+    pub fn finish(&mut self) -> Vec<Emit> {
+        let mut out = Vec::new();
+        if self.buf.is_empty() {
+            return out;
+        }
+        match &self.phase {
+            Phase::Inside(_) => {
+                out.push(Emit::Reasoning(std::mem::take(&mut self.buf)));
+            }
+            Phase::Pending | Phase::Passthrough => {
+                out.push(Emit::Content(std::mem::take(&mut self.buf)));
+            }
+        }
+        out
+    }
+}
+
+/// Return the byte length of the longest suffix of `buf` that equals a
+/// *proper* prefix of `needle` (length < `needle.len()`).  Returns 0 if no
+/// such suffix exists.
+///
+/// Example: `buf = "...abc</thin"`, `needle = "</think>"` → returns 6
+/// (the suffix `"</thin"` matches the proper prefix `"</thin"` of `"</think>"`).
+fn prefix_holdback(buf: &str, needle: &str) -> usize {
+    let max_k = buf.len().min(needle.len() - 1);
+    for k in (1..=max_k).rev() {
+        if buf.ends_with(&needle[..k]) {
+            return k;
+        }
+    }
+    0
+}

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.2.8",
-  "message": "revert the 0.2.7 history() trailing-assistant strip: it did not fix the prefill 400 on strict backends (llama.cpp/vLLM) and it degraded reasoning continuity, since the assistant-prefill is load-bearing for thinking models; a backend-aware fix is pending."
+  "version": "0.2.9",
+  "message": "robust thinking capture: reasoning field aliases (reasoning_content / thinking) so DeepSeek/vLLM/llama.cpp/MiMo thinking is caught, plus a streaming splitter that peels inline <think>/<thinking>/<thought> blocks out of content into the reasoning channel (Qwen, Gemma-3 fine-tunes). receive-side only, request unchanged."
 }


### PR DESCRIPTION
Layer 1: accept reasoning_content and thinking as serde aliases for the reasoning field on both the streaming Delta and the non-stream ResponseMessage, so DeepSeek/vLLM/llama.cpp/MiMo reasoning is captured (previously only OpenRouter's reasoning field was read).

Layer 2: ThinkSplit state machine peels a leading <think>/<thinking>/<thought> block out of delta.content into the reasoning channel, buffering across SSE chunk boundaries; start-of-turn gated so a <think> in a later code block stays literal content. Flushed at [DONE] and EOF.

Receive-side only; the outgoing request is unchanged.