### PR TITLE
fix: swap SurrealDB engine from SurrealKV to RocksDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +980,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,7 +1032,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -1069,6 +1097,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
 
 [[package]]
 name = "cfb"
@@ -1163,6 +1200,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1890,7 +1938,7 @@ checksum = "fac5fca71e65e94cc718a6e2af65d6e0f9c6027751c2aa562fbb5087fda639bc"
 dependencies = [
  "bit-set 0.8.0",
  "cssparser 0.37.0",
- "foldhash 0.2.0",
+ "foldhash",
  "html5ever 0.39.0",
  "nom 8.0.0",
  "precomputed-hash",
@@ -1906,7 +1954,7 @@ checksum = "cf8b9b294aabb8010b37c49a07d6f82175152f4927855d534979a38737721875"
 dependencies = [
  "dom_query",
  "flagset",
- "foldhash 0.2.0",
+ "foldhash",
  "gjson",
  "html-escape",
  "once_cell",
@@ -1915,12 +1963,6 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "double-ended-peekable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d05e1c0dbad51b52c38bda7adceef61b9efc2baf04acfe8726a8c4630a6f57"
 
 [[package]]
 name = "downcast-rs"
@@ -2346,12 +2388,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -2885,6 +2921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3038,24 +3080,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -3066,7 +3097,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -3919,6 +3950,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3988,7 +4030,7 @@ dependencies = [
  "cfg-if",
  "cssparser 0.36.0",
  "encoding_rs",
- "foldhash 0.2.0",
+ "foldhash",
  "hashbrown 0.17.1",
  "memchr",
  "mime",
@@ -4008,20 +4050,21 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -5684,18 +5727,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick_cache"
-version = "0.6.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c6658afe513a3b484e3abfdaa0d03ef3c0bbf017542c178dd55f94eb3051f9"
-dependencies = [
- "ahash 0.8.12",
- "equivalent",
- "hashbrown 0.16.1",
- "parking_lot",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5871,7 +5902,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.18.0",
+ "lru",
  "palette",
  "serde",
  "strum 0.28.0",
@@ -6227,15 +6258,6 @@ dependencies = [
 
 [[package]]
 name = "revision"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f53179a035f881adad8c4d58a2c599c6b4a8325b989c68d178d7a34d1b1e4c"
-dependencies = [
- "revision-derive 0.10.0",
-]
-
-[[package]]
-name = "revision"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b8ee532f15b2f0811eb1a50adf10d036e14a6cdae8d99893e7f3b921cb227d"
@@ -6243,21 +6265,10 @@ dependencies = [
  "chrono",
  "geo",
  "regex",
- "revision-derive 0.11.0",
+ "revision-derive",
  "roaring",
  "rust_decimal",
  "uuid",
-]
-
-[[package]]
-name = "revision-derive"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0ec466e5d8dca9965eb6871879677bef5590cf7525ad96cae14376efb75073"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -6993,6 +7004,12 @@ dependencies = [
 
 [[package]]
 name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -7376,7 +7393,7 @@ dependencies = [
  "path-clean",
  "pharos",
  "reblessive",
- "revision 0.11.0",
+ "revision",
  "ring",
  "rust_decimal",
  "rustls-pki-types",
@@ -7448,13 +7465,13 @@ dependencies = [
  "pharos",
  "phf 0.11.3",
  "pin-project-lite",
- "quick_cache 0.5.2",
+ "quick_cache",
  "radix_trie",
  "rand 0.8.6",
  "rayon",
  "reblessive",
  "regex",
- "revision 0.11.0",
+ "revision",
  "ring",
  "rmpv",
  "roaring",
@@ -7471,7 +7488,7 @@ dependencies = [
  "storekey",
  "strsim",
  "subtle",
- "surrealkv",
+ "surrealdb-rocksdb",
  "sysinfo",
  "tempfile",
  "thiserror 1.0.69",
@@ -7482,29 +7499,35 @@ dependencies = [
  "unicase",
  "url",
  "uuid",
- "vart 0.8.1",
+ "vart",
  "wasm-bindgen-futures",
  "wasmtimer",
  "ws_stream_wasm",
 ]
 
 [[package]]
-name = "surrealkv"
-version = "0.9.3"
+name = "surrealdb-librocksdb-sys"
+version = "0.18.3+11.0.0-4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a5041979bdff8599a1d5f6cb7365acb9a79664e2a84e5c4fddac2b3969f7d1"
+checksum = "25b82a18c7fa4b57206784a1a31e7b942ae1d3e24493e0c733019a409b2b4bea"
 dependencies = [
- "ahash 0.8.12",
- "bytes",
- "chrono",
- "crc32fast",
- "double-ended-peekable",
- "getrandom 0.2.17",
- "lru 0.12.5",
- "parking_lot",
- "quick_cache 0.6.24",
- "revision 0.10.0",
- "vart 0.9.3",
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "surrealdb-rocksdb"
+version = "0.24.0-surreal.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e8c3a004982458af159bcbf369e41663d538cd4a291a49c0d4a2fb373cbb7e"
+dependencies = [
+ "libc",
+ "surrealdb-librocksdb-sys",
 ]
 
 [[package]]
@@ -8473,12 +8496,6 @@ name = "vart"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87782b74f898179396e93c0efabb38de0d58d50bbd47eae00c71b3a1144dbbae"
-
-[[package]]
-name = "vart"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1982d899e57d646498709735f16e9224cf1e8680676ad687f930cf8b5b555ae"
 
 [[package]]
 name = "vcpkg"
@@ -9882,6 +9899,16 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/src-agent/Cargo.toml
+++ b/src-agent/Cargo.toml
@@ -63,10 +63,11 @@ sha2 = "0.10"
 # streamable-HTTP client transport. tokio-native; reuses the existing tokio runtime.
 rmcp = { version = "1.8", default-features = false, features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest", "macros"] }
 # SurrealDB embedded — turbo context layer for AI agents. Persistent on-disk
-# mirror (SurrealKV) of the SQLite message log with hybrid search (BM25 +
+# mirror (RocksDB) of the SQLite message log with hybrid search (BM25 +
 # vector cosine via HNSW), graph edges for agent orchestration, and memory
 # atoms for cross-session knowledge. NOT the canonical write path.
-surrealdb = { version = "2", default-features = false, features = ["kv-surrealkv"] }
+# Build requires cmake + clang/libclang (librocksdb-sys compiles RocksDB C++).
+surrealdb = { version = "2", default-features = false, features = ["kv-rocksdb"] }
 # Local ONNX embeddings for SurrealDB vector search. No API keys, no cloud.
 # Model downloads once (~130 MB BGE-small-en-v1.5) and runs offline thereafter.
 fastembed = "4"

--- a/src-agent/src/app/runtime/knowledge_daemon.rs
+++ b/src-agent/src/app/runtime/knowledge_daemon.rs
@@ -1,6 +1,6 @@
 //! The GLOBAL knowledge daemon (`koma --knowledge-daemon`).
 //!
-//! A SINGLETON headless process that owns the central SurrealKV knowledge store
+//! A SINGLETON headless process that owns the central RocksDB knowledge store
 //! at `~/.koma/knowledge/` so ALL sessions share entity resolution, graph-based
 //! recall expansion, and a persistent fact corpus that survives compaction.
 //! Sessions connect over IPC (`~/.koma/knowledge.sock`) to push facts and query
@@ -30,7 +30,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use surrealdb::engine::local::Db;
+use surrealdb::engine::local::{Db, RocksDb};
 use surrealdb::Surreal;
 
 use crate::ipc::frame::{read_frame_from, write_frame_to, FrameReader};
@@ -41,7 +41,7 @@ use super::signals::install_daemon_signals;
 
 /// Headless entry point: run the GLOBAL knowledge daemon event loop with NO terminal.
 ///
-/// Opens the central SurrealKV store at `~/.koma/knowledge/`, defines the knowledge
+/// Opens the central RocksDB store at `~/.koma/knowledge/`, defines the knowledge
 /// schema, binds `~/.koma/knowledge.sock`, and serves [`KnowledgeRequest`] frames
 /// until signalled. Returns when SIGTERM/SIGINT is observed (via the polled
 /// `shutting_down` flag).
@@ -99,7 +99,23 @@ pub fn run_knowledge_daemon(_opts: crate::cli::Opts) -> Result<()> {
 
 async fn open_knowledge_db(knowledge_path: &std::path::Path) -> Result<Surreal<Db>> {
     let path_str = knowledge_path.to_string_lossy().to_string();
-    let db = Surreal::<Db>::new(path_str).await?;
+
+    // Wipe legacy SurrealKV store if present — RocksDB cannot open it.
+    crate::model::surreal::core::ensure_rocksdb_compatible(knowledge_path);
+
+    let db = match Surreal::new::<RocksDb>(path_str).await {
+        Ok(db) => db,
+        Err(e) => {
+            // One-shot retry: wipe + reopen.
+            let _ = std::fs::remove_dir_all(knowledge_path);
+            crate::model::store::append_global_error_log(
+                "knowledge_daemon — first open failed, wiped + retrying",
+                &e.to_string(),
+            );
+            let path_str = knowledge_path.to_string_lossy().to_string();
+            Surreal::new::<RocksDb>(path_str).await?
+        }
+    };
     db.use_ns("koma").use_db("knowledge").await?;
 
     // Schema: fact, entity, and the relationship tables that build the graph.

--- a/src-agent/src/cli.rs
+++ b/src-agent/src/cli.rs
@@ -135,7 +135,7 @@ pub struct Opts {
     pub mcp_daemon: bool,
     /// When `true`, run the GLOBAL knowledge daemon with no terminal
     /// (`--knowledge-daemon` flag): a singleton process that owns the central
-    /// SurrealKV knowledge store (`~/.koma/knowledge.sock`) so sessions share entity
+    /// RocksDB knowledge store (`~/.koma/knowledge.sock`) so sessions share entity
     /// resolution, graph-based recall expansion, and a persistent fact corpus that
     /// survives compaction. No `--session` — it is not keyed to any session.
     pub knowledge_daemon: bool,

--- a/src-agent/src/main.rs
+++ b/src-agent/src/main.rs
@@ -231,7 +231,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     // --- headless path: run the GLOBAL knowledge daemon (no TUI) ---
-    // A singleton process that owns the central SurrealKV knowledge store so
+    // A singleton process that owns the central RocksDB knowledge store so
     // sessions share entity resolution and graph-expanded recall. Checked BEFORE
     // `--mcp-daemon` and `--daemon` so a stray combination can't accidentally
     // take the wrong branch.

--- a/src-agent/src/model/store.rs
+++ b/src-agent/src/model/store.rs
@@ -514,7 +514,7 @@ pub fn write_mcp_daemon_pid() -> Result<()> {
 /// Path to the GLOBAL knowledge daemon's Unix domain socket: `~/.koma/knowledge.sock`.
 ///
 /// Like the MCP daemon, the knowledge daemon is a SINGLETON — one process owns the
-/// central SurrealKV store at `~/.koma/knowledge/` and sessions push facts / query
+/// central RocksDB store at `~/.koma/knowledge/` and sessions push facts / query
 /// for graph expansion here. Whoever binds this socket IS the live knowledge daemon
 /// (bind-as-oracle, same rule as the session and MCP sockets).
 #[cfg(unix)]

--- a/src-agent/src/model/surreal/core.rs
+++ b/src-agent/src/model/surreal/core.rs
@@ -1,4 +1,4 @@
-//! Persistent SurrealDB mirror backed by SurrealKV.
+//! Persistent SurrealDB mirror backed by RocksDB.
 //!
 //! `open_db` returns a cached on-disk connection (schema is defined once per
 //! path). `start_sync` spawns a fire-and-forget background thread that reads
@@ -11,7 +11,7 @@ use std::sync::{Mutex, OnceLock};
 
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 
-use surrealdb::engine::local::Db;
+use surrealdb::engine::local::{Db, RocksDb};
 use surrealdb::Surreal;
 
 // ---------------------------------------------------------------------------
@@ -135,6 +135,34 @@ where
 }
 
 // ---------------------------------------------------------------------------
+// RocksDB store compatibility — wipe legacy SurrealKV dirs on first open
+// ---------------------------------------------------------------------------
+
+/// RocksDB marker file. Absent means not a RocksDB store (legacy SurrealKV or empty).
+fn is_rocksdb_store(path: &Path) -> bool {
+    path.join("CURRENT").is_file()
+}
+
+/// If `path` exists but is not a RocksDB store, remove it so a fresh open
+/// succeeds. Also clears session sync markers when wiping a session
+/// `messages.surreal` dir so hybrid re-syncs from SQLite.
+pub(crate) fn ensure_rocksdb_compatible(path: &Path) {
+    if !path.exists() {
+        return;
+    }
+    if is_rocksdb_store(path) {
+        return;
+    }
+    let _ = std::fs::remove_dir_all(path);
+    // If this looks like a session mirror path, drop sync markers so hybrid
+    // re-syncs from the SQLite message log.
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::remove_file(parent.join("messages.surreal.sync.done"));
+        let _ = std::fs::remove_file(parent.join("messages.surreal.sync.lock"));
+    }
+}
+
+// ---------------------------------------------------------------------------
 // open_db — process-wide cache, schema defined once per path
 // ---------------------------------------------------------------------------
 
@@ -154,7 +182,25 @@ pub(crate) async fn open_db(session_dir: &Path) -> anyhow::Result<Surreal<Db>> {
         }
     }
 
-    let db = Surreal::<Db>::new(path_str.clone()).await?;
+    // Wipe legacy SurrealKV store if present — RocksDB cannot open it.
+    ensure_rocksdb_compatible(&db_path);
+
+    let db = match Surreal::new::<RocksDb>(path_str.clone()).await {
+        Ok(db) => db,
+        Err(e) => {
+            // One-shot retry: wipe + reopen. Covers partial/corrupt dirs.
+            let _ = std::fs::remove_dir_all(&db_path);
+            if let Some(parent) = db_path.parent() {
+                let _ = std::fs::remove_file(parent.join("messages.surreal.sync.done"));
+                let _ = std::fs::remove_file(parent.join("messages.surreal.sync.lock"));
+            }
+            crate::model::store::append_global_error_log(
+                "surreal::open_db — first open failed, wiped + retrying",
+                &e.to_string(),
+            );
+            Surreal::new::<RocksDb>(path_str.clone()).await?
+        }
+    };
     db.use_ns("koma").use_db("messages").await?;
 
     // ── Message tables ──────────────────────────────────────────────

--- a/src-agent/src/model/surreal/memory.rs
+++ b/src-agent/src/model/surreal/memory.rs
@@ -692,11 +692,8 @@ mod tests {
 
     #[test]
     fn test_store_and_recall_fact() {
-        // Verify store_fact succeeds and recall_memory doesn't panic.
-        // NOTE: SurrealKV may not make writes visible to subsequent SELECT
-        // queries within the same process lifetime. This is a SurrealDB
-        // engine behavior, not a bug. The store_fact CREATE response
-        // confirms the data is written; recall_memory handles empty results.
+        // After RocksDB swap, store → recall must be visible in the same process.
+        // If this test fails, the engine swap did not fix the visibility bug.
         let dir = std::env::temp_dir().join("koma_test_surreal_memory");
         let _ = std::fs::remove_dir_all(&dir);
         let _ = std::fs::create_dir_all(&dir);
@@ -704,13 +701,19 @@ mod tests {
         let id = store_fact(&dir, "Rust is a systems programming language", "tech", 0.9);
         assert!(id.is_some(), "store_fact should return an id");
 
-        // Second store may return None due to SurrealKV visibility lag within the
-        // same process; this is documented engine behaviour, not a failure.
+        // Second store may return None — with RocksDB the KNN dedup check now
+        // actually sees the first fact, and two programming-language facts can
+        // trigger near-duplicate detection. This is correct engine behavior.
         let _ = store_fact(&dir, "Python is used for ML", "tech", 0.8);
 
-        // recall_memory should not panic, even if HNSW returns empty.
-        let qv = embed_one("programming languages");
-        let _facts = recall_memory(&dir, &qv, 5);
+        // RocksDB must make store_fact visible to recall_memory.
+        let qv = embed_one("systems programming language Rust");
+        let facts = recall_memory(&dir, &qv, 5);
+        assert!(!facts.is_empty(), "RocksDB must make store_fact visible to recall_memory");
+        assert!(
+            facts.iter().any(|f| f.content.contains("Rust")),
+            "recall should find the stored Rust fact"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-agent/src/model/surreal/mod.rs
+++ b/src-agent/src/model/surreal/mod.rs
@@ -1,7 +1,7 @@
 //! SurrealDB hypercharge — persistent context layer for AI agents.
 //!
 //! Four capabilities:
-//! 1. **Persistent storage** (SurrealKV) with incremental sync from SQLite
+//! 1. **Persistent storage** (RocksDB) with incremental sync from SQLite
 //! 2. **Hybrid search** — FTS5 + vector cosine fused via reciprocal rank fusion
 //! 3. **Graph edges** — RELATE for agent orchestration / tool call tracking
 //! 4. **Memory atoms** — fact extraction, trust scoring, knowledge graph


### PR DESCRIPTION
SurrealKV had broken same-process write-then-read visibility. RocksDB is the mature production backend with reliable read-after-write and HNSW concurrency.

- Cargo.toml: kv-surrealkv → kv-rocksdb (requires cmake + clang)
- core.rs: add ensure_rocksdb_compatible() to wipe legacy SurrealKV dirs
- knowledge_daemon.rs: same RocksDb + wipe + retry pattern
- memory.rs: strengthen proof test to assert recall finds stored facts
- Doc cleanup: SurrealKV → RocksDB across 6 files