### PR TITLE
fix(webgui): Windows-safe basenames in Explore File changed

### DIFF
--- a/src-webgui/src/components/AccordionSection.tsx
+++ b/src-webgui/src/components/AccordionSection.tsx
@@ -32,7 +32,7 @@ export function AccordionSection({ title, open, onToggle, action, children }: Ac
         </button>
         {action && <div className="flex items-center opacity-0 group-hover:opacity-100">{action}</div>}
       </div>
-      {open && <div className="min-h-0 flex-1 overflow-y-auto pb-1">{children}</div>}
+      {open && <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden pb-1">{children}</div>}
     </div>
   )
 }

--- a/src-webgui/src/components/GitChangesShared.tsx
+++ b/src-webgui/src/components/GitChangesShared.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { FileText, Plus, Minus, Undo2, Check, X } from 'lucide-react'
 import type { GitFileEntry } from '../store/koma'
+import { baseName, dirName } from '../utils/path'
 
 // Shared presentational atoms for the two "Source Control"-flavoured
 // surfaces: the sidebar GitPanel and the graph tab's GraphChanges accordion
@@ -21,16 +22,7 @@ export const STATUS_TONE: Record<string, string> = {
   U: 'text-koma-error',
 }
 
-export function baseName(path: string): string {
-  const parts = path.split('/')
-  return parts[parts.length - 1] || path
-}
-
-export function dirName(path: string): string {
-  const parts = path.split('/')
-  parts.pop()
-  return parts.join('/')
-}
+export { baseName, dirName }
 
 // A subtle row-hover action button (stage/unstage/discard) — invisible until
 // the row is hovered/focused, mirroring VSCode's Source Control row actions.

--- a/src-webgui/src/components/GraphDetail.tsx
+++ b/src-webgui/src/components/GraphDetail.tsx
@@ -2,6 +2,8 @@ import { FileText } from 'lucide-react'
 import { useKoma } from '../store/koma'
 import { relTime } from './GraphRow'
 import { BrailleSpinner } from './BrailleSpinner'
+import { baseName, dirName } from '../utils/path'
+
 
 // git status char -> badge tone (mirrors GitPanel's STATUS_TONE): A = added
 // (good), M = modified (accent), D = deleted (error), R/C = rename/copy (warn).
@@ -14,15 +16,6 @@ const FILE_TONE: Record<string, string> = {
 }
 function fileTone(status: string): string {
   return FILE_TONE[status.charAt(0)] ?? 'text-koma-dim'
-}
-function baseName(path: string): string {
-  const parts = path.split('/')
-  return parts[parts.length - 1] || path
-}
-function dirName(path: string): string {
-  const parts = path.split('/')
-  parts.pop()
-  return parts.join('/')
 }
 
 // The commit-graph tab's detail pane (bottom split): full metadata + body +

--- a/src-webgui/src/components/panels/ExplorePanel.tsx
+++ b/src-webgui/src/components/panels/ExplorePanel.tsx
@@ -19,6 +19,8 @@ import { AccordionSection } from '../AccordionSection'
 import { Empty } from './helpers'
 import { useKoma, visiblePlanTodos } from '../../store/koma'
 import { BrailleSpinner } from '../BrailleSpinner'
+import { baseName } from '../../utils/path'
+
 
 // File-change status -> single-letter git-style badge + tone. added = new (good),
 // modified = touched (accent), deleted = removed (error/red).
@@ -26,12 +28,6 @@ const FILE_STATUS: Record<string, { letter: string; tone: string }> = {
   added: { letter: 'A', tone: 'text-koma-success' },
   modified: { letter: 'M', tone: 'text-koma-accent' },
   deleted: { letter: 'D', tone: 'text-koma-error' },
-}
-
-// Show just the basename in the main label; the full path rides the tooltip.
-function baseName(path: string): string {
-  const parts = path.split('/')
-  return parts[parts.length - 1] || path
 }
 
 // Shared status -> icon/tone map for both the Agents and Bash rows. Mirrors

