### PR TITLE
fix: Linux prebuilt crash — glibc 2.35 baseline + launcher preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,20 @@ name: release
 #
 # All builds ship the GUI feature by default (default = ["gui"] in Cargo.toml),
 # so `koma gui` works out of the box on every platform. Linux raw binaries
-# bundle webkit2gtk; Darwin uses the system WebKit; Windows uses WebView2.
+# link against system webkit2gtk (not bundled); Darwin uses the system WebKit;
+# Windows uses WebView2.
 #
 # The linux-packages / windows-package jobs additionally publish desktop
 # installers under STABLE, VERSIONLESS names (hard-linked from the homepage via
 # /releases/latest/download/): koma-x64.deb, koma-arm64.deb, koma-x64.AppImage,
 # koma-arm64.AppImage, koma-x64.msi, plus the raw koma-windows-x64.exe.
 # These are NOT referenced by install.sh.
+#
+# IMPORTANT: Linux runners are pinned to ubuntu-22.04 (glibc 2.35) so that
+# prebuilt binaries run on Ubuntu 22.04 LTS and all newer releases. Glibc is
+# backward-compatible: a binary linked against 2.35 runs on 2.35+ but NOT on
+# older systems. Building on ubuntu-latest (24.04 / glibc 2.39) would produce
+# binaries that crash with "GLIBC_2.38/2.39 not found" on Jammy.
 on:
   push:
     tags:
@@ -29,13 +36,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # ----- Linux -----
-          - os: ubuntu-latest
+          # ----- Linux (pinned to 22.04 for glibc 2.35 baseline) -----
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             asset: koma-linux-x64
             cross: false
             buildflags: ""
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             asset: koma-linux-arm64
             cross: true
@@ -116,9 +123,8 @@ jobs:
   # names embed the version (e.g. koma_0.2.27_amd64.deb), so a rename step maps
   # them to the stable versionless homepage names.
   #
-  # NOTE: `ubuntu-24.04-arm` is a GitHub-hosted arm64 runner. It is free for
-  # PUBLIC repos (this repo is public); private repos would need a paid larger-
-  # runner plan for the arm label.
+  # Pinned to ubuntu-22.04 / ubuntu-22.04-arm for the same glibc 2.35 floor as
+  # the raw binary jobs above.
   # ---------------------------------------------------------------------------
   linux-packages:
     name: package linux ${{ matrix.arch }} (deb + appimage)
@@ -127,9 +133,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-24.04
+          - runner: ubuntu-22.04
             arch: x64
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-22.04
             arch: arm64
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Works on Linux, macOS, and Windows. On Windows, run that same command from a Git
 The `koma gui` desktop client (a wry webview hosting xterm.js) is behind the `gui` cargo feature at build time, but you don't need to build it yourself on most platforms:
 
 - **macOS** — the install.sh binary already has `gui` baked in; `koma gui` just works.
