### PR TITLE
fix: --security-install fails on Python 3.14

### DIFF
--- a/src-agent/src/security/mod.rs
+++ b/src-agent/src/security/mod.rs
@@ -146,6 +146,15 @@ pub fn install(force: bool) -> Result<()> {
     // Step 6: install Python dependencies.
     let pip = dest.join("venv").join("bin").join("pip");
     let requirements = dest.join("requirements.txt");
+
+    // 6a: upgrade pip itself to get modern wheel tag support.
+    println!("upgrading pip...");
+    let _ = std::process::Command::new(&pip)
+        .args(["install", "--upgrade", "pip", "setuptools", "wheel"])
+        .status();
+
+    // 6b: install main requirements (lief>=0.17.5 pins a modern version
+    //     with Python 3.14 wheels, bypassing checksec.py's exact pin).
     println!(
         "installing Python dependencies from {}...",
         requirements.display()
@@ -160,6 +169,16 @@ pub fn install(force: bool) -> Result<()> {
         .context("failed to launch pip install")?;
     if !status.success() {
         return Err(anyhow!("pip install exited with status {}", status));
+    }
+
+    // 6c: install checksec.py with --no-deps so it doesn't downgrade lief.
+    println!("installing checksec.py (with --no-deps)...");
+    let status = std::process::Command::new(&pip)
+        .args(["install", "--no-deps", "checksec.py"])
+        .status()
+        .context("failed to launch pip install checksec.py")?;
+    if !status.success() {
+        return Err(anyhow!("pip install checksec.py exited with status {}", status));
     }
 
     println!("security daemon installed at {}", dest.display());

--- a/src-security/requirements.txt
+++ b/src-security/requirements.txt
@@ -1,4 +1,4 @@
-checksec.py
+lief>=0.17.5
 fpylll
 hashid
 jsbeautifier


### PR DESCRIPTION
### Problem

`koma --security-install` fails on Python 3.14 with a `ModuleNotFoundError:
No module named 'pkg_resources'` during the lief build. Root cause:
`checksec.py` v0.7.5 (the latest PyPI release) pins `lief==0.16.6` exactly,
which has no prebuilt wheel for cp314-x86_64-linux-gnu. pip falls back to
building lief 0.11.0 from source, and that old version needs `pkg_resources`.

### Solution

Two changes:

1. **`src-security/requirements.txt`** — replace `checksec.py` with
   `lief>=0.17.5`. lief 0.17.5 ships prebuilt wheels for Python 3.14.

2. **`src-agent/src/security/mod.rs`** — the `install()` function now
   runs three sub-steps instead of one `pip install -r`:
   - 6a: upgrade pip/setuptools/wheel (best-effort, errors swallowed)
   - 6b: install `requirements.txt` normally → `lief>=0.17.5` is resolved
   - 6c: install `checksec.py` with `--no-deps` → prevents pip from
     reverting lief to 0.16.6

### Verification

- `cargo build --release` compiles cleanly.
- `cat src-security/requirements.txt` confirms `lief>=0.17.5` present and
  other deps unchanged.
- The installed venv's checksec module imports and works (uses the
  `lief>=0.17.5` version).

### Future cleanup

When checksec.py publishes a release with `lief>=0.17.5` (their master
branch already uses `lief = "0.17.2"` in pyproject.toml), step 6c and the
`--no-deps` workaround can be removed. The checksec.py line in
requirements.txt should be restored at that point.

Fixes #112 