--- a/src-webgui/src/components/panels/GitPanel.tsx
+++ b/src-webgui/src/components/panels/GitPanel.tsx
@@ -27,6 +27,8 @@ import { useKoma } from '../../store/koma'
 import type { GitFileEntry } from '../../store/koma'
 import { BrailleSpinner } from '../BrailleSpinner'
 import { GitPushMenu } from '../GitPushMenu'
+import { baseName, dirName } from '../../utils/path'
+
 
 // git-porcelain status char -> badge tone. Mirrors ExplorePanel's FILE_STATUS
 // idiom (added = good, modified = accent, deleted = error): A/? = new
@@ -43,16 +45,6 @@ const STATUS_TONE: Record<string, string> = {
   U: 'text-koma-error',
 }
 
-function baseName(path: string): string {
-  const parts = path.split('/')
-  return parts[parts.length - 1] || path
-}
-
-function dirName(path: string): string {
-  const parts = path.split('/')
-  parts.pop()
-  return parts.join('/')
-}
 
 // A subtle row-hover action button (stage/unstage/discard) — invisible until
 // the row is hovered/focused, mirroring VSCode's Source Control row actions.

--- a/src-webgui/src/store/coding.ts
+++ b/src-webgui/src/store/coding.ts
@@ -2,6 +2,10 @@
 // Merged into the main koma store as `coding` (see store/koma.ts).
 // Actions live on KomaState; this module owns the state shape + push reducers.
 
