### PR TITLE
feat: add koma/peach premium model support

### DIFF
--- a/models.json
+++ b/models.json
@@ -68,5 +68,13 @@
       "id": "deepseek-chat",
       "pricing": { "input": 0.27, "cached": 0.07, "output": 1.1 }
     }
+  ],
+  "https://koma.run/api/v1/koma-premium": [
+    {
+      "id": "koma/peach",
+      "reasoning": { "mandatory": false, "supported_efforts": ["low", "medium", "high"] },
+      "context_length": 200000,
+      "pricing": { "input": 0.0, "cached": 0.0, "output": 0.0 }
+    }
   ]
 }

--- a/src-agent/Cargo.toml
+++ b/src-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src-agent/src/app/mode/settings/provider_types.rs
+++ b/src-agent/src/app/mode/settings/provider_types.rs
@@ -111,6 +111,7 @@ impl OAuthDraft {
                     OAuthProvider::Xai => "xai",
                     OAuthProvider::ClaudeAI => "claude",
                     OAuthProvider::KomaRun => "koma",
+                    OAuthProvider::KomaPremium => "komapremium",
                     // W11: ext-backed conns aren't authored via the TUI provider modal,
                     // but stay exhaustive with a generic short label.
                     OAuthProvider::Extension => "ext",

--- a/src-agent/src/app/resolve.rs
+++ b/src-agent/src/app/resolve.rs
@@ -321,6 +321,8 @@ fn from_entry(config: &AppConfig, settings: &Settings, entry: &ModelEntry, role:
         // wire koma.run as an actual chat backend). Safe placeholder wire type;
         // never actually hit today since no ModelEntry references this conn.
         OAuthProvider::KomaRun => ApiType::OpenAiCompatible,
+        // Koma Premium: uses KomaRun OAuth tokens with the premium endpoint.
+        OAuthProvider::KomaPremium => ApiType::OpenAiCompatible,
         // W11: an ext-backed conn is not a model provider in v1 — no ModelEntry
         // references it, so this `find` never yields one and this arm never runs.
         // Placeholder wire type; W12 sources the real api_type from the extension
@@ -339,6 +341,8 @@ fn from_entry(config: &AppConfig, settings: &Settings, entry: &ModelEntry, role:
         OAuthProvider::ClaudeAI => String::new(),
         // Koma account login has no org/account header concept either.
         OAuthProvider::KomaRun => String::new(),
+        // Koma Premium: same as KomaRun — no org/account header.
+        OAuthProvider::KomaPremium => String::new(),
         // W11: ext-backed conns carry no send-time account/org header (not a model
         // provider in v1). Empty, same as the account-login providers.
         OAuthProvider::Extension => String::new(),

--- a/src-agent/src/ipc/snapshot/projection/modes.rs
+++ b/src-agent/src/ipc/snapshot/projection/modes.rs
@@ -116,6 +116,7 @@ pub fn onboard_provider_snapshot(op: &OnboardProviderState) -> OnboardProviderSn
                 crate::model::app_config::OAuthProvider::Xai => "xai",
                 crate::model::app_config::OAuthProvider::ClaudeAI => "claudeai",
                 crate::model::app_config::OAuthProvider::KomaRun => "komarun",
+                crate::model::app_config::OAuthProvider::KomaPremium => "komapremium",
                 // W11: ext-backed marker (a native TUI onboard flow never selects it).
                 crate::model::app_config::OAuthProvider::Extension => "extension",
             }
@@ -284,6 +285,7 @@ pub fn oauth_draft_snapshot(o: &OAuthDraft) -> OAuthDraftSnapshot {
             crate::model::app_config::OAuthProvider::Xai => "xai",
             crate::model::app_config::OAuthProvider::ClaudeAI => "claudeai",
             crate::model::app_config::OAuthProvider::KomaRun => "komarun",
+            crate::model::app_config::OAuthProvider::KomaPremium => "komapremium",
             // W11: ext-backed marker.
             crate::model::app_config::OAuthProvider::Extension => "extension",
         }

--- a/src-agent/src/model/app_config.rs
+++ b/src-agent/src/model/app_config.rs
@@ -130,6 +130,9 @@ pub enum OAuthProvider {
     /// shape but against koma.run's native-client OAuth endpoints (form-encoded token
     /// exchange, no client_id/scope). Account login only — not a model provider yet.
     KomaRun,
+    /// Koma Premium (koma/peach): uses KomaRun OAuth tokens but routes to the
+    /// premium endpoint (`/api/v1/koma-premium`) for paid subscribers.
+    KomaPremium,
     /// W11: a token stored by an EXTENSION-delegated OAuth flow. The actual provider
     /// identity lives in the connection's `ext_id`/`provider_id` fields, not this enum
     /// (which stays `Copy` + closed) — this variant is just the "backed by an extension"
@@ -150,6 +153,7 @@ impl OAuthProvider {
             OAuthProvider::Xai => "xAI",
             OAuthProvider::ClaudeAI => "Claude",
             OAuthProvider::KomaRun => "Koma",
+            OAuthProvider::KomaPremium => "Koma Premium",
             // W11: generic marker label; a real ext-backed conn's picker row uses the
             // extension manifest's provider `name`, never this (see
             // `requests_oauth::ext_oauth_rows_for`).
@@ -168,6 +172,7 @@ impl OAuthProvider {
             OAuthProvider::Xai => "xai",
             OAuthProvider::ClaudeAI => "claudeai",
             OAuthProvider::KomaRun => "komarun",
+            OAuthProvider::KomaPremium => "komapremium",
             // W11: stamped as the `provider` on an ext-backed conn's tokenless wire
             // projection (so the webview sees a stable marker); the connection's real
             // identity is its `ext_id`/`provider_id`. NOT a `from_wire_id` input.
@@ -194,6 +199,7 @@ impl OAuthProvider {
             "xai" => Some(OAuthProvider::Xai),
             "claudeai" => Some(OAuthProvider::ClaudeAI),
             "komarun" => Some(OAuthProvider::KomaRun),
+            "komapremium" => Some(OAuthProvider::KomaPremium),
             _ => None,
         }
     }
@@ -210,6 +216,7 @@ impl OAuthProvider {
             OAuthProvider::Xai => "device",
             OAuthProvider::ClaudeAI => "pkce",
             OAuthProvider::KomaRun => "pkce",
+            OAuthProvider::KomaPremium => "pkce",
             // W11: never surfaced through the enum-driven `oauth_providers()` list (ext
             // rows carry their own kind, mapped from the manifest `method` — see
             // `requests_oauth::method_to_kind`), so this value is exhaustiveness-only and

--- a/src-agent/src/service/oauth/flow.rs
+++ b/src-agent/src/service/oauth/flow.rs
@@ -27,6 +27,7 @@ pub async fn run_flow(provider: OAuthProvider, tx: tokio::sync::mpsc::UnboundedS
         OAuthProvider::Xai => run_xai_flow(tx).await,
         OAuthProvider::ClaudeAI => run_claude_flow(tx).await,
         OAuthProvider::KomaRun => run_komarun_flow(tx).await,
+        OAuthProvider::KomaPremium => run_komarun_flow(tx).await,
         // W11: an extension-delegated flow is NEVER driven through here — it runs
         // off-loop in the daemon hub (`requests_oauth::run_ext_oauth_delegate`), keyed
         // by an `ext:<id>:<provider>` picker id, and never via `Action::OAuthStart`

--- a/src-agent/src/service/oauth/manager.rs
+++ b/src-agent/src/service/oauth/manager.rs
@@ -61,6 +61,8 @@ impl TokenSnap {
             OAuthProvider::ClaudeAI => String::new(),
             // koma.run account login has no org/account header concept either.
             OAuthProvider::KomaRun => String::new(),
+            // Koma Premium: same as KomaRun — no org/account header.
+            OAuthProvider::KomaPremium => String::new(),
             // W11: an ext-backed conn is not a model provider in v1, so it has no
             // send-time account/org header. (It never reaches send-time either — no
             // ModelEntry resolves to it — but stay exhaustive + inert.)
@@ -139,6 +141,7 @@ fn refresh_window(provider: OAuthProvider) -> Option<(u64, u64)> {
         OAuthProvider::Xai => Some((XAI_REFRESH_LEAD_SECS, XAI_MAX_REFRESH_AGE_SECS)),
         OAuthProvider::ClaudeAI => Some((CLAUDE_REFRESH_LEAD_SECS, CLAUDE_MAX_REFRESH_AGE_SECS)),
         OAuthProvider::KomaRun => Some((KOMA_REFRESH_LEAD_SECS, KOMA_MAX_REFRESH_AGE_SECS)),
+        OAuthProvider::KomaPremium => Some((KOMA_REFRESH_LEAD_SECS, KOMA_MAX_REFRESH_AGE_SECS)),
         OAuthProvider::Kilocode => None,
         // W12: an ext-backed token MAY be refreshable (when its manifest declared a refresh
         // descriptor). Use a generic short lead + no age cap; a stale token only actually
@@ -287,6 +290,7 @@ pub async fn fresh_key(oauth_uuid: &str, fallback_key: &str) -> (String, String)
         OAuthProvider::Codex => codex::refresh(http_client(), &snap.refresh_token).await,
         OAuthProvider::ClaudeAI => claude::refresh(http_client(), &snap.refresh_token).await,
         OAuthProvider::KomaRun => komarun::refresh(http_client(), &snap.refresh_token).await,
+        OAuthProvider::KomaPremium => komarun::refresh(http_client(), &snap.refresh_token).await,
         OAuthProvider::Kilocode => return (snap.access_token.clone(), snap.account.clone()),
         // W12: refresh via the manifest-declared generic OAuth2 `refresh_token` endpoint,
         // gated on the conn carrying BOTH a non-empty `refresh_token` AND a

--- a/src-agent/src/service/oauth/registry.rs
+++ b/src-agent/src/service/oauth/registry.rs
@@ -163,6 +163,7 @@ pub fn oauth_providers() -> Vec<(&'static str, &'static str, &'static str)> {
         OAuthProvider::Xai,
         OAuthProvider::ClaudeAI,
         OAuthProvider::KomaRun,
+        OAuthProvider::KomaPremium,
     ]
     .iter()
     .map(|p| (p.wire_id(), p.label(), p.flow_kind()))
@@ -197,6 +198,12 @@ pub fn meta(p: OAuthProvider) -> OAuthProviderMeta {
         // extension wires koma.run as an actual chat/catalogue backend.
         OAuthProvider::KomaRun => OAuthProviderMeta {
             chat_endpoint: "https://koma.run/api/v1",
+            catalogue_endpoint: "",
+        },
+        // Koma Premium (koma/peach): uses the same OAuth tokens as KomaRun but routes
+        // to the premium endpoint for paid subscribers.
+        OAuthProvider::KomaPremium => OAuthProviderMeta {
+            chat_endpoint: "https://koma.run/api/v1/koma-premium",
             catalogue_endpoint: "",
         },
         // W12: extension-backed conns are resolved DATA-DRIVEN from the conn's OWN stored

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.3.10",
-  "message": "feat: koma.run OAuth as a shared provider — extensions can read your koma.run session via the oauth:read grant and oauth.token broker verb"
+  "version": "0.3.11",
+  "message": "feat: add koma/peach premium model support"
 }


### PR DESCRIPTION
- Add OAuthProvider::KomaPremium variant reusing KomaRun tokens
- Add koma/peach model to models.json with premium endpoint
- Update all match statements across 8 files for exhaustiveness
- Route KomaPremium to https://koma.run/api/v1/koma-premium endpoint