### PR TITLE
security + fix: gate git_operator/web_download/git_worktree-remove + …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "base64",

--- a/src-agent/Cargo.toml
+++ b/src-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src-agent/src/app/runtime/actions/chat.rs
+++ b/src-agent/src/app/runtime/actions/chat.rs
@@ -79,7 +79,17 @@ pub(super) fn handle_submit(
             )
         });
         let capable = match (state.rest.models_cache.as_deref(), main.as_ref()) {
-            (Some(models), Some(m)) => crate::service::openrouter::model_takes_images(models, &m.model_id),
+            // Only trust the catalogue when it was fetched for THIS model's
+            // endpoint. After a mid-session provider/model swap the cache may
+            // still hold the old endpoint's models (missing the new model) —
+            // treating that as "can't see images" wrongly blocks the send. If
+            // the cache is cold or for a different endpoint, assume capable and
+            // never wrongly block (a fresh catalogue re-fetch corrects it).
+            (Some(models), Some(m))
+                if state.rest.models_cache_endpoint.as_deref() == Some(m.endpoint.as_str()) =>
+            {
+                crate::service::openrouter::model_takes_images(models, &m.model_id)
+            }
             _ => true,
         };
         if !capable {
@@ -337,6 +347,17 @@ pub(super) fn handle_approve_tool(
     state.rest.fg_mut().awaiting_approval = false;
     state.rest.fg_mut().approval_reason = None;
     if let Some(call) = state.rest.fg().pending_tool_calls.get(state.rest.fg().tool_idx).cloned() {
+        // `git_worktree` is intercepted in `process_tools` and needs its special
+        // post-processing (workdir de-registration + cwd snap-back); the generic
+        // `run_tool` path below would push a raw sentinel string and skip that
+        // cleanup. So for an approved git_worktree call, mark it approved and
+        // re-enter the machine, which runs the interception (skipping the gate for
+        // this one call).
+        if call.function.name == "git_worktree" {
+            state.rest.fg_mut().approved_worktree_call = Some(call.id.clone());
+            process_tools(state, fgi, client, handle);
+            return Ok(());
+        }
         // The approved call is a risky tool (write/edit/delete/bash) — all of which
         // are heavy/blocking and live in `DEFERRED_TOOLS`. Run it OFF the UI thread
         // and PARK rather than running it inline here: an approved large write would

--- a/src-agent/src/app/runtime/stream/tools/approval.rs
+++ b/src-agent/src/app/runtime/stream/tools/approval.rs
@@ -428,6 +428,103 @@ pub(crate) fn process_tools(
         // `sess.save()` in a scoped block so the `state` borrow is fully released
         // before calling `apply_workspace_change` (which also borrows `state` mutably).
         if call.function.name == "git_worktree" {
+            // Gate the destructive `remove` action behind the approval classifier —
+            // it deletes a worktree (hard to undo). The other actions (create /
+            // enter / exit / list) only move cwd/roots and are cheap to reverse, so
+            // they skip the gate. On the resume pass after the user approves,
+            // `approved_worktree_call` holds this call's id → skip re-gating and run
+            // the interception for real. Mirrors the generic risky gate below
+            // (~line 622+) but lives here because git_worktree is intercepted before
+            // that gate and can't reach it.
+            let wt_args: serde_json::Value = serde_json::from_str(
+                &crate::dto::chat::sanitize_tool_arguments(&call.function.arguments),
+            )
+            .unwrap_or_default();
+            let is_remove =
+                wt_args.get("action").and_then(|a| a.as_str()) == Some("remove");
+            let pre_approved = state.rest.sessions[sess_idx]
+                .approved_worktree_call
+                .as_deref()
+                == Some(call.id.as_str());
+            if pre_approved {
+                // Consume the one-shot approval so a later un-approved remove re-gates.
+                state.rest.sessions[sess_idx].approved_worktree_call = None;
+            } else if is_remove && mode != AgentMode::Yolo {
+                match tac_inputs(state, sess_idx, client) {
+                    Some((c, config, settings)) => {
+                        let verdict = handle.block_on(
+                            crate::app::harness::classify_toolcall(
+                                &c,
+                                &config,
+                                &settings,
+                                &convo_context,
+                                &call.function.name,
+                                &call.function.arguments,
+                            ),
+                        );
+                        if verdict.available && verdict.allow {
+                            // Definite allow. Auto runs inline; Normal still asks.
+                            if mode == AgentMode::Normal {
+                                state.rest.sessions[sess_idx].approval_reason =
+                                    Some(format!("classifier: ok — {}", verdict.reason));
+                                state.rest.sessions[sess_idx].awaiting_approval = true;
+                                state.rest.sessions[sess_idx].status =
+                                    format!("approve {}? [y/n]", call.function.name);
+                                return;
+                            }
+                            // Auto + allow → fall through and run it inline.
+                        } else if verdict.available {
+                            // Definite block. Auto records + continues; Normal asks.
+                            if mode == AgentMode::Auto {
+                                state.rest.sessions[sess_idx].tool_results.push((
+                                    call.id.clone(),
+                                    format!("blocked by harness: {}", verdict.reason),
+                                ));
+                                state.rest.sessions[sess_idx].tool_idx += 1;
+                                continue;
+                            }
+                            state.rest.sessions[sess_idx].approval_reason =
+                                Some(verdict.reason);
+                            state.rest.sessions[sess_idx].awaiting_approval = true;
+                            state.rest.sessions[sess_idx].status =
+                                format!("approve {}? [y/n]", call.function.name);
+                            return;
+                        } else {
+                            // Classifier unavailable. Normal → human y/n; Auto →
+                            // fail-CLOSED (never delete a worktree unverified).
+                            if mode == AgentMode::Normal {
+                                state.rest.sessions[sess_idx].approval_reason =
+                                    Some(verdict.reason.clone());
+                                state.rest.sessions[sess_idx].awaiting_approval = true;
+                                state.rest.sessions[sess_idx].status =
+                                    format!("approve {}? [y/n]", call.function.name);
+                                return;
+                            }
+                            state.rest.sessions[sess_idx].tool_results.push((
+                                call.id.clone(),
+                                format!(
+                                    "not executed: classifier unavailable — {}. The \
+                                     safety classifier could not verify this \
+                                     git_worktree remove, so it was NOT run.",
+                                    verdict.reason
+                                ),
+                            ));
+                            state.rest.sessions[sess_idx].tool_idx += 1;
+                            continue;
+                        }
+                    }
+                    // Classifier disabled → Normal asks, Auto runs.
+                    None => {
+                        if mode == AgentMode::Normal {
+                            state.rest.sessions[sess_idx].awaiting_approval = true;
+                            state.rest.sessions[sess_idx].status =
+                                format!("approve {}? [y/n]", call.function.name);
+                            return;
+                        }
+                        // Auto + classifier disabled → fall through and run inline.
+                    }
+                }
+            }
             let result = super::dispatch::run_tool(state, sess_idx, &call);
             let final_result =
                 if let Some(target) =

--- a/src-agent/src/app/state/runtime.rs
+++ b/src-agent/src/app/state/runtime.rs
@@ -150,6 +150,14 @@ pub struct SessionRuntime {
     /// `None` for an approval that wasn't classifier-driven. Cleared when the
     /// approval resolves.
     pub approval_reason: Option<String>,
+    /// One-shot marker: the `call.id` of a `git_worktree` call the user just
+    /// approved at the y/n prompt. `git_worktree` is intercepted before the
+    /// generic risky gate and needs its special post-processing, so the approval
+    /// resume can't run it via the normal `run_tool` path. The resume instead
+    /// sets this id and re-enters `process_tools`, whose git_worktree arm sees the
+    /// match, skips re-gating, runs the interception, and clears it. `None`
+    /// normally.
+    pub approved_worktree_call: Option<String>,
     // --- deferred tool-task lane (parallel to the sub-agent lane below) ---
     /// Tool-call ids of DEFERRED tools (see [`crate::tool::DEFERRED_TOOLS`] — the
     /// heavy/blocking ones: read / write / edit / delete / bash / grep / glob /
@@ -406,6 +414,7 @@ impl SessionRuntime {
             tool_results: Vec::new(),
             awaiting_approval: false,
             approval_reason: None,
+            approved_worktree_call: None,
             pending_tool_tasks: Vec::new(),
             awaiting_tool_tasks: false,
             tool_task_rx: None,

--- a/src-agent/src/tool/mod.rs
+++ b/src-agent/src/tool/mod.rs
@@ -33,12 +33,16 @@ pub mod task;
 
 pub use dircache::DirCache;
 
-/// True for built-in tools that mutate the workspace (or run arbitrary shell
-/// commands) and therefore require approval in Normal mode. Deterministic,
-/// name-based — no classifier / network call. Canonical single-source definition
-/// used by both the interactive approval gate and the sub-agent engine.
+/// True for built-in tools that mutate the workspace, run arbitrary shell
+/// commands, mutate git state (local or remote, e.g. `git_operator` push /
+/// reset), or fetch from the network and write the result to disk
+/// (`web_download`) — and therefore require approval in Normal mode.
+/// Deterministic, name-based — no classifier / network call. Canonical
+/// single-source definition used by both the interactive approval gate and the
+/// sub-agent engine. NOTE: `git_worktree remove` is gated separately, inside its
+/// interception in `process_tools` (it never reaches this generic gate).
 pub(crate) fn tool_is_risky(name: &str) -> bool {
-    matches!(name, "write" | "delete" | "edit" | "bash")
+    matches!(name, "write" | "delete" | "edit" | "bash" | "git_operator" | "web_download")
 }
 
 /// Shared context handed to every tool invocation.

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.2.10",
-  "message": "fix: git_worktree runs git in the active working directory (ctx.workspace / effective_cwd) instead of the launch-time workspace root, so worktree create/list/remove work after cd-ing into a git repo nested under a non-git parent dir — now consistent with bash and git_operator."
+  "version": "0.2.11",
+  "message": "security + fix: gate git_operator, web_download, and git_worktree remove behind the approval/TAC classifier so they prompt in Normal mode (and are classifier-checked in Auto) instead of running unguarded — a bare git push, an arbitrary web_download, or a worktree deletion no longer slips through; also make the image-capability guard endpoint-aware so switching to a vision-capable model mid-session no longer wrongly blocks image sends (the stale per-endpoint catalogue is trusted only when it matches the current model's endpoint)."
 }


### PR DESCRIPTION
…endpoint-aware image guard (0.2.11)

Route git_operator, web_download, and git_worktree remove through the approval/TAC classifier so they prompt in Normal mode (and are classifier- checked in Auto) instead of running unguarded — a bare `git push`, an arbitrary web_download, or a worktree deletion no longer slips past the harness.

git_operator and web_download join tool_is_risky. git_worktree remove is gated inside its interception in process_tools (it never reaches the generic gate), with a one-shot approved_worktree_call marker so the approval resume re-enters and runs the real interception (workdir de-registration + cwd snap-back) rather than the generic run_tool path (which would push a raw sentinel string and skip the cleanup). Deny never executes the tool.

Also fix a stale image-capability guard: after a mid-session model/provider swap the per-endpoint model catalogue could be for the old endpoint (missing the new model), wrongly blocking image sends. Trust the catalogue only when it matches the current model's endpoint; otherwise assume capable.