### PR TITLE
fix: emit OpenRouter-only reasoning fields (exclude/enabled) only for…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "base64",

--- a/src-agent/Cargo.toml
+++ b/src-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src-agent/src/service/openrouter/helpers.rs
+++ b/src-agent/src/service/openrouter/helpers.rs
@@ -70,25 +70,42 @@ pub(super) fn provider_routing_for(
     }
 }
 
+/// True when `endpoint` speaks OpenRouter's `reasoning` dialect — i.e. accepts
+/// the OpenRouter-only `enabled` / `exclude` sub-fields. OpenAI-native gateways
+/// (OpenAI itself, a codex/9router gateway, etc.) reject those with
+/// `400 Unknown parameter: 'reasoning.exclude'`, so we emit them ONLY here. Groq
+/// & friends are reached THROUGH OpenRouter, so they match and keep working.
+pub(super) fn is_openrouter(endpoint: &str) -> bool {
+    endpoint.to_lowercase().contains("openrouter")
+}
+
 /// Map a stored effort token to the request `reasoning` object.
 ///
 /// - `""` / `"default"` → `None`: omit `reasoning` entirely so the model uses
 ///   its own default thinking behaviour.
-/// - `"off"` / `"none"` → `Some(enabled: false)`: turn thinking off.
+/// - `"off"` / `"none"` → OpenRouter: `Some(enabled: false)` (turn thinking off);
+///   non-OpenRouter: `None` (the `enabled` field is an OpenRouter-only extension
+///   that OpenAI-native gateways 400 on — omit `reasoning` entirely and let the
+///   model use its own, often model-name-encoded, default).
 /// - any effort token (`minimal`/`low`/`medium`/`high`/`xhigh`/`max`/…) →
-///   `Some(effort: <token>)`. `effort` and `enabled` are mutually exclusive, so
-///   only `effort` is set here.
+///   `Some(effort: <token>)`. `effort` is OpenAI-standard, accepted everywhere.
 ///
 /// Free helper (not a method) so it has no hidden state — what you pass is what
 /// you get. Applied only on the interactive chat path.
