### PR TITLE
feat(tui): add /clear to wipe live chat, keep system + archive

### DIFF
--- a/src-agent/src/app/runtime/commands/clear.rs
+++ b/src-agent/src/app/runtime/commands/clear.rs
@@ -1,0 +1,61 @@
+//! Clear command: `/clear` — wipe the live chat transcript, keep system + archive.
+
+use anyhow::Result;
+
+use crate::app::runtime::stream::abort_current;
+use crate::app::state::AppState;
+use crate::model::msglog;
+
+/// Handle `/clear`: destructively empty the live conversation so the session
+/// starts fresh, without opening a new session.
+///
+/// Kept:
+/// - system prompt at `messages[0]` (rebuilt fresh after the cut)
+/// - `messages.sqlite` archive rows (`messages` / `blobs` tables)
+///
+/// Cleared / rewritten:
+/// - every non-system turn in the live `Conversation` + `messages.json`
+/// - short-send rolling summary (empty text + watermark frozen at archive tip
+///   so the reshaper cannot re-inject pre-clear history into a fresh chat)
+/// - transcript cache / scroll (so the empty chat renders immediately)
+///
+/// Mid-stream: aborts the in-flight turn first (same full cancel as rewind),
+/// then cuts — otherwise a late stream event could re-append onto a cleared
+/// history.
+pub(super) fn handle_clear(state: &mut AppState) -> Result<()> {
+    if state.rest.fg().session.is_none() {
+        state.rest.fg_mut().status = "no active session".into();
+        return Ok(());
+    }
+
+    // Full round teardown if anything is in flight (stream / approvals / subs).
+    if state.rest.fg().waiting {
+        abort_current(&mut state.rest);
+        state.rest.fg_mut().waiting = false;
+    }
+
+    let session_dir = {
+        let sess = state.rest.fg_mut().session.as_mut().unwrap();
+        // Drop user/assistant/tool turns; keep system if present.
+        sess.conversation.clear_body();
+        // Re-seed / refresh the live system prompt (embedded + MEMORY.md etc.).
+        sess.rebuild_system();
+        let _ = sess.save();
+        sess.path.clone()
+    };
+
+    // Freeze short-send at the archive tip without deleting message/blob rows.
+    let _ = msglog::clear_rolling_summary(&session_dir);
+
+    // Transient UI flush: force next paint to rebuild blocks; stick to bottom of
+    // the (now empty-of-turns) transcript. Cache is a single global scratch
+    // (same pattern as compaction).
+    state.rest.transcript_cache.borrow_mut().blocks.clear();
+    {
+        let fg = state.rest.fg_mut();
+        fg.follow = true;
+        fg.scroll = 0;
+        fg.status = "chat cleared".into();
+    }
+    Ok(())
+}

--- a/src-agent/src/app/runtime/commands/mod.rs
+++ b/src-agent/src/app/runtime/commands/mod.rs
@@ -9,6 +9,7 @@ use crate::controller::command::Command;
 use crate::service::openrouter::OpenRouterClient;
 
 mod bash;
+mod clear;
 mod todo;
 mod cd;
 // `pub(crate)` so the plan-approval compaction rail (deferred/idle drain) can call
