### PR TITLE
fix: ThinkSplit peels inline/orphan <think> tags from local reasoning…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent"
-version = "0.2.21"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "base64",

--- a/src-agent/Cargo.toml
+++ b/src-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent"
-version = "0.2.22"
+version = "0.2.23"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src-agent/src/service/openrouter/think_split.rs
+++ b/src-agent/src/service/openrouter/think_split.rs
@@ -6,6 +6,12 @@
 //! the content stream and routes it to the reasoning channel, handling the
 //! case where tag markers are split across SSE chunks.
 //!
+//! On tool-call continuation turns some vLLM/local backends peel the opener
+//! and the reasoning into `delta.reasoning` but still leak a bare, orphaned
+//! *closing* tag (e.g. `</think>`) at the very start of `delta.content`.  That
+//! stray closer is swallowed here instead of surfacing as visible content.
+//! Tag matching is case-insensitive.
+//!
 //! **Key invariant:** the Pending → (Inside | Passthrough) decision is made
 //! exactly once per response.  Once the phase is `Passthrough`, it stays
 //! `Passthrough` for the entire stream — a `<think>` tag appearing mid-answer
@@ -30,7 +36,7 @@ enum Phase {
     Passthrough,
 }
 
-/// (opener, closer) tag pairs, tried in order, matched case-sensitively.
+/// (opener, closer) tag pairs, tried in order, matched case-insensitively.
 const TAG_PAIRS: [(&str, &str); 3] = [
     ("<think>",    "</think>"),
     ("<thinking>", "</thinking>"),
@@ -67,37 +73,60 @@ impl ThinkSplit {
         loop {
             match &self.phase {
                 Phase::Pending => {
-                    // Count leading ASCII-whitespace bytes.
+                    // Skip leading Unicode whitespace: a stray whitespace character
+                    // (e.g. NBSP `\u{00A0}`) before the opener must not latch
+                    // Passthrough. `ws_len` is a
+                    // BYTE offset (index of the first non-whitespace char); it is
+                    // only *consumed* once a tag matches, so a genuine
+                    // leading-whitespace answer still survives into Passthrough.
                     let ws_len = self.buf
-                        .as_bytes()
-                        .iter()
-                        .take_while(|&&b| b == b' ' || b == b'\t' || b == b'\r' || b == b'\n')
-                        .count();
+                        .find(|c: char| !c.is_whitespace())
+                        .unwrap_or(self.buf.len());
                     let t = &self.buf[ws_len..];
                     if t.is_empty() {
                         // Only whitespace so far — wait for more.
                         break;
                     }
-                    // Check for a full opener match.
-                    let full_match = TAG_PAIRS.iter().enumerate().find(|(_, (open, _))| {
-                        t.starts_with(open)
-                    });
-                    if let Some((i, (open, _))) = full_match {
+                    // (1) Full opener match (case-insensitive) — enter Inside.
+                    let opener = TAG_PAIRS
+                        .iter()
+                        .enumerate()
+                        .find(|&(_, &(open, _))| starts_with_ci(t, open));
+                    if let Some((i, &(open, _))) = opener {
                         // Consume leading whitespace + opener, enter Inside.
                         self.buf.drain(..ws_len + open.len());
                         self.phase = Phase::Inside(i);
                         continue;
                     }
-                    // Check whether `t` is a strict prefix of any opener (could
-                    // still become one once more bytes arrive).
-                    let is_prefix = TAG_PAIRS.iter().any(|(open, _)| {
-                        open.starts_with(t) && t.len() < open.len()
-                    });
-                    if is_prefix {
-                        // Ambiguous — wait for more input.
+                    // (2) `t` is a strict prefix of some opener — it could still
+                    // become one once more bytes arrive; wait.
+                    if TAG_PAIRS.iter().any(|&(open, _)| is_ci_prefix(t, open)) {
                         break;
                     }
-                    // Not an opener and not a prefix of one — passthrough.
+                    // (3) Leading ORPHAN closer: some vLLM/local backends peel the
+                    // opener + reasoning into the dedicated reasoning field but leak
+                    // the bare close tag into content. There is nothing to route to
+                    // Reasoning — swallow the tag and passthrough the remainder.
+                    //
+                    // Caveat: content whose very first bytes literally spell a closer
+                    // tag (e.g. a model answering about `</think>` itself) is
+                    // indistinguishable from a leaked orphan closer and will be
+                    // swallowed here. Accepted trade-off — vanishingly rare, and the
+                    // alternative (leaking stray close tags) is worse.
+                    if let Some(&(_, close)) =
+                        TAG_PAIRS.iter().find(|&&(_, close)| starts_with_ci(t, close))
+                    {
+                        self.buf.drain(..ws_len + close.len());
+                        self.phase = Phase::Passthrough;
+                        continue;
+                    }
+                    // (4) A closer split across SSE chunks (`</`, `</thi`,
+                    // `</think` …). Hold back — never leak a partial orphan closer
+                    // as visible content.
+                    if TAG_PAIRS.iter().any(|&(_, close)| is_ci_prefix(t, close)) {
+                        break;
+                    }
+                    // (5) Genuine content — passthrough.
                     // DO NOT discard anything; leading whitespace is real content.
                     self.phase = Phase::Passthrough;
                     continue;
@@ -105,7 +134,7 @@ impl ThinkSplit {
 
                 Phase::Inside(i) => {
                     let closer = TAG_PAIRS[*i].1;
-                    if let Some(p) = self.buf.find(closer) {
+                    if let Some(p) = find_ci(&self.buf, closer) {
                         // Found the closing tag; flush reasoning up to it.
                         if p > 0 {
                             out.push(Emit::Reasoning(self.buf[..p].to_string()));
@@ -158,18 +187,152 @@ impl ThinkSplit {
     }
 }
 
+/// Case-insensitive ASCII prefix test: does `buf` begin with `tag`?  Tags are
+/// always ASCII think-markers, so a byte compare is sufficient (and byte
+/// slicing avoids the char-boundary panics that `str` slicing could hit).
+fn starts_with_ci(buf: &str, tag: &str) -> bool {
+    let (bb, tb) = (buf.as_bytes(), tag.as_bytes());
+    bb.len() >= tb.len() && bb[..tb.len()].eq_ignore_ascii_case(tb)
+}
+
+/// Case-insensitive ASCII: is `buf` a *proper* prefix of `tag` — strictly
+/// shorter, with every byte matching ignoring case?  Used to hold an
+/// opener/closer that is split across SSE chunks.
+fn is_ci_prefix(buf: &str, tag: &str) -> bool {
+    let (bb, tb) = (buf.as_bytes(), tag.as_bytes());
+    bb.len() < tb.len() && tb[..bb.len()].eq_ignore_ascii_case(bb)
+}
+
+/// Case-insensitive ASCII substring search — byte index of the first position
+/// where `needle` matches `haystack` ignoring ASCII case (`needle` is ASCII).
+fn find_ci(haystack: &str, needle: &str) -> Option<usize> {
+    let (hb, nb) = (haystack.as_bytes(), needle.as_bytes());
+    if nb.is_empty() {
+        return Some(0);
+    }
+    if hb.len() < nb.len() {
+        return None;
+    }
+    (0..=hb.len() - nb.len()).find(|&i| hb[i..i + nb.len()].eq_ignore_ascii_case(nb))
+}
+
 /// Return the byte length of the longest suffix of `buf` that equals a
-/// *proper* prefix of `needle` (length < `needle.len()`).  Returns 0 if no
-/// such suffix exists.
+/// *proper* prefix of `needle` (length < `needle.len()`), matched
+/// case-insensitively.  Returns 0 if no such suffix exists.
 ///
 /// Example: `buf = "...abc</thin"`, `needle = "</think>"` → returns 6
 /// (the suffix `"</thin"` matches the proper prefix `"</thin"` of `"</think>"`).
 fn prefix_holdback(buf: &str, needle: &str) -> usize {
-    let max_k = buf.len().min(needle.len() - 1);
+    let (bb, nb) = (buf.as_bytes(), needle.as_bytes());
+    let max_k = bb.len().min(nb.len() - 1);
     for k in (1..=max_k).rev() {
-        if buf.ends_with(&needle[..k]) {
+        if bb[bb.len() - k..].eq_ignore_ascii_case(&nb[..k]) {
             return k;
         }
     }
     0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feed `chunks` through a fresh splitter (push each, then finish) and
+    /// return the concatenated `(reasoning, content)` streams.
+    fn run(chunks: &[&str]) -> (String, String) {
+        fn drain(emits: Vec<Emit>, reasoning: &mut String, content: &mut String) {
+            for e in emits {
+                match e {
+                    Emit::Reasoning(s) => reasoning.push_str(&s),
+                    Emit::Content(s) => content.push_str(&s),
+                }
+            }
+        }
+        let mut ts = ThinkSplit::new();
+        let (mut reasoning, mut content) = (String::new(), String::new());
+        for chunk in chunks {
+            drain(ts.push(chunk), &mut reasoning, &mut content);
+        }
+        drain(ts.finish(), &mut reasoning, &mut content);
+        (reasoning, content)
+    }
+
+    #[test]
+    fn standard_inline_block() {
+        // Shape 1: full inline block, reasoning field empty.
+        let (reasoning, content) = run(&["<think>reason</think>answer"]);
+        assert_eq!(reasoning, "reason");
+        assert_eq!(content, "answer");
+        assert!(!content.contains("think>"), "tag leaked into content: {content:?}");
+    }
+
+    #[test]
+    fn leading_orphan_close_is_stripped() {
+        // Shape 2: bare orphan closer at the start of content.
+        let (reasoning, content) = run(&["</think>answer"]);
+        assert_eq!(reasoning, "");
+        assert_eq!(content, "answer");
+        assert!(!content.contains("think>"), "orphan closer leaked: {content:?}");
+        assert!(!content.contains("</"), "orphan closer leaked: {content:?}");
+    }
+
+    #[test]
+    fn orphan_close_split_across_chunks() {
+        // The orphan closer is split across two SSE chunks.
+        let (reasoning, content) = run(&["</thi", "nk>hi"]);
+        assert_eq!(reasoning, "");
+        assert_eq!(content, "hi");
+        assert!(!content.contains("think>"), "split closer leaked: {content:?}");
+        assert!(!content.contains("</thi"), "split closer leaked: {content:?}");
+    }
+
+    #[test]
+    fn mid_answer_think_is_literal() {
+        // Invariant: once Passthrough is latched by real content, a later
+        // `<think>` stays literal — it is NOT captured as reasoning.
+        let (reasoning, content) = run(&["answer ", "<think>x"]);
+        assert_eq!(reasoning, "");
+        assert_eq!(content, "answer <think>x");
+    }
+
+    #[test]
+    fn leading_whitespace_then_think() {
+        // Leading whitespace before the opener is skipped, not leaked.
+        let (reasoning, content) = run(&["\n  <think>r</think>a"]);
+        assert_eq!(reasoning, "r");
+        assert_eq!(content, "a");
+    }
+
+    #[test]
+    fn orphan_close_case_insensitive() {
+        // Upper-case orphan closer is still stripped.
+        let (reasoning, content) = run(&["</THINK>hey"]);
+        assert_eq!(reasoning, "");
+        assert_eq!(content, "hey");
+        assert!(
+            !content.to_ascii_lowercase().contains("think>"),
+            "orphan closer leaked: {content:?}"
+        );
+    }
+
+    #[test]
+    fn angle_slash_non_closer_passes_through() {
+        // "</" is a prefix of every closer, so it can be held back waiting to
+        // see whether it completes one — but once the bytes diverge from all
+        // known closers, the held (and subsequent) bytes must be released as
+        // ordinary content, not dropped or held forever.
+        let (reasoning, content) = run(&["</di", "v>hello"]);
+        assert_eq!(reasoning, "");
+        assert_eq!(content, "</div>hello");
+    }
+
+    #[test]
+    fn multibyte_content_around_tags_no_panic() {
+        // Multi-byte UTF-8 reasoning content butting up against a closer tag
+        // that is itself split across chunks must not panic on a byte slice
+        // that lands mid-character.
+        let (reasoning, content) = run(&["<think>abc🎉", "</th", "ink>done"]);
+        assert_eq!(reasoning, "abc🎉");
+        assert_eq!(content, "done");
+    }
 }

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.2.22",
+  "version": "0.2.23",
   "message": "feat: koma-free keyless tier - start koma with zero setup. New 3-way first-run chooser (koma free / provider / custom): koma free routes everything to a free hosted model with no API key, provider runs a guided OAuth login then model pick, custom keeps the endpoint+key flow. /free toggles any session onto the free tier and back."
 }


### PR DESCRIPTION
… models

Local/vLLM reasoning models, on TOOL-CALL CONTINUATION turns, don't route reasoning to the dedicated field — they either dump a full <think>...</think> block inline in content, or (when the parser half-fires) leak a bare orphan </think>. ThinkSplit's Pending phase had no handling for a leading closer, so </think> leaked into the answer and the thought went uncaptured (no gray thinking block).

Harden the Pending arm (order: full opener -> opener-prefix hold -> full closer strip -> closer-prefix hold -> passthrough):
- strip a leading orphan </think>/</thinking>/</thought> (emit nothing; reasoning already arrived via the reasoning field) with cross-chunk holdback for a split closer.
- tolerate Unicode leading whitespace (NBSP) before the tag.
- case-insensitive tag matching (byte-level eq_ignore_ascii_case; ASCII tags never split a multibyte char, so offsets stay char-aligned). Mid-answer <think> stays literal (Passthrough terminal) — invariant preserved. 8 unit tests (orphan strip, split-across-chunks, inline block, mid-answer literal, whitespace, case, </div> non-closer passthrough, multibyte). Bump 0.2.23. Codex transport unaffected.