+import { baseName, parentDirPath } from '../utils/path'
+
+export { baseName, parentDirPath }
+
 export type FileTreeEntry = {
   name: string
   path: string
@@ -54,16 +58,6 @@ export function mintRequestId(): string {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
 }
 
-export function parentDirPath(path: string): string {
-  if (!path) return ''
-  const idx = path.lastIndexOf('/')
-  return idx <= 0 ? '' : path.slice(0, idx)
-}
-
-export function baseName(path: string): string {
-  const parts = path.split('/').filter(Boolean)
-  return parts[parts.length - 1] || path
-}
 
 export function emptyFileState(partial?: Partial<CodingFileState>): CodingFileState {
   return {

--- a/src-webgui/src/utils/path.test.ts
+++ b/src-webgui/src/utils/path.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import { baseName, dirName, parentDirPath, stripWinPrefix } from './path'
+
+// Unix
+assert.equal(baseName('/home/u/proj/src/main.rs'), 'main.rs')
+assert.equal(baseName('src/main.rs'), 'main.rs')
+assert.equal(baseName('main.rs'), 'main.rs')
+assert.equal(baseName('/'), '/')
+
+// Windows separators
+assert.equal(baseName('C:\\Users\\62895\\Documents\\main.rs'), 'main.rs')
+assert.equal(baseName('C:/Users/62895/Documents/main.rs'), 'main.rs')
+assert.equal(baseName('src\\main.rs'), 'main.rs')
+
+// Extended-length prefix (the Explore panel bug from issue #81)
+assert.equal(baseName('\\\\?\\C:\\Users\\62895\\Documents\\Repository\\main.rs'), 'main.rs')
+assert.equal(baseName('//?/C:/Users/62895/Documents/main.rs'), 'main.rs')
+assert.equal(stripWinPrefix('\\\\?\\C:\\Users\\x\\a.rs'), 'C:\\Users\\x\\a.rs')
+
+// dirName
+assert.equal(dirName('/home/u/proj/src/main.rs'), 'home/u/proj/src')
+assert.equal(dirName('C:\\Users\\62895\\Documents\\main.rs'), 'C:/Users/62895/Documents')
+assert.equal(dirName('\\\\?\\C:\\Users\\62895\\Documents\\main.rs'), 'C:/Users/62895/Documents')
+assert.equal(dirName('main.rs'), '')
+
+// coding-panel parentDirPath (relative, mixed seps)
+assert.equal(parentDirPath('src/nested/a.ts'), 'src/nested')
+assert.equal(parentDirPath('src\\nested\\a.ts'), 'src/nested')
+assert.equal(parentDirPath('a.ts'), '')
+assert.equal(parentDirPath(''), '')
+
+console.log('path.test.ts: ok')

--- a/src-webgui/src/utils/path.ts
+++ b/src-webgui/src/utils/path.ts
@@ -1,0 +1,46 @@
+// Cross-platform path display helpers for the webgui.
+//
+// The daemon may push absolute Windows paths (including the `\\?\` extended-length
+// prefix). Naive `split('/')` basename helpers leave the full path as the "name",
+// which blows up Explore "File changed" rows and forces horizontal scroll.
+
+/** Strip Windows extended-length / device prefixes so the rest looks like a normal path. */
+export function stripWinPrefix(path: string): string {
+  if (!path) return path
+  // `\\?\C:\...` or `//?/C:/...`
+  if (path.startsWith('\\\\?\\') || path.startsWith('//?/')) return path.slice(4)
+  // `\\.\C:\...` device namespace
+  if (path.startsWith('\\\\.\\') || path.startsWith('//./')) return path.slice(4)
+  return path
+}
+
+/** Last path segment, accepting `/` and `\` separators (and Windows prefixes). */
+export function baseName(path: string): string {
+  if (!path) return path
+  const cleaned = stripWinPrefix(path).replace(/\\/g, '/')
+  const parts = cleaned.split('/').filter(Boolean)
+  return parts[parts.length - 1] || path
+}
+
+/** Parent directory using the same separator-tolerant logic as {@link baseName}. */
+export function dirName(path: string): string {
+  if (!path) return ''
+  const cleaned = stripWinPrefix(path).replace(/\\/g, '/')
+  const parts = cleaned.split('/').filter(Boolean)
+  if (parts.length <= 1) return ''
+  parts.pop()
+  // Preserve a drive root like `C:` when present.
+  if (/^[A-Za-z]:$/.test(parts[0] ?? '')) {
+    const drive = parts.shift()!
+    return parts.length === 0 ? `${drive}/` : `${drive}/${parts.join('/')}`
+  }
+  return parts.join('/')
+}
+
+/** Parent path for coding-panel relative paths (usually POSIX-ish). */
+export function parentDirPath(path: string): string {
+  if (!path) return ''
+  const cleaned = path.replace(/\\/g, '/')
+  const idx = cleaned.lastIndexOf('/')
+  return idx <= 0 ? '' : cleaned.slice(0, idx)
+}


### PR DESCRIPTION
## Summary
Fixes #81.

Explore **File changed** rows on Windows rendered full absolute paths like `\\?\C:\Users\...` and forced horizontal scroll. `baseName()` only split on `/`, so Windows `\` paths and extended-length prefixes never collapsed to a filename.

## Changes
- Add shared `src-webgui/src/utils/path.ts` helpers:
  - strip `\\?\` / `//?/` / device prefixes
  - `baseName` / `dirName` / `parentDirPath` accept both `/` and `\`
- Use them in Explore, Git, Graph, Coding path labels
- Clip accordion body with `overflow-x-hidden` as defense-in-depth
- Unit tests for the Windows cases from the issue screenshot

## Before
Rows showed `\\?\C:\Users\62895\Doc...` with horizontal scroll.

## After
Rows show basename only (e.g. `main.rs`); full path stays in the tooltip; no horizontal scroll from long absolute paths.

## Test plan
- [x] `npx tsx src/utils/path.test.ts`
- [x] `npx tsx src/store/coding.test.ts`
- [x] `npx tsc --noEmit -p tsconfig.json`
- [x] `npm run build`
- [ ] Open GUI on Windows with file changes under `C:\...` / `\\?\C:\...` and confirm Explore File changed shows basenames only