@@ -56,6 +57,7 @@ pub(super) fn apply_slash(
 ) -> Result<()> {
     match cmd {
         Command::Compact => compact::handle_compact(state, client, handle, None)?,
+        Command::Clear => clear::handle_clear(state)?,
         Command::New(mode) => new_session::handle_new(state, client, handle, mode)?,
         Command::Mode(arg) => misc::handle_mode(state, arg)?,
         Command::Effort => effort::handle_effort(state, client)?,

--- a/src-agent/src/app/runtime/shortsend/recall.rs
+++ b/src-agent/src/app/runtime/shortsend/recall.rs
@@ -163,9 +163,15 @@ pub async fn shape(
     }
 
     // 4. No summary yet → nothing to compress against; send the full history.
+    //    Empty text is treated the same as absent: `/clear` freezes the watermark
+    //    with a blank body so pre-clear archive content cannot re-enter the wire
+    //    via fold/blob recall while still leaving `messages`/`blobs` intact.
     let Some(sum) = msglog::read_summary(session_dir) else {
         return history;
     };
+    if sum.text.trim().is_empty() {
+        return history;
+    }
 
     // Everything newer than the summary boundary must stay verbatim: that span is
     // the current (in-progress) exchange plus any completed tail the fold hasn't

--- a/src-agent/src/controller/command.rs
+++ b/src-agent/src/controller/command.rs
@@ -9,7 +9,7 @@
 //! `/rename [session] <name>`, `/settings` (alias `/config`),
 //! `/resume` (alias `/sessions`), `/task <agent> <task>`,
 //! `/cd <path>`, `/adddir <path>`,
-//! `/internet [simple|full]`, `/help`, `/quit` (aliases: `/q`, `/exit`).
+//! `/internet [simple|full]`, `/clear`, `/help`, `/quit` (aliases: `/q`, `/exit`).
 
 use crate::model::settings::InternetMode;
 
@@ -35,6 +35,7 @@ pub const COMMANDS: &[(&str, &str)] = &[
     ("/cd", "Change the session working directory"),
     ("/adddir", "Add a directory to the workspace roots"),
     ("/compact", "Summarize and compact the conversation"),
+    ("/clear", "Clear the chat history (keeps system prompt + archive)"),
     ("/usage", "Show the cost and token usage dashboard"),
     ("/rename", "Rename the current session"),
     ("/select", "Dump history to the terminal to copy/paste"),
@@ -96,6 +97,9 @@ pub enum NewMode {
 pub enum Command {
     /// Compact the conversation history to save context window space.
     Compact,
+    /// Destructively clear the live chat transcript (system prompt kept;
+    /// `messages.sqlite` archive kept; short-send rolling summary reset).
+    Clear,
     /// Spawn a fresh PARALLEL session. `NewMode` controls whether the previous
     /// foreground is kept running (`Swap`) or tombstoned (`Kill`).
     New(NewMode),
@@ -176,6 +180,7 @@ pub fn parse(line: &str) -> Command {
 
     match head_lc.as_str() {
         "compact" => Command::Compact,
+        "clear" => Command::Clear,
         "new" => {
             let mode = match rest.split_whitespace().next().unwrap_or("").to_lowercase().as_str() {
                 "kill" => NewMode::Kill,
@@ -215,5 +220,24 @@ pub fn parse(line: &str) -> Command {
             Command::Rename(name.trim().to_string())
         }
         other => Command::Unknown(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod parse_tests {
+    use super::*;
+
+    #[test]
+    fn parse_clear() {
+        assert_eq!(parse("/clear"), Command::Clear);
+        assert_eq!(parse("/CLEAR"), Command::Clear);
+        assert_eq!(parse("  /clear  "), Command::Clear);
+    }
+
+    #[test]
+    fn palette_lists_clear() {
+        assert!(COMMANDS.iter().any(|(n, _)| *n == "/clear"));
+        let matches = palette_matches("/cl");
+        assert!(matches.iter().any(|(n, _)| *n == "/clear"));
     }
 }

--- a/src-agent/src/model/conversation.rs
+++ b/src-agent/src/model/conversation.rs
@@ -386,6 +386,22 @@ impl Conversation {
         self.messages.truncate(idx);
     }
 
+    /// Drop every non-system turn. Keeps `messages[0]` when it is System;
+    /// otherwise empties the vec entirely (caller should re-seed via
+    /// `set_system` / `Session::rebuild_system`). Used by `/clear`.
+    pub fn clear_body(&mut self) {
+        if self
+            .messages
+            .first()
+            .map(|m| m.role == Role::System)
+            .unwrap_or(false)
+        {
+            self.messages.truncate(1);
+        } else {
+            self.messages.clear();
+        }
+    }
+
     /// Pop all trailing `Assistant` messages (used before a resend so the
     /// model doesn't see its own previous partial reply as context).
     ///
@@ -455,5 +471,37 @@ impl Conversation {
             .collect();
         picked.reverse();
         picked.join("\n")
+    }
+}
+
+#[cfg(test)]
+mod clear_body_tests {
+    use super::*;
+
+    #[test]
+    fn clear_body_keeps_system_drops_rest() {
+        let mut c = Conversation::new("sys");
+        c.push_user("hi");
+        c.push_assistant("hello", None, false);
+        c.clear_body();
+        assert_eq!(c.messages().len(), 1);
+        assert_eq!(c.messages()[0].role, Role::System);
+        assert_eq!(c.messages()[0].content, "sys");
+    }
+
+    #[test]
+    fn clear_body_empties_when_no_system() {
+        let mut c = Conversation::from_messages(vec![]);
+        c.push_user("hi");
+        c.push_assistant("hello", None, false);
+        c.clear_body();
+        assert!(c.messages().is_empty());
+    }
+
+    #[test]
+    fn clear_body_on_empty_is_noop() {
+        let mut c = Conversation::from_messages(vec![]);
+        c.clear_body();
+        assert!(c.messages().is_empty());
     }
 }

--- a/src-agent/src/model/msglog/mod.rs
+++ b/src-agent/src/model/msglog/mod.rs
@@ -52,4 +52,4 @@ pub use records::{
     read_bash_jobs, read_file_baseline, read_file_changes, read_subagents, record_file_baseline,
     record_file_change, write_bash_jobs, write_subagents,
 };
-pub use summary::{read_summary, write_summary};
+pub use summary::{clear_rolling_summary, read_summary, write_summary};

--- a/src-agent/src/model/msglog/query_test.rs
+++ b/src-agent/src/model/msglog/query_test.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::dto::chat::Role;
+use crate::model::msglog::{clear_rolling_summary, read_summary, write_summary};
 
 /// A unique path under the OS temp root for a single test, removed
 /// recursively on drop. Mirrors `app::bgbash::mod_test`'s `TempDir` helper —
@@ -57,4 +58,33 @@ fn message_count_is_a_plain_row_count() {
     append(dir.path(), Role::User, "hi", None).unwrap();
 
     assert_eq!(message_count(dir.path()), Some(2));
+}
+
+#[test]
+fn clear_rolling_summary_freezes_watermark_and_empties_text() {
+    let dir = TempDir::new("clear-summary");
+    append(dir.path(), Role::User, "hi", None).unwrap();
+    append(dir.path(), Role::Assistant, "hello", Some((10, 5, 0.0))).unwrap();
+    let tip = max_message_id(dir.path());
+    assert!(tip >= 2);
+    // Seed a non-empty summary covering the archive.
+    write_summary(dir.path(), "old summary of prior chat", tip, tip + 1).unwrap();
+    clear_rolling_summary(dir.path()).unwrap();
+
+    let sum = read_summary(dir.path()).expect("summary row kept");
+    assert!(sum.text.is_empty(), "body wiped so shape skips injection");
+    assert_eq!(sum.covers_up_to, tip, "watermark frozen at archive tip");
+    // Archive rows must remain.
+    assert_eq!(message_count(dir.path()), Some(2));
+}
+
+#[test]
+fn clear_rolling_summary_on_empty_archive_deletes_row() {
+    let dir = TempDir::new("clear-empty");
+    // Open schema by writing then... actually empty dir has no DB. Seed then
+    // delete via clear when max_id is 0 after truncate is awkward; write a
+    // summary against an empty DB first (open creates schema).
+    write_summary(dir.path(), "stale", 0, 1).unwrap();
+    clear_rolling_summary(dir.path()).unwrap();
+    assert!(read_summary(dir.path()).is_none());
 }

--- a/src-agent/src/model/msglog/summary.rs
+++ b/src-agent/src/model/msglog/summary.rs
@@ -61,3 +61,22 @@ pub fn write_summary(
     )?;
     Ok(())
 }
+
+/// After `/clear`: wipe the rolling short-send summary text and advance the
+/// watermark to the current archive tip so the fold step will not re-summarise
+/// pre-clear history into a fresh chat. Leaves `messages`/`blobs` untouched
+/// (the archive stays). Wrote as empty `text`; short-send `shape` treats empty
+/// summary text as absent and skips injection/recall.
+pub fn clear_rolling_summary(session_dir: &Path) -> Result<()> {
+    let max_id = super::query::max_message_id(session_dir);
+    // Empty archive → delete the summary row if present so a new session starts
+    // with no summary at all.
+    if max_id <= 0 {
+        let conn = open(session_dir)?;
+        conn.execute("DELETE FROM summary WHERE id = 1", [])?;
+        return Ok(());
+    }
+    // Archive retained: freeze the watermark at the tip + empty the body so fold
+    // has nothing new to merge until post-clear tools/messages append past max_id.
+    write_summary(session_dir, "", max_id, max_id.saturating_add(1))
+}


### PR DESCRIPTION
Destructively empties the live Conversation/messages.json while preserving the system prompt (rebuilt) and messages.sqlite rows. Freezes the short-send rolling summary at the archive tip with empty text so pre-clear history cannot re-enter the wire. Aborts an in-flight turn first (same as rewind).