### PR TITLE
fix: thread OAuthProvider through wait states so TUI

### DIFF
--- a/src-agent/src/app/mode/settings/oauth_types.rs
+++ b/src-agent/src/app/mode/settings/oauth_types.rs
@@ -14,19 +14,23 @@ pub enum OAuthFlowState {
     /// A flow was just started (`Action::OAuthStart`) but the background task
     /// hasn't reported its first event yet (no URL/code to show). Transitional —
     /// swapped for `CodexWait`/`KiloWait` the moment the corresponding
-    /// [`crate::service::oauth::OAuthEvent`] lands.
-    Starting,
+    /// [`crate::service::oauth::OAuthEvent`] lands. `provider` carries the
+    /// chosen provider so the view can render the correct title/port.
+    Starting { provider: OAuthProvider },
     /// Provider picker cursor. Indices (must match TUI OPTIONS in
     /// `view/settings/oauth.rs`):
     /// 0 Codex, 1 Kilo Code, 2 koma.run, 3 xAI, 4 Claude,
     /// 5 Command Code, 6 Codex paste, 7 Command Code paste.
     Pick(usize),
-    /// Codex browser flow: the loopback listener is up and `url` is the
+    /// Browser-based flow: the loopback listener is up and `url` is the
     /// authorization URL (shown so the user can copy it if the browser didn't
-    /// open). `frame` drives the braille spinner, advanced once per tick.
-    /// `copied` flips to `true` after a successful `c` (copy-url) press, so
-    /// the view can show a one-shot confirmation line.
+    /// open). Shared by Codex, Claude, Koma, and Command Code browser flows —
+    /// `provider` determines the title and port. `frame` drives the braille
+    /// spinner, advanced once per tick. `copied` flips to `true` after a
+    /// successful `c` (copy-url) press, so the view can show a one-shot
+    /// confirmation line.
     CodexWait {
+        provider: OAuthProvider,
         url: String,
         frame: u8,
         copied: bool,
@@ -38,10 +42,12 @@ pub enum OAuthFlowState {
         input: String,
         provider: OAuthProvider,
     },
-    /// Kilo Code device flow: waiting for the user to approve `user_code` at
-    /// `verification_url`. `frame` drives the braille spinner. `copied` flips
-    /// to `true` after a successful `c` (copy-url) press.
+    /// Device flow: waiting for the user to approve `user_code` at
+    /// `verification_url`. Shared by Kilo Code and xAI device flows —
+    /// `provider` determines the title. `frame` drives the braille spinner.
+    /// `copied` flips to `true` after a successful `c` (copy-url) press.
     KiloWait {
+        provider: OAuthProvider,
         user_code: String,
         verification_url: String,
         frame: u8,

--- a/src-agent/src/app/runtime/actions/oauth.rs
+++ b/src-agent/src/app/runtime/actions/oauth.rs
@@ -40,8 +40,8 @@ pub(super) fn handle_oauth_start(
 
     // Optimistic transitional paint on whichever oauth-flow-bearing mode is active.
     match state.mode_mut() {
-        Mode::Settings(s) => s.oauth_flow = OAuthFlowState::Starting,
-        Mode::OnboardProvider(op) => op.oauth_flow = OAuthFlowState::Starting,
+        Mode::Settings(s) => s.oauth_flow = OAuthFlowState::Starting { provider },
+        Mode::OnboardProvider(op) => op.oauth_flow = OAuthFlowState::Starting { provider },
         _ => {}
     }
 

--- a/src-agent/src/app/runtime/client/host.rs
+++ b/src-agent/src/app/runtime/client/host.rs
@@ -679,7 +679,7 @@ fn host_swapper<P: Fn(String) + Clone + Send + 'static>(
                         handle.spawn(async move {
                             while let Some(ev) = orx.recv().await {
                                 match ev {
-                                    crate::service::oauth::OAuthEvent::CodexUrl { url } => {
+                                    crate::service::oauth::OAuthEvent::CodexUrl { provider: _, url } => {
                                         let (conns, providers) = build_host_oauth_state();
                                         push_oauth_state(
                                             &push2,
@@ -693,6 +693,7 @@ fn host_swapper<P: Fn(String) + Clone + Send + 'static>(
                                         );
                                     }
                                     crate::service::oauth::OAuthEvent::KiloCode {
+                                        provider: _,
                                         user_code,
                                         verification_url,
                                     } => {

--- a/src-agent/src/app/runtime/client_shadow/settings.rs
+++ b/src-agent/src/app/runtime/client_shadow/settings.rs
@@ -242,19 +242,22 @@ fn shadow_oauth_draft(o: OAuthDraftSnapshot) -> OAuthDraft {
 ///
 /// `pub(super)` — also called from `super::modes::shadow_onboard_provider`.
 pub(super) fn shadow_oauth_flow(s: crate::ipc::proto::OAuthFlowSnapshot) -> OAuthFlowState {
+    let provider = shadow_oauth_provider(&s.provider);
     match s.kind.as_str() {
-        "starting" => OAuthFlowState::Starting,
+        "starting" => OAuthFlowState::Starting { provider },
         "pick" => OAuthFlowState::Pick(s.cursor),
         "codex_wait" => OAuthFlowState::CodexWait {
+            provider,
             url: s.url,
             frame: s.frame,
             copied: s.copied,
         },
         "codex_paste" => OAuthFlowState::CodexPaste {
             input: s.input,
-            provider: crate::model::app_config::OAuthProvider::default(),
+            provider,
         },
         "kilo_wait" => OAuthFlowState::KiloWait {
+            provider,
             user_code: s.user_code,
             verification_url: s.url,
             frame: s.frame,

--- a/src-agent/src/app/runtime/event_loop/daemon/hub/requests_oauth.rs
+++ b/src-agent/src/app/runtime/event_loop/daemon/hub/requests_oauth.rs
@@ -842,13 +842,17 @@ fn run_ext_oauth_delegate(
     };
     match parse_begin(&begin) {
         BeginOutcome::Browser { url } => {
-            let _ = tx.send(OAuthEvent::CodexUrl { url });
+            let _ = tx.send(OAuthEvent::CodexUrl {
+                provider: OAuthProvider::Extension,
+                url,
+            });
         }
         BeginOutcome::Device {
             user_code,
             verification_url,
         } => {
             let _ = tx.send(OAuthEvent::KiloCode {
+                provider: OAuthProvider::Extension,
                 user_code,
                 verification_url,
             });

--- a/src-agent/src/app/runtime/event_loop/global/drains.rs
+++ b/src-agent/src/app/runtime/event_loop/global/drains.rs
@@ -151,9 +151,10 @@ pub(super) fn drain_oauth(state: &mut AppState, handle: &tokio::runtime::Handle)
     let mut dirty = false;
     if let Some(mut orx) = state.rest.oauth_rx.take() {
         match orx.try_recv() {
-            Ok(OAuthEvent::CodexUrl { url }) => {
+            Ok(OAuthEvent::CodexUrl { provider, url }) => {
                 for flow in oauth_flow_states(state) {
                     *flow = OAuthFlowState::CodexWait {
+                        provider,
                         url: url.clone(),
                         frame: 0,
                         copied: false,
@@ -166,11 +167,13 @@ pub(super) fn drain_oauth(state: &mut AppState, handle: &tokio::runtime::Handle)
                 dirty = true;
             }
             Ok(OAuthEvent::KiloCode {
+                provider,
                 user_code,
                 verification_url,
             }) => {
                 for flow in oauth_flow_states(state) {
                     *flow = OAuthFlowState::KiloWait {
+                        provider,
                         user_code: user_code.clone(),
                         verification_url: verification_url.clone(),
                         frame: 0,

--- a/src-agent/src/controller/input/onboard_provider.rs
+++ b/src-agent/src/controller/input/onboard_provider.rs
@@ -39,7 +39,7 @@ pub fn handle_onboard_provider(
 /// but Esc on the picker backs out to the chooser (no idle connections list here).
 fn handle_login(s: &mut OnboardProviderState, key: KeyEvent) -> Action {
     match s.oauth_flow.clone() {
-        OAuthFlowState::Starting
+        OAuthFlowState::Starting { .. }
         | OAuthFlowState::CodexWait { .. }
         | OAuthFlowState::KiloWait { .. } => match key.code {
             KeyCode::Esc => Action::OAuthCancel,

--- a/src-agent/src/controller/input/settings/mod.rs
+++ b/src-agent/src/controller/input/settings/mod.rs
@@ -243,7 +243,7 @@ fn handle_oauth_page(s: &mut SettingsState, key: KeyEvent) -> Action {
 fn handle_oauth_flow(s: &mut SettingsState, key: KeyEvent) -> Action {
     match s.oauth_flow.clone() {
         OAuthFlowState::Idle => Action::None,
-        OAuthFlowState::Starting
+        OAuthFlowState::Starting { .. }
         | OAuthFlowState::CodexWait { .. }
         | OAuthFlowState::KiloWait { .. } => match key.code {
             KeyCode::Esc => Action::OAuthCancel,

--- a/src-agent/src/ipc/proto/snapshot/connector.rs
+++ b/src-agent/src/ipc/proto/snapshot/connector.rs
@@ -109,6 +109,9 @@ pub struct OAuthFlowSnapshot {
     /// `codex_wait`/`kilo_wait`'s "url copied to clipboard" confirmation flag,
     /// set after a successful `c` (copy-url) key press.
     pub copied: bool,
+    /// Provider wire id for `starting`/`codex_wait`/`kilo_wait`/`codex_paste`
+    /// states (`"codex"`, `"xai"`, etc.). Empty when N/A (idle, pick, failed).
+    pub provider: String,
 }
 
 /// A serde-safe projection of one model draft.

--- a/src-agent/src/ipc/snapshot/projection/modes.rs
+++ b/src-agent/src/ipc/snapshot/projection/modes.rs
@@ -303,8 +303,9 @@ pub fn oauth_flow_snapshot(
             kind: "idle".to_string(),
             ..Default::default()
         },
-        OAuthFlowState::Starting => OAuthFlowSnapshot {
+        OAuthFlowState::Starting { provider } => OAuthFlowSnapshot {
             kind: "starting".to_string(),
+            provider: provider.wire_id().to_string(),
             ..Default::default()
         },
         OAuthFlowState::Pick(cursor) => OAuthFlowSnapshot {
@@ -312,25 +313,29 @@ pub fn oauth_flow_snapshot(
             cursor: *cursor,
             ..Default::default()
         },
-        OAuthFlowState::CodexWait { url, frame, copied } => OAuthFlowSnapshot {
+        OAuthFlowState::CodexWait { provider, url, frame, copied } => OAuthFlowSnapshot {
             kind: "codex_wait".to_string(),
+            provider: provider.wire_id().to_string(),
             url: url.clone(),
             frame: *frame,
             copied: *copied,
             ..Default::default()
         },
-        OAuthFlowState::CodexPaste { input, .. } => OAuthFlowSnapshot {
+        OAuthFlowState::CodexPaste { input, provider, .. } => OAuthFlowSnapshot {
             kind: "codex_paste".to_string(),
             input: input.clone(),
+            provider: provider.wire_id().to_string(),
             ..Default::default()
         },
         OAuthFlowState::KiloWait {
+            provider,
             user_code,
             verification_url,
             frame,
             copied,
         } => OAuthFlowSnapshot {
             kind: "kilo_wait".to_string(),
+            provider: provider.wire_id().to_string(),
             url: verification_url.clone(),
             user_code: user_code.clone(),
             frame: *frame,

--- a/src-agent/src/service/oauth/flow.rs
+++ b/src-agent/src/service/oauth/flow.rs
@@ -22,12 +22,12 @@ use crate::model::app_config::OAuthProvider;
 /// provider means adding one arm here, not touching either caller.
 pub async fn run_flow(provider: OAuthProvider, tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
     match provider {
-        OAuthProvider::Codex => run_codex_flow(tx).await,
-        OAuthProvider::Kilocode => run_kilo_flow(tx).await,
-        OAuthProvider::Xai => run_xai_flow(tx).await,
-        OAuthProvider::ClaudeAI => run_claude_flow(tx).await,
-        OAuthProvider::KomaRun => run_komarun_flow(tx).await,
-        OAuthProvider::CommandCode => run_commandcode_flow(tx).await,
+        OAuthProvider::Codex => run_codex_flow(provider, tx).await,
+        OAuthProvider::Kilocode => run_kilo_flow(provider, tx).await,
+        OAuthProvider::Xai => run_xai_flow(provider, tx).await,
+        OAuthProvider::ClaudeAI => run_claude_flow(provider, tx).await,
+        OAuthProvider::KomaRun => run_komarun_flow(provider, tx).await,
+        OAuthProvider::CommandCode => run_commandcode_flow(provider, tx).await,
         // W11: an extension-delegated flow is NEVER driven through here — it runs
         // off-loop in the daemon hub (`requests_oauth::run_ext_oauth_delegate`), keyed
         // by an `ext:<id>:<provider>` picker id, and never via `Action::OAuthStart`
@@ -46,9 +46,10 @@ pub async fn run_flow(provider: OAuthProvider, tx: tokio::sync::mpsc::UnboundedS
 /// wait on the loopback redirect, then exchange the code for tokens. Sends exactly one
 /// terminal event (`Success` or `Failed`) after an initial `CodexUrl`; a dropped
 /// receiver (flow superseded/cancelled) makes every send a silent no-op.
-async fn run_codex_flow(tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
+async fn run_codex_flow(provider: OAuthProvider, tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
     let auth = super::codex::build_auth_url();
     let _ = tx.send(OAuthEvent::CodexUrl {
+        provider,
         url: auth.url.clone(),
     });
     super::browser::open_in_browser(&auth.url);
@@ -79,9 +80,10 @@ async fn run_codex_flow(tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
 /// The Claude (Anthropic) browser flow: build the PKCE authorization URL, open the
 /// system browser, wait on the loopback redirect (port 54545), then exchange the code
 /// for tokens. Mirrors `run_codex_flow` exactly, against Anthropic's own endpoints.
-async fn run_claude_flow(tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
+async fn run_claude_flow(provider: OAuthProvider, tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
     let auth = super::claude::build_auth_url();
     let _ = tx.send(OAuthEvent::CodexUrl {
+        provider,
         url: auth.url.clone(),
     });
     super::browser::open_in_browser(&auth.url);
@@ -114,9 +116,10 @@ async fn run_claude_flow(tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
 /// browser, wait on the loopback redirect (port 51004), then exchange the code for
 /// tokens. Mirrors `run_claude_flow` exactly, against koma.run's own (form-encoded, no
 /// client_id/scope) endpoints.
-async fn run_komarun_flow(tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
+async fn run_komarun_flow(provider: OAuthProvider, tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
     let auth = super::komarun::build_auth_url();
     let _ = tx.send(OAuthEvent::CodexUrl {
+        provider,
         url: auth.url.clone(),
     });
     super::browser::open_in_browser(&auth.url);
@@ -149,7 +152,7 @@ async fn run_komarun_flow(tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
 /// The Kilo Code device flow: request a device code, open the system browser to its
 /// verification URL, poll for approval, then fetch the profile (org id / email) to
 /// label the connection. Sends exactly one terminal event after an initial `KiloCode`.
-async fn run_kilo_flow(tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
+async fn run_kilo_flow(provider: OAuthProvider, tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
     let http = reqwest::Client::new();
     let dc = match super::kilo::device_init(&http).await {
         Ok(dc) => dc,
@@ -159,6 +162,7 @@ async fn run_kilo_flow(tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
         }
     };
     let _ = tx.send(OAuthEvent::KiloCode {
+        provider,
         user_code: dc.code.clone(),
         verification_url: dc.verification_url.clone(),
     });
@@ -181,7 +185,7 @@ async fn run_kilo_flow(tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
 /// returned access + refresh token set. Reuses the `KiloCode` event as the generic
 /// device-code carrier (`user_code` + `verification_url`). Sends exactly one terminal
 /// event after an initial `KiloCode`.
-async fn run_xai_flow(tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
+async fn run_xai_flow(provider: OAuthProvider, tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
     let http = reqwest::Client::new();
     let dc = match super::xai::device_init(&http).await {
         Ok(dc) => dc,
@@ -191,6 +195,7 @@ async fn run_xai_flow(tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
         }
     };
     let _ = tx.send(OAuthEvent::KiloCode {
+        provider,
         user_code: dc.user_code.clone(),
         verification_url: dc.verification_url.clone(),
     });
@@ -211,7 +216,7 @@ async fn run_xai_flow(tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
 /// authorization URL in the browser, wait for the Studio website to POST the
 /// API key back. Sends exactly one terminal event after an initial `CodexUrl`
 /// (reused as the generic browser-URL carrier).
-async fn run_commandcode_flow(tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
+async fn run_commandcode_flow(provider: OAuthProvider, tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>) {
     let state = super::commandcode::generate_state();
     let timeout = super::registry::COMMANDCODE_AUTH_TIMEOUT_SECS;
 
@@ -226,6 +231,7 @@ async fn run_commandcode_flow(tx: tokio::sync::mpsc::UnboundedSender<OAuthEvent>
 
     let auth_url = super::commandcode::build_auth_url(port, &state);
     let _ = tx.send(OAuthEvent::CodexUrl {
+        provider,
         url: auth_url.clone(),
     });
     super::browser::open_in_browser(&auth_url);

--- a/src-agent/src/service/oauth/mod.rs
+++ b/src-agent/src/service/oauth/mod.rs
@@ -26,7 +26,7 @@ pub mod pkce;
 pub mod registry;
 pub mod xai;
 
-use crate::model::app_config::OAuthConn;
+use crate::model::app_config::{OAuthConn, OAuthProvider};
 
 /// Lifecycle events emitted by an in-flight `/settings` OAuth submenu connect
 /// flow (Codex browser login, or a Kilo Code / xAI device login). Sent across
@@ -40,13 +40,17 @@ use crate::model::app_config::OAuthConn;
 /// (W11 grew `OAuthConn` by two `Option<String>`s, nudging it past clippy's threshold.)
 #[allow(clippy::large_enum_variant)]
 pub enum OAuthEvent {
-    /// The Codex flow reached the "open this URL" step (loopback listener is up).
-    CodexUrl { url: String },
+    /// The browser flow reached the "open this URL" step (loopback listener is up).
+    /// `provider` identifies the originating provider so the drain can title/label
+    /// the wait screen correctly (shared by Codex, Claude, Koma, Command Code).
+    CodexUrl { provider: OAuthProvider, url: String },
     /// A device flow issued a device code the user must approve. Reused as the
     /// generic device-code carrier for BOTH Kilo Code and xAI (Grok) — both show
     /// a `user_code` + a `verification_url`, and the downstream wait screen / GUI
     /// `waiting_code` push are identical, so no separate variant is warranted.
+    /// `provider` identifies the originating provider for correct titling.
     KiloCode {
+        provider: OAuthProvider,
         user_code: String,
         verification_url: String,
     },

--- a/src-agent/src/view/onboard_provider.rs
+++ b/src-agent/src/view/onboard_provider.rs
@@ -30,6 +30,19 @@ const BLOCK_W: u16 = 64;
 /// Braille spinner frames (matches the `/settings` OAuth wait screens).
 const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
+/// Return the fixed loopback port for providers that bind one, or `None` for
+/// providers whose port is dynamic (Command Code) or that don't use a loopback.
+fn wait_port(p: crate::model::app_config::OAuthProvider) -> Option<u16> {
+    use crate::model::app_config::OAuthProvider;
+    use crate::service::oauth::registry::*;
+    match p {
+        OAuthProvider::Codex => Some(CODEX_PORT),
+        OAuthProvider::ClaudeAI => Some(CLAUDE_PORT),
+        OAuthProvider::KomaRun => Some(KOMA_PORT),
+        _ => None,
+    }
+}
+
 /// Render the wizard for `state`.
 pub fn draw(
     frame: &mut Frame,
@@ -119,48 +132,59 @@ fn draw_login(frame: &mut Frame, flow: &OAuthFlowState, palette: &Palette, area:
         // No idle "connections list" in the wizard — Idle falls back to the picker.
         OAuthFlowState::Idle => draw_picker(frame, 0, palette, area),
         OAuthFlowState::Pick(cursor) => draw_picker(frame, *cursor, palette, area),
-        OAuthFlowState::Starting => draw_message(
+        OAuthFlowState::Starting { provider } => draw_message(
             frame,
             palette,
             area,
-            &format!("{} starting login…", SPINNER[0]),
+            &format!("{} {} starting login…", SPINNER[0], provider.label()),
             None,
             false,
         ),
         OAuthFlowState::CodexWait {
+            provider,
             url,
             frame: f,
             copied,
-        } => draw_message(
-            frame,
-            palette,
-            area,
-            &format!(
-                "{} waiting for browser · listening on localhost:{}",
-                SPINNER[(*f as usize) % SPINNER.len()],
-                crate::service::oauth::registry::CODEX_PORT,
-            ),
-            Some(url),
-            *copied,
-        ),
+        } => {
+            let label = provider.label();
+            let status = match wait_port(*provider) {
+                Some(port) => format!(
+                    "{} waiting for browser · {} listening on localhost:{}",
+                    SPINNER[(*f as usize) % SPINNER.len()],
+                    label,
+                    port,
+                ),
+                None => format!(
+                    "{} waiting for browser · {}",
+                    SPINNER[(*f as usize) % SPINNER.len()],
+                    label,
+                ),
+            };
+            draw_message(frame, palette, area, &status, Some(url), *copied)
+        }
         OAuthFlowState::CodexPaste { input, .. } => draw_paste(frame, input, palette, area),
         OAuthFlowState::KiloWait {
+            provider,
             user_code,
             verification_url,
             frame: f,
             copied,
-        } => draw_message(
-            frame,
-            palette,
-            area,
-            &format!(
-                "{} approve in browser · code: {}",
-                SPINNER[(*f as usize) % SPINNER.len()],
-                user_code,
-            ),
-            Some(verification_url),
-            *copied,
-        ),
+        } => {
+            let label = provider.label();
+            draw_message(
+                frame,
+                palette,
+                area,
+                &format!(
+                    "{} approve in browser · {} · code: {}",
+                    SPINNER[(*f as usize) % SPINNER.len()],
+                    label,
+                    user_code,
+                ),
+                Some(verification_url),
+                *copied,
+            )
+        }
         OAuthFlowState::Failed(msg) => draw_failed(frame, msg, palette, area),
     }
 }

--- a/src-agent/src/view/settings/mod.rs
+++ b/src-agent/src/view/settings/mod.rs
@@ -216,19 +216,22 @@ pub fn draw(
             OAuthFlowState::Pick(cursor) => {
                 oauth::draw_picker(frame, *cursor, palette, body);
             }
-            OAuthFlowState::CodexWait { url, copied, .. } => {
-                oauth::draw_message(frame, palette, body, "codex login", Some(url), *copied);
+            OAuthFlowState::CodexWait { provider, url, copied, .. } => {
+                let title = format!("{} login", provider.label());
+                oauth::draw_message(frame, palette, body, &title, Some(url), *copied);
             }
             OAuthFlowState::KiloWait {
+                provider,
                 verification_url,
                 copied,
                 ..
             } => {
+                let title = format!("{} login", provider.label());
                 oauth::draw_message(
                     frame,
                     palette,
                     body,
-                    "kilo code login",
+                    &title,
                     Some(verification_url),
                     *copied,
                 );
@@ -239,8 +242,9 @@ pub fn draw(
             OAuthFlowState::Failed(msg) => {
                 oauth::draw_failed(frame, msg, palette, body);
             }
-            OAuthFlowState::Starting => {
-                oauth::draw_message(frame, palette, body, "starting login\u{2026}", None, false);
+            OAuthFlowState::Starting { provider } => {
+                let title = format!("starting {} login\u{2026}", provider.label());
+                oauth::draw_message(frame, palette, body, &title, None, false);
             }
             _ => {}
         }

--- a/src-agent/src/view/settings/pages/oauth.rs
+++ b/src-agent/src/view/settings/pages/oauth.rs
@@ -18,6 +18,20 @@ use crate::view::theme::Palette;
 /// Braille spinner frames, matching the `/security` panel's in-flight probe glyph.
 const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
+/// Return the fixed loopback port for providers that bind one, or `None` for
+/// providers whose port is dynamic (Command Code) or that don't use a loopback.
+fn wait_port(p: crate::model::app_config::OAuthProvider) -> Option<u16> {
+    use crate::model::app_config::OAuthProvider;
+    use crate::service::oauth::registry::*;
+    match p {
+        OAuthProvider::Codex => Some(CODEX_PORT),
+        OAuthProvider::ClaudeAI => Some(CLAUDE_PORT),
+        OAuthProvider::KomaRun => Some(KOMA_PORT),
+        // Command Code binds dynamically in a range — omit specific port.
+        _ => None,
+    }
+}
+
 /// Pull the parenthesized identity out of an `OAuthDraft::label` like
 /// `"codex (foo@bar.com)"` → `"foo@bar.com"`. Falls back to the whole label if it
 /// doesn't match that shape.
@@ -44,49 +58,63 @@ pub(crate) fn draw_oauth_page(
 
     match &st.oauth_flow {
         OAuthFlowState::Idle => draw_list(frame, st, palette, area),
-        OAuthFlowState::Starting => draw_message(
-            frame,
-            palette,
-            area,
-            &format!("{} starting login…", SPINNER[0]),
-            None,
-            false,
-        ),
+        OAuthFlowState::Starting { provider } => {
+            let label = provider.label();
+            draw_message(
+                frame,
+                palette,
+                area,
+                &format!("{} {} starting login…", SPINNER[0], label),
+                None,
+                false,
+            )
+        }
         OAuthFlowState::Pick(cursor) => draw_picker(frame, *cursor, palette, area),
         OAuthFlowState::CodexWait {
+            provider,
             url,
             frame: f,
             copied,
-        } => draw_message(
-            frame,
-            palette,
-            area,
-            &format!(
-                "{} waiting for browser · listening on localhost:{}",
-                SPINNER[(*f as usize) % SPINNER.len()],
-                crate::service::oauth::registry::CODEX_PORT,
-            ),
-            Some(url),
-            *copied,
-        ),
+        } => {
+            let label = provider.label();
+            let status = match wait_port(*provider) {
+                Some(port) => format!(
+                    "{} waiting for browser · {} listening on localhost:{}",
+                    SPINNER[(*f as usize) % SPINNER.len()],
+                    label,
+                    port,
+                ),
+                None => format!(
+                    "{} waiting for browser · {}",
+                    SPINNER[(*f as usize) % SPINNER.len()],
+                    label,
+                ),
+            };
+            draw_message(frame, palette, area, &status, Some(url), *copied)
+        }
         OAuthFlowState::CodexPaste { input, .. } => draw_paste(frame, input, palette, area),
         OAuthFlowState::KiloWait {
+            provider,
             user_code,
             verification_url,
             frame: f,
             copied,
-        } => draw_message(
-            frame,
-            palette,
-            area,
-            &format!(
-                "{} approve in browser · code: {}",
-                SPINNER[(*f as usize) % SPINNER.len()],
-                user_code,
-            ),
-            Some(verification_url),
-            *copied,
-        ),
+        } => {
+            let label = provider.label();
+            draw_message(
+                frame,
+                palette,
+                area,
+                &format!(
+                    "{} approve in browser · {} · code: {}",
+                    SPINNER[(*f as usize) % SPINNER.len()],
+                    label,
+                    user_code,
+                ),
+                Some(verification_url),
+                *copied,
+            )
+        }
         OAuthFlowState::Failed(msg) => draw_failed(frame, msg, palette, area),
     }
 }


### PR DESCRIPTION
fixes the IPC snapshot: OAuthFlowSnapshot.provider field enables thin clients to reconstruct correct titles under --attach, and shadow_oauth_flow now decodes the real provider for codex_paste (was forced to Codex default).

Affected: settings overlay, page body, onboard wizard, host GUI path, extension-delegated flow, controller input match sites (15 files).