-- **Linux** — the raw install.sh binary is TUI-only (webkitgtk isn't safe to hard-link into a binary meant to run on headless servers). Grab the `.deb` or `.AppImage` instead; both are `gui`-featured and add a desktop entry that launches straight into `koma gui`.
+- **Linux** — the raw install.sh binary is GUI-featured but requires `libwebkit2gtk-4.1-0` and `libgtk-3-0` at runtime. On Linux, install.sh ships a launcher (`koma`) that checks for these libraries and prints install commands if they are missing. If you prefer a package that handles dependencies automatically, grab the `.deb` or `.AppImage` instead; both are `gui`-featured and add a desktop entry that launches straight into `koma gui`. Prebuilt Linux binaries target **glibc 2.35 (Ubuntu 22.04 LTS)** and run on 22.04 and all newer releases.
 - **Windows** — the `.msi` installer is the GUI build (it installs the WebView2 runtime for you if it's missing; WebView2 ships with Windows 11 and most patched Windows 10 machines already). The raw `koma-windows-x64.exe` from install.sh is TUI-only.
 
 Grab the platform installer from the [latest release](https://github.com/aula-id/koma/releases/latest): `koma-x64.deb` / `koma-arm64.deb`, `koma-x64.AppImage` / `koma-arm64.AppImage`, `koma-x64.msi`.

--- a/build.sh
+++ b/build.sh
@@ -108,8 +108,22 @@ if [ "$_os" = "Darwin" ] && command -v xattr > /dev/null 2>&1; then
     xattr -d com.apple.quarantine "$bin" 2>/dev/null || true
 fi
 
+# ---------------------------------------------------------------------------
+# Linux: wrap the real ELF with a launcher script that preflights shared libs
+# (missing webkit/gtk, too-old glibc) before the dynamic linker can crash.
+# On macOS, skip — system WebKit is always available.
+# ---------------------------------------------------------------------------
+launcher="$bin"   # final PATH entry (launcher on Linux, bare binary on macOS)
+
+if [ "$_os" = "Linux" ]; then
+    mv "$bin" "${bin}.bin"
+    cp packaging/linux/koma-launcher.sh "$bin"
+    chmod +x "$bin"
+    launcher="$bin"
+fi
+
 echo ""
-echo "Build complete: $bin"
+echo "Build complete: $launcher"
 
 # ---------------------------------------------------------------------------
 # Optional install to $INSTALL_DIR.
@@ -118,29 +132,50 @@ echo "Build complete: $bin"
 if [ "$DO_INSTALL" = "1" ]; then
     echo ""
     echo "Installing to $INSTALL_DIR/koma ..."
-    if [ -w "$INSTALL_DIR" ]; then
-        cp "$bin" "$INSTALL_DIR/koma"
-        chmod +x "$INSTALL_DIR/koma"
-    else
-        echo "  $INSTALL_DIR is not writable; using sudo for the copy step."
-        sudo cp "$bin" "$INSTALL_DIR/koma"
-        sudo chmod +x "$INSTALL_DIR/koma"
-    fi
-    # Re-strip quarantine on the installed copy (macOS).
-    if [ "$_os" = "Darwin" ] && command -v xattr > /dev/null 2>&1; then
-        if [ -w "$INSTALL_DIR/koma" ]; then
-            xattr -d com.apple.quarantine "$INSTALL_DIR/koma" 2>/dev/null || true
+    if [ "$_os" = "Linux" ]; then
+        # Linux: install both launcher and real binary.
+        if [ -w "$INSTALL_DIR" ]; then
+            cp "$bin" "$INSTALL_DIR/koma"
+            cp "${bin}.bin" "$INSTALL_DIR/koma.bin"
+            chmod +x "$INSTALL_DIR/koma"
         else
-            sudo xattr -d com.apple.quarantine "$INSTALL_DIR/koma" 2>/dev/null || true
+            echo "  $INSTALL_DIR is not writable; using sudo for the copy step."
+            sudo cp "$bin" "$INSTALL_DIR/koma"
+            sudo cp "${bin}.bin" "$INSTALL_DIR/koma.bin"
+            sudo chmod +x "$INSTALL_DIR/koma"
+        fi
+        # Remove any stale bare-ELF koma from older installs (would shadow
+        # the launcher if someone manually placed a binary there before).
+    else
+        # macOS: single binary, no launcher needed.
+        if [ -w "$INSTALL_DIR" ]; then
+            cp "$bin" "$INSTALL_DIR/koma"
+            chmod +x "$INSTALL_DIR/koma"
+        else
+            echo "  $INSTALL_DIR is not writable; using sudo for the copy step."
+            sudo cp "$bin" "$INSTALL_DIR/koma"
+            sudo chmod +x "$INSTALL_DIR/koma"
+        fi
+        # Re-strip quarantine on the installed copy.
+        if command -v xattr > /dev/null 2>&1; then
+            if [ -w "$INSTALL_DIR/koma" ]; then
+                xattr -d com.apple.quarantine "$INSTALL_DIR/koma" 2>/dev/null || true
+            else
+                sudo xattr -d com.apple.quarantine "$INSTALL_DIR/koma" 2>/dev/null || true
+            fi
         fi
     fi
     echo "Installed: $INSTALL_DIR/koma"
     echo "Run 'koma' to start."
 else
     echo ""
-    echo "  Run it:        ./$bin"
+    echo "  Run it:        ./$launcher"
     echo "  Install it:    ./build.sh --install      (copies to $INSTALL_DIR)"
-    echo "  Or by hand:    sudo cp $bin $INSTALL_DIR/koma"
+    if [ "$_os" = "Linux" ]; then
+        echo "  Or by hand:    sudo cp $launcher ${bin}.bin $INSTALL_DIR/"
+    else
+        echo "  Or by hand:    sudo cp $bin $INSTALL_DIR/koma"
+    fi
 fi
 
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -125,17 +125,271 @@ chmod +x "$tmp"
 
 # ---------------------------------------------------------------------------
 # Install — fall back to sudo if the directory is not user-writable
+#
+# On Linux: install the real ELF as koma.bin and a shell launcher as koma.
+# The launcher preflights shared-library availability (missing webkit/gtk,
+# too-old glibc) before the dynamic linker crashes.  macOS / Windows:
+# single binary named koma / koma.exe.
 # ---------------------------------------------------------------------------
 mkdir -p "$INSTALL_DIR" 2>/dev/null || true
-if [ -w "$INSTALL_DIR" ]; then
-    mv "$tmp" "$INSTALL_DIR/$bin_name"
+
+if [ "$os" = "linux" ]; then
+    # Linux: two-file layout — koma (launcher) + koma.bin (real ELF).
+    _install_linux_binary() {
+        mv "$tmp" "$INSTALL_DIR/koma.bin"
+        # --- embedded launcher — keep in sync with packaging/linux/koma-launcher.sh ---
+        cat > "$INSTALL_DIR/koma" << 'KOMA_LAUNCHER'
+#!/bin/sh
+# koma launcher — preflight shared libs before the dynamic linker crashes.
+# Keep in sync with packaging/linux/koma-launcher.sh
+set -e
+resolve_dir() {
+    _src="$0"
+    while [ -L "$_src" ]; do
+        _dir="$(cd -P "$(dirname -- "$_src")" && pwd)"
+        _src="$(readlink -- "$_src")"
+        case "$_src" in
+            /*) ;;
+            *)  _src="$_dir/$_src" ;;
+        esac
+    done
+    cd -P "$(dirname -- "$_src")" && pwd
+}
+DIR="$(resolve_dir)"
+BIN="$DIR/koma.bin"
+if [ ! -f "$BIN" ]; then
+    echo "koma: $BIN not found." >&2
+    echo "The koma launcher expects the real binary alongside itself as koma.bin." >&2
+    exit 1
+fi
+if [ ! -x "$BIN" ]; then
+    echo "koma: $BIN is not executable." >&2
+    echo "Run: chmod +x $BIN" >&2
+    exit 1
+fi
+ldd_out=""
+ldd_ok=0
+if command -v ldd >/dev/null 2>&1; then
+    ldd_out="$(ldd "$BIN" 2>&1)" && ldd_ok=1 || ldd_ok=0
+fi
+if [ "$ldd_ok" = "1" ] && echo "$ldd_out" | grep -q "not a dynamic executable"; then
+    exec "$BIN" "$@"
+fi
+if [ "$ldd_ok" = "1" ] && ! echo "$ldd_out" | grep -q "not found"; then
+    exec "$BIN" "$@"
+fi
+glibc_needed=""
+missing_libs=""
+if [ "$ldd_out" != "" ]; then
+    glibc_needed=$(echo "$ldd_out" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -uV | tr '\n' ' ')
+    missing_libs=$(echo "$ldd_out" | grep "not found" | grep -v 'GLIBC_' | awk '{print $1}' | sort -u)
+fi
+if [ -n "$glibc_needed" ]; then
+    echo "" >&2
+    echo "koma: prebuilt binary requires a newer glibc than this system provides." >&2
+    echo "" >&2
+    if ldd --version >/dev/null 2>&1; then
+        _glibcv="$(ldd --version 2>&1 | head -1)"
+        echo "  Host:    $_glibcv" >&2
+    fi
+    echo "  Need:    glibc $glibc_needed" >&2
+    echo "" >&2
+    echo "You have two options:" >&2
+    echo "" >&2
+    echo "  1. Build from source on this machine (links against your local glibc):" >&2
+    echo "     git clone https://github.com/aula-id/koma.git && cd koma" >&2
+    echo "     ./build.sh" >&2
+    echo "" >&2
+    echo "  2. Use Ubuntu 22.04 LTS or newer (ships glibc 2.35+)." >&2
+    echo "" >&2
+    if [ -n "$missing_libs" ]; then
+        echo "Additional missing libraries:" >&2
+        echo "$missing_libs" | sed 's/^/  /' >&2
+        echo "" >&2
+    fi
+    exit 127
+fi
+if [ -n "$missing_libs" ]; then
+    has_webkit=0
+    has_gtk=0
+    echo "$missing_libs" | grep -q 'libwebkit2gtk' && has_webkit=1
+    echo "$missing_libs" | grep -q 'libgtk-3' && has_gtk=1
+    if [ "$has_webkit" = "1" ] || [ "$has_gtk" = "1" ]; then
+        echo "" >&2
+        echo "koma: missing system libraries required for the GUI." >&2
+        echo "" >&2
+        echo "Install them with your package manager:" >&2
+        echo "" >&2
+        if command -v apt-get >/dev/null 2>&1; then
+            echo "  sudo apt-get install -y libwebkit2gtk-4.1-0 libgtk-3-0" >&2
+        elif command -v dnf >/dev/null 2>&1; then
+            echo "  sudo dnf install webkit2gtk4.1 gtk3" >&2
+        elif command -v pacman >/dev/null 2>&1; then
+            echo "  sudo pacman -S webkit2gtk-4.1 gtk3" >&2
+        elif command -v zypper >/dev/null 2>&1; then
+            echo "  sudo zypper install libwebkit2gtk-4_1-0 libgtk-3-0" >&2
+        else
+            echo "  # Debian/Ubuntu:" >&2
+            echo "  sudo apt-get install -y libwebkit2gtk-4.1-0 libgtk-3-0" >&2
+            echo "  # Fedora:" >&2
+            echo "  sudo dnf install webkit2gtk4.1 gtk3" >&2
+            echo "  # Arch:" >&2
+            echo "  sudo pacman -S webkit2gtk-4.1 gtk3" >&2
+        fi
+        echo "" >&2
+        echo "(Package names may vary by distro/version.)" >&2
+        echo "" >&2
+    else
+        echo "" >&2
+        echo "koma: missing shared libraries:" >&2
+        echo "$ldd_out" | grep "not found" | sed 's/^/  /' >&2
+        echo "" >&2
+        echo "Install the missing libraries via your package manager." >&2
+        echo "" >&2
+    fi
+    exit 127
+fi
+exec "$BIN" "$@"
+KOMA_LAUNCHER
+        chmod +x "$INSTALL_DIR/koma"
+    }
+
+    if [ -w "$INSTALL_DIR" ]; then
+        _install_linux_binary
+    else
+        if [ "$(id -u)" = "0" ]; then
+            _install_linux_binary
+        else
+            echo "  $INSTALL_DIR is not writable; using sudo for install step."
+            _tmp_launcher=$(mktemp)
+            cat > "$_tmp_launcher" << 'KOMA_LAUNCHER'
+#!/bin/sh
+# koma launcher — preflight shared libs before the dynamic linker crashes.
+# Keep in sync with packaging/linux/koma-launcher.sh
+set -e
+resolve_dir() {
+    _src="$0"
+    while [ -L "$_src" ]; do
+        _dir="$(cd -P "$(dirname -- "$_src")" && pwd)"
+        _src="$(readlink -- "$_src")"
+        case "$_src" in
+            /*) ;;
+            *)  _src="$_dir/$_src" ;;
+        esac
+    done
+    cd -P "$(dirname -- "$_src")" && pwd
+}
+DIR="$(resolve_dir)"
+BIN="$DIR/koma.bin"
+if [ ! -f "$BIN" ]; then
+    echo "koma: $BIN not found." >&2
+    exit 1
+fi
+if [ ! -x "$BIN" ]; then
+    echo "koma: $BIN is not executable." >&2
+    echo "Run: chmod +x $BIN" >&2
+    exit 1
+fi
+ldd_out=""
+ldd_ok=0
+if command -v ldd >/dev/null 2>&1; then
+    ldd_out="$(ldd "$BIN" 2>&1)" && ldd_ok=1 || ldd_ok=0
+fi
+if [ "$ldd_ok" = "1" ] && echo "$ldd_out" | grep -q "not a dynamic executable"; then
+    exec "$BIN" "$@"
+fi
+if [ "$ldd_ok" = "1" ] && ! echo "$ldd_out" | grep -q "not found"; then
+    exec "$BIN" "$@"
+fi
+glibc_needed=""
+missing_libs=""
+if [ "$ldd_out" != "" ]; then
+    glibc_needed=$(echo "$ldd_out" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -uV | tr '\n' ' ')
+    missing_libs=$(echo "$ldd_out" | grep "not found" | grep -v 'GLIBC_' | awk '{print $1}' | sort -u)
+fi
+if [ -n "$glibc_needed" ]; then
+    echo "" >&2
+    echo "koma: prebuilt binary requires a newer glibc than this system provides." >&2
+    echo "" >&2
+    if ldd --version >/dev/null 2>&1; then
+        _glibcv="$(ldd --version 2>&1 | head -1)"
+        echo "  Host:    $_glibcv" >&2
+    fi
+    echo "  Need:    glibc $glibc_needed" >&2
+    echo "" >&2
+    echo "You have two options:" >&2
+    echo "" >&2
+    echo "  1. Build from source on this machine (links against your local glibc):" >&2
+    echo "     git clone https://github.com/aula-id/koma.git && cd koma" >&2
+    echo "     ./build.sh" >&2
+    echo "" >&2
+    echo "  2. Use Ubuntu 22.04 LTS or newer (ships glibc 2.35+)." >&2
+    echo "" >&2
+    if [ -n "$missing_libs" ]; then
+        echo "Additional missing libraries:" >&2
+        echo "$missing_libs" | sed 's/^/  /' >&2
+        echo "" >&2
+    fi
+    exit 127
+fi
+if [ -n "$missing_libs" ]; then
+    has_webkit=0
+    has_gtk=0
+    echo "$missing_libs" | grep -q 'libwebkit2gtk' && has_webkit=1
+    echo "$missing_libs" | grep -q 'libgtk-3' && has_gtk=1
+    if [ "$has_webkit" = "1" ] || [ "$has_gtk" = "1" ]; then
+        echo "" >&2
+        echo "koma: missing system libraries required for the GUI." >&2
+        echo "" >&2
+        echo "Install them with your package manager:" >&2
+        echo "" >&2
+        if command -v apt-get >/dev/null 2>&1; then
+            echo "  sudo apt-get install -y libwebkit2gtk-4.1-0 libgtk-3-0" >&2
+        elif command -v dnf >/dev/null 2>&1; then
+            echo "  sudo dnf install webkit2gtk4.1 gtk3" >&2
+        elif command -v pacman >/dev/null 2>&1; then
+            echo "  sudo pacman -S webkit2gtk-4.1 gtk3" >&2
+        elif command -v zypper >/dev/null 2>&1; then
+            echo "  sudo zypper install libwebkit2gtk-4_1-0 libgtk-3-0" >&2
+        else
+            echo "  # Debian/Ubuntu:" >&2
+            echo "  sudo apt-get install -y libwebkit2gtk-4.1-0 libgtk-3-0" >&2
+            echo "  # Fedora:" >&2
+            echo "  sudo dnf install webkit2gtk4.1 gtk3" >&2
+            echo "  # Arch:" >&2
+            echo "  sudo pacman -S webkit2gtk-4.1 gtk3" >&2
+        fi
+        echo "" >&2
+        echo "(Package names may vary by distro/version.)" >&2
+        echo "" >&2
+    else
+        echo "" >&2
+        echo "koma: missing shared libraries:" >&2
+        echo "$ldd_out" | grep "not found" | sed 's/^/  /' >&2
+        echo "" >&2
+        echo "Install the missing libraries via your package manager." >&2
+        echo "" >&2
+    fi
+    exit 127
+fi
+exec "$BIN" "$@"
+KOMA_LAUNCHER
+            sudo mv "$_tmp_launcher" "$INSTALL_DIR/koma"
+            sudo chmod +x "$INSTALL_DIR/koma"
+        fi
+    fi
 else
-    if [ "$(id -u)" = "0" ]; then
+    # macOS / Windows: single binary, no launcher needed.
+    if [ -w "$INSTALL_DIR" ]; then
         mv "$tmp" "$INSTALL_DIR/$bin_name"
     else
-        echo "  $INSTALL_DIR is not writable; using sudo for install step."
-        sudo mv "$tmp" "$INSTALL_DIR/$bin_name"
-        sudo chmod +x "$INSTALL_DIR/$bin_name"
+        if [ "$(id -u)" = "0" ]; then
+            mv "$tmp" "$INSTALL_DIR/$bin_name"
+        else
+            echo "  $INSTALL_DIR is not writable; using sudo for install step."
+            sudo mv "$tmp" "$INSTALL_DIR/$bin_name"
+            sudo chmod +x "$INSTALL_DIR/$bin_name"
+        fi
     fi
 fi
 
@@ -149,6 +403,27 @@ if [ "$os" = "darwin" ] && command -v xattr > /dev/null 2>&1; then
         xattr -d com.apple.quarantine "$INSTALL_DIR/$bin_name" 2>/dev/null || true
     else
         sudo xattr -d com.apple.quarantine "$INSTALL_DIR/$bin_name" 2>/dev/null || true
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Linux: non-fatal preflight warning (after install, before success banner).
+# Tells the user right away if their system is missing webkit/gtk, instead of
+# waiting for them to run `koma` and hit the error.
+# ---------------------------------------------------------------------------
+if [ "$os" = "linux" ] && command -v ldd >/dev/null 2>&1; then
+    _ldd_check="$(ldd "$INSTALL_DIR/koma.bin" 2>&1)" || true
+    if echo "$_ldd_check" | grep -qE 'GLIBC_[0-9]'; then
+        _glibc_needed="$(echo "$_ldd_check" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -uV | tr '\n' ' ')"
+        echo ""
+        echo "WARNING: this binary requires glibc $_glibc_needed" >&2
+        echo "  If koma fails to start, build from source: ./build.sh" >&2
+    elif echo "$_ldd_check" | grep -q "not found"; then
+        echo ""
+        echo "WARNING: some shared libraries are missing — koma may not start." >&2
+        echo "  Debian/Ubuntu: sudo apt-get install -y libwebkit2gtk-4.1-0 libgtk-3-0" >&2
+        echo "  Fedora:        sudo dnf install webkit2gtk4.1 gtk3" >&2
+        echo "  Arch:          sudo pacman -S webkit2gtk-4.1 gtk3" >&2
     fi
 fi
 

--- a/packaging/linux/koma-launcher.sh
+++ b/packaging/linux/koma-launcher.sh
@@ -1,0 +1,172 @@
+#!/bin/sh
+# koma launcher — Linux safety-net wrapper for prebuilt binaries.
+#
+# Resolves the real ELF (koma.bin) next to this script, preflights shared-
+# library availability via ldd, and either execs the binary or prints a
+# friendly, actionable error message.
+#
+# CONSTRAINT: We never run sudo, apt, dnf, pacman, or any package manager.
+# We only PRINT commands for the user to run themselves.
+#
+# This is the canonical copy. install.sh embeds a duplicate via here-doc;
+# keep them in sync when editing.
+
+set -e
+
+# ---------------------------------------------------------------------------
+# Resolve directory of this script (handles symlinks best-effort).
+# ---------------------------------------------------------------------------
+resolve_dir() {
+    # $0 may be a relative or absolute path; strip trailing slash.
+    _src="$0"
+    while [ -L "$_src" ]; do
+        _dir="$(cd -P "$(dirname -- "$_src")" && pwd)"
+        _src="$(readlink -- "$_src")"
+        # If readlink gave a relative path, resolve against _dir.
+        case "$_src" in
+            /*) ;;
+            *)  _src="$_dir/$_src" ;;
+        esac
+    done
+    cd -P "$(dirname -- "$_src")" && pwd
+}
+
+DIR="$(resolve_dir)"
+BIN="$DIR/koma.bin"
+
+# ---------------------------------------------------------------------------
+# Sanity: real binary must exist and be executable.
+# ---------------------------------------------------------------------------
+if [ ! -f "$BIN" ]; then
+    echo "koma: $BIN not found." >&2
+    echo "The koma launcher expects the real binary alongside itself as koma.bin." >&2
+    exit 1
+fi
+if [ ! -x "$BIN" ]; then
+    echo "koma: $BIN is not executable." >&2
+    echo "Run: chmod +x $BIN" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Preflight: ldd to check shared libraries before the dynamic linker does.
+# Prefer ldd over ldconfig -p because ldd catches BOTH missing .so files
+# AND symbol version mismatches (e.g. GLIBC_2.38 not found).
+# ---------------------------------------------------------------------------
+ldd_out=""
+ldd_ok=0
+if command -v ldd >/dev/null 2>&1; then
+    ldd_out="$(ldd "$BIN" 2>&1)" && ldd_ok=1 || ldd_ok=0
+fi
+
+if [ "$ldd_ok" = "1" ] && echo "$ldd_out" | grep -q "not a dynamic executable"; then
+    # ldd says it's not an ELF — unusual, but let the exec try anyway.
+    exec "$BIN" "$@"
+fi
+
+if [ "$ldd_ok" = "1" ] && ! echo "$ldd_out" | grep -q "not found"; then
+    # Clean ldd — all libs resolved. Also check for GLIBC version strings
+    # in the output (ldd doesn't print "not found" for version mismatches
+    # on all systems; some print a warning but still show the lib).
+    # Double-check: if ldd exited 0 and no "not found", we're good.
+    exec "$BIN" "$@"
+fi
+
+# ---------------------------------------------------------------------------
+# ldd found issues. Classify and print actionable message.
+# ---------------------------------------------------------------------------
+glibc_needed=""
+missing_libs=""
+
+if [ "$ldd_out" != "" ]; then
+    # Extract GLIBC version requirements from "GLIBC_X.Y not found" lines.
+    glibc_needed=$(echo "$ldd_out" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -uV | tr '\n' ' ')
+
+    # Extract missing .so names (not glibc — those are handled separately).
+    missing_libs=$(echo "$ldd_out" | grep "not found" | grep -v 'GLIBC_' | awk '{print $1}' | sort -u)
+fi
+
+# --- Case 1: GLIBC too old ---
+if [ -n "$glibc_needed" ]; then
+    echo "" >&2
+    echo "koma: prebuilt binary requires a newer glibc than this system provides." >&2
+    echo "" >&2
+
+    # Show host glibc version if possible.
+    if ldd --version >/dev/null 2>&1; then
+        _glibcv="$(ldd --version 2>&1 | head -1)"
+        echo "  Host:    $_glibcv" >&2
+    fi
+
+    echo "  Need:    glibc $glibc_needed" >&2
+    echo "" >&2
+    echo "You have two options:" >&2
+    echo "" >&2
+    echo "  1. Build from source on this machine (links against your local glibc):" >&2
+    echo "     git clone https://github.com/aula-id/koma.git && cd koma" >&2
+    echo "     ./build.sh" >&2
+    echo "" >&2
+    echo "  2. Use Ubuntu 22.04 LTS or newer (ships glibc 2.35+)." >&2
+    echo "" >&2
+
+    # Also mention any missing GUI libs.
+    if [ -n "$missing_libs" ]; then
+        echo "Additional missing libraries:" >&2
+        echo "$missing_libs" | sed 's/^/  /' >&2
+        echo "" >&2
+    fi
+
+    exit 127
+fi
+
+# --- Case 2: Missing GUI / other shared libraries ---
+if [ -n "$missing_libs" ]; then
+    has_webkit=0
+    has_gtk=0
+    echo "$missing_libs" | grep -q 'libwebkit2gtk' && has_webkit=1
+    echo "$missing_libs" | grep -q 'libgtk-3' && has_gtk=1
+
+    if [ "$has_webkit" = "1" ] || [ "$has_gtk" = "1" ]; then
+        echo "" >&2
+        echo "koma: missing system libraries required for the GUI." >&2
+        echo "" >&2
+        echo "Install them with your package manager:" >&2
+        echo "" >&2
+
+        if command -v apt-get >/dev/null 2>&1; then
+            echo "  sudo apt-get install -y libwebkit2gtk-4.1-0 libgtk-3-0" >&2
+        elif command -v dnf >/dev/null 2>&1; then
+            echo "  sudo dnf install webkit2gtk4.1 gtk3" >&2
+        elif command -v pacman >/dev/null 2>&1; then
+            echo "  sudo pacman -S webkit2gtk-4.1 gtk3" >&2
+        elif command -v zypper >/dev/null 2>&1; then
+            echo "  sudo zypper install libwebkit2gtk-4_1-0 libgtk-3-0" >&2
+        else
+            echo "  # Debian/Ubuntu:" >&2
+            echo "  sudo apt-get install -y libwebkit2gtk-4.1-0 libgtk-3-0" >&2
+            echo "  # Fedora:" >&2
+            echo "  sudo dnf install webkit2gtk4.1 gtk3" >&2
+            echo "  # Arch:" >&2
+            echo "  sudo pacman -S webkit2gtk-4.1 gtk3" >&2
+        fi
+
+        echo "" >&2
+        echo "(Package names may vary by distro/version.)" >&2
+        echo "" >&2
+    else
+        # Other missing libs — just show what ldd found.
+        echo "" >&2
+        echo "koma: missing shared libraries:" >&2
+        echo "$ldd_out" | grep "not found" | sed 's/^/  /' >&2
+        echo "" >&2
+        echo "Install the missing libraries via your package manager." >&2
+        echo "" >&2
+    fi
+
+    exit 127
+fi
+
+# --- Fallback: ldd unavailable or unclassifiable ---
+# If we got here without a clear classification, try to exec anyway.
+# This handles edge cases where ldd is missing or behaved unexpectedly.
+exec "$BIN" "$@"


### PR DESCRIPTION
Pin release.yml Linux jobs to ubuntu-22.04 (glibc 2.35 floor).

Add Linux shell launcher (koma) + real ELF (koma.bin) layout.

Launcher runs ldd, classifies GLIBC mismatch vs missing webkit/gtk,

prints actionable message (never runs sudo). Applied to build.sh and install.sh.