### PR TITLE
fix: add g++-aarch64-linux-gnu for cross-compile RocksDB

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         if: matrix.cross
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           mkdir -p .cargo
           {
             echo '[target.aarch64-unknown-linux-gnu]'


### PR DESCRIPTION
surrealdb-librocksdb-sys needs a C++ cross compiler (g++) to build
RocksDB from source. Only gcc was installed, causing aarch64 CI to fail.