-pub(super) fn reasoning_config(effort: &str) -> Option<ReasoningConfig> {
+pub(super) fn reasoning_config(effort: &str, endpoint: &str) -> Option<ReasoningConfig> {
     match effort.trim() {
         "" | "default" => None,
-        "off" | "none" => Some(ReasoningConfig {
-            effort: None,
-            enabled: Some(false),
-            exclude: None,
-        }),
+        "off" | "none" => {
+            if is_openrouter(endpoint) {
+                Some(ReasoningConfig {
+                    effort: None,
+                    enabled: Some(false),
+                    exclude: None,
+                })
+            } else {
+                None
+            }
+        }
         level => Some(ReasoningConfig {
             effort: Some(level.to_string()),
             enabled: None,

--- a/src-agent/src/service/openrouter/oneshot.rs
+++ b/src-agent/src/service/openrouter/oneshot.rs
@@ -8,7 +8,7 @@ use crate::dto::chat::{ChatMessage, Role};
 use crate::dto::openrouter::{
     to_wire, ChatRequest, ChatResponse, ReasoningConfig, UsageRequest,
 };
-use super::helpers::{clean_error, provider_routing_for};
+use super::helpers::{clean_error, is_openrouter, provider_routing_for};
 use super::client::OpenRouterClient;
 use super::types::Conn;
 
@@ -182,10 +182,11 @@ impl OpenRouterClient {
             usage: UsageRequest { include: true },
             // Classifier calls use no tools.
             tools: None,
-            // Thinking excluded: `exclude: true` keeps reasoning mandatory for
-            // endpoints that require it, but strips the `reasoning` field from the
-            // response — deterministic, fast, bleed-proof, verdict lands in `content`.
-            reasoning: Some(ReasoningConfig {
+            // `exclude: true` (strip reasoning, keep it mandatory for gateways that
+            // force it) is an OpenRouter-only extension — OpenAI-native gateways 400
+            // on it. Emit the `reasoning` object only for OpenRouter; elsewhere omit
+            // it and rely on the strict `response_format` JSON landing in `content`.
+            reasoning: is_openrouter(conn.endpoint).then_some(ReasoningConfig {
                 effort: None,
                 enabled: None,
                 exclude: Some(true),
@@ -292,12 +293,11 @@ impl OpenRouterClient {
             usage: UsageRequest { include: true },
             // Fold calls use no tools.
             tools: None,
-            // Thinking excluded: `exclude: true` keeps reasoning mandatory for
-            // endpoints that require it, but strips the `reasoning` field from the
-            // response. The summary is PERSISTED and replayed forever — a CoT bleed
-            // would poison the conversation permanently, so the `reasoning` fallback
-            // is intentionally absent here. Content-only, bleed-proof.
-            reasoning: Some(ReasoningConfig {
+            // `exclude: true` (strip reasoning, keep it mandatory for gateways that
+            // force it) is an OpenRouter-only extension — OpenAI-native gateways 400
+            // on it. Emit the `reasoning` object only for OpenRouter; elsewhere omit
+            // it and rely on the strict `response_format` JSON landing in `content`.
+            reasoning: is_openrouter(conn.endpoint).then_some(ReasoningConfig {
                 effort: None,
                 enabled: None,
                 exclude: Some(true),
@@ -411,10 +411,11 @@ impl OpenRouterClient {
             usage: UsageRequest { include: true },
             // Router calls use no tools.
             tools: None,
-            // Thinking excluded: `exclude: true` keeps reasoning mandatory for
-            // endpoints that require it, but strips the `reasoning` field from the
-            // response — deterministic, fast, bleed-proof, id list lands in `content`.
-            reasoning: Some(ReasoningConfig {
+            // `exclude: true` (strip reasoning, keep it mandatory for gateways that
+            // force it) is an OpenRouter-only extension — OpenAI-native gateways 400
+            // on it. Emit the `reasoning` object only for OpenRouter; elsewhere omit
+            // it and rely on the strict `response_format` JSON landing in `content`.
+            reasoning: is_openrouter(conn.endpoint).then_some(ReasoningConfig {
                 effort: None,
                 enabled: None,
                 exclude: Some(true),

--- a/src-agent/src/service/openrouter/stream.rs
+++ b/src-agent/src/service/openrouter/stream.rs
@@ -86,7 +86,7 @@ impl OpenRouterClient {
             tools: Some(tools),
             // Interactive chat is the only path that thinks; map the resolved
             // role's effort token to a `reasoning` directive (None = model default).
-            reasoning: reasoning_config(effort),
+            reasoning: reasoning_config(effort, conn.endpoint),
             // Free-form text reply; structured output is classifier-only.
             response_format: None,
             // Generous runaway cap for the interactive path.

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.2.11",
-  "message": "security + fix: gate git_operator, web_download, and git_worktree remove behind the approval/TAC classifier so they prompt in Normal mode (and are classifier-checked in Auto) instead of running unguarded — a bare git push, an arbitrary web_download, or a worktree deletion no longer slips through; also make the image-capability guard endpoint-aware so switching to a vision-capable model mid-session no longer wrongly blocks image sends (the stale per-endpoint catalogue is trusted only when it matches the current model's endpoint)."
+  "version": "0.2.12",
+  "message": "fix: emit the OpenRouter-only reasoning sub-fields (reasoning.exclude / reasoning.enabled) ONLY for OpenRouter endpoints. OpenAI-native gateways (e.g. a codex/9router gateway) reject them with 400 'Unknown parameter: reasoning.exclude', which — now that git_operator routes through the classifier — fail-closed even read-only git calls. The classifier, fold, blob-router, and thinking-off paths now omit those fields for non-OpenRouter endpoints (effort, which is OpenAI-standard, is unchanged). Groq etc. keep working since they're reached through OpenRouter."
 }


### PR DESCRIPTION
… OpenRouter endpoints (0.2.12)

koma sent `reasoning.exclude` (classifier / fold / blob-router) and `reasoning.enabled` (thinking-off, Main path) unconditionally. Those are OpenRouter-only extensions; OpenAI-native gateways (e.g. a codex/9router gateway) reject them with `400 Unknown parameter: 'reasoning.exclude'`. Since 0.2.11 routes git_operator through the classifier, that 400 fail-closed even read-only git calls (a `git log` came back "classifier unavailable").

Add `is_openrouter(endpoint)` and gate both fields on it: emit them only when the endpoint is OpenRouter, otherwise omit the `reasoning` object entirely for those structured/off paths. `effort` (OpenAI-standard) is untouched. Groq etc. keep working because they're reached through OpenRouter.