### PR TITLE
feat(gui): multi-select sessions + bulk kill/delete

### DIFF
--- a/src-webgui/src/components/HelpTab.tsx
+++ b/src-webgui/src/components/HelpTab.tsx
@@ -103,6 +103,12 @@ export default function HelpTab() {
               permanently — there's no undo. Killing the currently-attached session drops you back to the start
               screen once the daemon is confirmed stopped.
             </InfoRow>
+            <InfoRow label="Multi-select">
+              In the start screen Recent list and the change-session hub, a plain click selects and highlights a
+              row (it does not open it). Ctrl/⌘-click toggles; Shift-click selects a range. Double-click or Enter
+              opens/resumes. With one or more rows selected, the bulk bar offers Kill (live) and Delete forever
+              (history), each with a yes/no confirm. Esc clears the selection first.
+            </InfoRow>
             <InfoRow label="+ New session">
               The primary button opens a folder picker for a new session and leaves whatever's currently cooking
               running in the background. The chevron next to it offers "New session + close current," which stops

--- a/src-webgui/src/components/ResumePalette.tsx
+++ b/src-webgui/src/components/ResumePalette.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState, type MouseEvent as ReactMouseEvent } from 'react'
 import { motion } from 'framer-motion'
 import { Search, Plus } from 'lucide-react'
 import { CMD_SEARCH_SPRING, CMD_SEARCH_WIDTH } from './Titlebar'
 import { NewSessionMenu } from './NewSessionMenu'
 import { SessionRowActions, SessionRowConfirmStrip, type ArmedRow } from './SessionRowActions'
+import { SessionBulkBar } from './SessionBulkBar'
+import { useSessionMultiSelect } from './sessionListSelection'
 import { useKoma, isDying } from '../store/koma'
 
 type ResumePaletteProps = {
@@ -27,6 +29,9 @@ function Empty({ children }: { children: string }) {
 // reveals below. New session is inline with the Cooking header. Cooking
 // (live) + History (past) are driven straight off the koma store's hub
 // slice, itself an authoritative mirror of the host's Hub push envelope.
+//
+// Session rows (issue #126): plain click selects/highlights; Ctrl/Cmd toggles;
+// Shift ranges; double-click or Enter opens. Bulk Kill/Delete via SessionBulkBar.
 export function ResumePalette({ onClose }: ResumePaletteProps) {
   const cooking = useKoma((s) => s.hub.cooking)
   const history = useKoma((s) => s.hub.history)
@@ -37,12 +42,18 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
   // The single armed row (kill/delete confirm pill) across BOTH lists — arming
   // a different row disarms whichever was armed before.
   const [armed, setArmed] = useState<ArmedRow>(null)
+  const multi = useSessionMultiSelect()
 
+  const multiHas = multi.hasSelection
+  const multiClear = multi.clear
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        // Escape cancels an armed row first; only closes the palette once
-        // nothing is armed.
+        // Escape: multi-select → armed row → close palette.
+        if (multiHas) {
+          multiClear()
+          return
+        }
         if (armed) {
           setArmed(null)
           return
@@ -52,7 +63,7 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [onClose, armed])
+  }, [onClose, armed, multiHas, multiClear])
 
   // Live-session-listing fix: the host only discovers live sessions on
   // demand. Ask for a fresh Hub the moment this overlay opens, then keep
@@ -66,7 +77,13 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
     return () => window.clearInterval(interval)
   }, [req])
 
-  const selectSession = (id: string, name: string) => {
+  // Clear multi-select when the search query changes (visible order / membership
+  // shifts — range anchors would otherwise point at stale rows).
+  useEffect(() => {
+    multiClear()
+  }, [query, multiClear])
+
+  const openSession = (id: string, name: string) => {
     // Optimistic: fires the full-screen swap overlay immediately, since the
     // host gives no "swap started" push and the attach can block for
     // seconds. Cleared by the next authoritative Snapshot (see koma.ts).
@@ -99,6 +116,34 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
   // most-recent matches.
   const filteredHistory = history.filter((h) => matches(h.id, h.name)).slice(0, 10)
 
+  const cookingIds = useMemo(
+    () => filteredCooking.map((c) => c.id).filter((id): id is string => !!id),
+    [filteredCooking],
+  )
+  const historyIds = useMemo(() => filteredHistory.map((h) => h.id), [filteredHistory])
+  const fgCooking = useMemo(
+    () => filteredCooking.filter((c) => c.foreground && c.id).map((c) => c.id as string),
+    [filteredCooking],
+  )
+
+  const armRow = (row: ArmedRow) => {
+    multi.clear()
+    setArmed(row)
+  }
+
+  const onRowMouse = (
+    e: ReactMouseEvent,
+    kind: 'session' | 'history',
+    id: string,
+    ordered: string[],
+  ) => {
+    if (armed) setArmed(null)
+    multi.onRowClick(e, kind, id, ordered)
+  }
+
+  const bulkCooking = multi.selectedIds('session')
+  const bulkHistory = multi.selectedIds('history')
+
   return (
     <div className="absolute inset-0 z-50" onMouseDown={onClose}>
       <div
@@ -126,6 +171,15 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
             transition={{ duration: 0.16, ease: 'easeOut', delay: 0.02 }}
             className="max-h-[50vh] overflow-auto border-t border-koma-border py-1"
           >
+            {multi.hasSelection && (
+              <SessionBulkBar
+                cookingIds={bulkCooking}
+                historyIds={bulkHistory}
+                foregroundCookingIds={fgCooking}
+                onDone={() => multi.clear()}
+                onClear={() => multi.clear()}
+              />
+            )}
             <div className="flex items-center justify-between px-3 pb-1 pt-2">
               <span className="text-[10px] font-semibold uppercase tracking-wider text-koma-fg opacity-40">
                 Cooking
@@ -145,30 +199,44 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
               <Empty>{q === '' ? 'No live sessions' : 'No matches'}</Empty>
             ) : (
               filteredCooking.map((c) => {
-                const dying = !!c.id && isDying(dyingSessions, c.id, 'session')
-                const rowArmed = !!c.id && armed?.id === c.id && armed.kind === 'session'
+                const id = c.id as string
+                const dying = !!c.id && isDying(dyingSessions, id, 'session')
+                const rowArmed = !!c.id && armed?.id === id && armed.kind === 'session'
+                const sel = !!c.id && multi.isSelected('session', id)
                 return (
                   <div
                     key={c.id}
                     role="button"
                     tabIndex={dying || rowArmed ? -1 : 0}
-                    onClick={() => {
-                      if (dying) return
-                      if (armed && armed.id === c.id && armed.kind === 'session') return
-                      c.id && selectSession(c.id, c.name)
+                    aria-selected={sel}
+                    onClick={(e) => {
+                      if (dying || !c.id) return
+                      if (rowArmed) return
+                      onRowMouse(e, 'session', id, cookingIds)
+                    }}
+                    onDoubleClick={(e) => {
+                      if (dying || rowArmed || !c.id) return
+                      e.preventDefault()
+                      openSession(id, c.name)
                     }}
                     onKeyDown={(e) => {
                       if (e.key !== 'Enter' && e.key !== ' ') return
                       if (e.key === ' ') e.preventDefault()
-                      if (!dying && !armed && c.id) selectSession(c.id, c.name)
+                      if (!dying && !armed && c.id) openSession(id, c.name)
                     }}
                     className={`group flex w-full cursor-pointer items-center justify-between text-left text-[12px] text-koma-fg transition-colors ${
-                      rowArmed ? '' : 'px-3 py-1.5 hover:bg-koma-hover'
-                    } ${dying ? 'pointer-events-none opacity-60' : ''}`}
+                      rowArmed ? '' : 'px-3 py-1.5'
+                    } ${dying ? 'pointer-events-none opacity-60' : ''} ${
+                      rowArmed
+                        ? ''
+                        : sel
+                          ? 'bg-koma-accent/15 hover:bg-koma-accent/20'
+                          : 'hover:bg-koma-hover'
+                    }`}
                   >
                     {rowArmed && c.id ? (
                       <SessionRowConfirmStrip
-                        id={c.id}
+                        id={id}
                         kind="session"
                         foreground={c.foreground}
                         onCancel={() => setArmed(null)}
@@ -176,9 +244,6 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
                       />
                     ) : (
                       <>
-                        {/* Content cell — flex-1 min-w-0 so ALL text/status/folder
-                            chips truncate INSIDE this cell, never spilling into
-                            the fixed trailing action column next to it. */}
                         <div className="flex min-w-0 flex-1 items-center gap-1.5">
                           {c.working && (
                             <span className="h-1.5 w-1.5 flex-none animate-pulse rounded-full bg-emerald-500" />
@@ -195,14 +260,9 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
                             </span>
                           )}
                         </div>
-                        {/* Trailing action cell — fixed ~28px, always reserved
-                            (opacity-toggled inside, never conditionally
-                            rendered) so text width never jumps on hover, and
-                            the destructive button's hit area is strictly this
-                            column, never the content cell's text. */}
                         <div className="flex w-7 flex-none items-center justify-center">
                           {c.id && (
-                            <SessionRowActions id={c.id} kind="session" armed={armed} onArm={setArmed} />
+                            <SessionRowActions id={id} kind="session" armed={armed} onArm={armRow} />
                           )}
                         </div>
                       </>
@@ -218,24 +278,37 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
               filteredHistory.map((h) => {
                 const dying = isDying(dyingSessions, h.id, 'history')
                 const rowArmed = armed?.id === h.id && armed.kind === 'history'
+                const sel = multi.isSelected('history', h.id)
                 return (
                   <div
                     key={h.id}
                     role="button"
                     tabIndex={dying || rowArmed ? -1 : 0}
-                    onClick={() => {
+                    aria-selected={sel}
+                    onClick={(e) => {
                       if (dying) return
-                      if (armed && armed.id === h.id && armed.kind === 'history') return
-                      selectSession(h.id, h.name)
+                      if (rowArmed) return
+                      onRowMouse(e, 'history', h.id, historyIds)
+                    }}
+                    onDoubleClick={(e) => {
+                      if (dying || rowArmed) return
+                      e.preventDefault()
+                      openSession(h.id, h.name)
                     }}
                     onKeyDown={(e) => {
                       if (e.key !== 'Enter' && e.key !== ' ') return
                       if (e.key === ' ') e.preventDefault()
-                      if (!dying && !armed) selectSession(h.id, h.name)
+                      if (!dying && !armed) openSession(h.id, h.name)
                     }}
                     className={`group flex w-full cursor-pointer items-center justify-between text-left text-[12px] text-koma-fg transition-colors ${
-                      rowArmed ? '' : 'px-3 py-1.5 hover:bg-koma-hover'
-                    } ${dying ? 'pointer-events-none opacity-60' : ''}`}
+                      rowArmed ? '' : 'px-3 py-1.5'
+                    } ${dying ? 'pointer-events-none opacity-60' : ''} ${
+                      rowArmed
+                        ? ''
+                        : sel
+                          ? 'bg-koma-accent/15 hover:bg-koma-accent/20'
+                          : 'hover:bg-koma-hover'
+                    }`}
                   >
                     {rowArmed ? (
                       <SessionRowConfirmStrip
@@ -255,7 +328,7 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
                           )}
                         </div>
                         <div className="flex w-7 flex-none items-center justify-center">
-                          <SessionRowActions id={h.id} kind="history" armed={armed} onArm={setArmed} />
+                          <SessionRowActions id={h.id} kind="history" armed={armed} onArm={armRow} />
                         </div>
                       </>
                     )}
@@ -263,6 +336,9 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
                 )
               })
             )}
+            <div className="px-3 pb-1 pt-0.5 text-[10px] text-koma-fg opacity-30">
+              Click select · Ctrl/⌘ toggle · Shift range · Double-click / Enter open
+            </div>
           </motion.div>
         </div>
       </div>

--- a/src-webgui/src/components/ResumePalette.tsx
+++ b/src-webgui/src/components/ResumePalette.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type MouseEvent as ReactMouseEvent } from 'react'
+import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
 import { motion } from 'framer-motion'
 import { Search, Plus } from 'lucide-react'
 import { CMD_SEARCH_SPRING, CMD_SEARCH_WIDTH } from './Titlebar'
@@ -43,6 +43,7 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
   // a different row disarms whichever was armed before.
   const [armed, setArmed] = useState<ArmedRow>(null)
   const multi = useSessionMultiSelect()
+  const searchRef = useRef<HTMLInputElement>(null)
 
   const multiHas = multi.hasSelection
   const multiClear = multi.clear
@@ -52,6 +53,9 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
         // Escape: multi-select → armed row → close palette.
         if (multiHas) {
           multiClear()
+          // Drop keyboard focus ring on the last-clicked row (tabIndex=0
+          // leaves a blue outline after Esc clears the green multi-select).
+          searchRef.current?.focus()
           return
         }
         if (armed) {
@@ -158,6 +162,7 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
           >
             <Search size={13} className="flex-none text-koma-fg opacity-50" />
             <input
+              ref={searchRef}
               autoFocus
               value={query}
               onChange={(e) => setQuery(e.target.value)}
@@ -224,7 +229,7 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
                       if (e.key === ' ') e.preventDefault()
                       if (!dying && !armed && c.id) openSession(id, c.name)
                     }}
-                    className={`group flex w-full cursor-pointer items-center justify-between text-left text-[12px] text-koma-fg transition-colors ${
+                    className={`group flex w-full cursor-pointer items-center justify-between text-left text-[12px] text-koma-fg transition-colors outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-koma-accent/50 ${
                       rowArmed ? '' : 'px-3 py-1.5'
                     } ${dying ? 'pointer-events-none opacity-60' : ''} ${
                       rowArmed
@@ -300,7 +305,7 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
                       if (e.key === ' ') e.preventDefault()
                       if (!dying && !armed) openSession(h.id, h.name)
                     }}
-                    className={`group flex w-full cursor-pointer items-center justify-between text-left text-[12px] text-koma-fg transition-colors ${
+                    className={`group flex w-full cursor-pointer items-center justify-between text-left text-[12px] text-koma-fg transition-colors outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-koma-accent/50 ${
                       rowArmed ? '' : 'px-3 py-1.5'
                     } ${dying ? 'pointer-events-none opacity-60' : ''} ${
                       rowArmed

--- a/src-webgui/src/components/SessionBulkBar.tsx
+++ b/src-webgui/src/components/SessionBulkBar.tsx
@@ -1,0 +1,176 @@
+import { useMemo, useState } from 'react'
+import { Check, Power, Trash2, X } from 'lucide-react'
+import { useKoma } from '../store/koma'
+
+type Props = {
+  cookingIds: string[]
+  historyIds: string[]
+  /** Cooking rows that are the currently-attached session (need detachSession). */
+  foregroundCookingIds?: string[]
+  onDone: () => void
+  onClear: () => void
+  className?: string
+}
+
+// Compact bulk action strip shown above a session list when multi-select is
+// non-empty. Kill applies only to cooking ids; Delete forever only to history.
+// Confirm is a full-width danger strip (same visual language as
+// SessionRowConfirmStrip) so bulk destructive ops never one-click-fire.
+export function SessionBulkBar({
+  cookingIds,
+  historyIds,
+  foregroundCookingIds = [],
+  onDone,
+  onClear,
+  className = '',
+}: Props) {
+  const req = useKoma((s) => s.req)
+  const markDying = useKoma((s) => s.markDying)
+  const detachSession = useKoma((s) => s.detachSession)
+  const theme = useKoma((s) => s.config.theme)
+  const palettes = useKoma((s) => s.config.palettes)
+  const [pending, setPending] = useState<null | 'kill' | 'delete'>(null)
+
+  const errorTint = useMemo(() => {
+    const active = palettes.find((p) => p.name === theme)
+    return active?.colors?.[9] || 'var(--koma-fg)'
+  }, [palettes, theme])
+
+  const nCook = cookingIds.length
+  const nHist = historyIds.length
+  const total = nCook + nHist
+  if (total === 0) return null
+
+  const runKill = () => {
+    const fg = new Set(foregroundCookingIds)
+    for (const id of cookingIds) {
+      req({ r: 'KillSession', id })
+      markDying(id, 'kill')
+      if (fg.has(id)) detachSession()
+    }
+    setPending(null)
+    onDone()
+  }
+
+  const runDelete = () => {
+    for (const id of historyIds) {
+      req({ r: 'DeleteSession', id })
+      markDying(id, 'delete')
+    }
+    setPending(null)
+    onDone()
+  }
+
+  if (pending === 'kill') {
+    return (
+      <div
+        className={`flex w-full items-center justify-between px-3 py-1.5 text-[12px] font-medium ${className}`}
+        style={{ color: errorTint, backgroundColor: `color-mix(in srgb, ${errorTint} 16%, transparent)` }}
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <span className="min-w-0 flex-1 truncate">
+          {nCook === 1 ? 'kill 1 session?' : `kill ${nCook} sessions?`}
+        </span>
+        <span className="flex flex-none items-center gap-1.5">
+          <button
+            onClick={runKill}
+            autoFocus
+            aria-label="Confirm kill"
+            className="flex flex-none items-center gap-1 rounded px-3 text-[12px] font-semibold opacity-90 transition-opacity hover:opacity-100"
+            style={{ color: errorTint }}
+          >
+            <Check size={13} className="flex-none" />
+            yes
+          </button>
+          <button
+            onClick={() => setPending(null)}
+            aria-label="Cancel"
+            className="flex flex-none items-center gap-1 rounded px-3 text-[12px] text-koma-fg opacity-70 transition-opacity hover:opacity-100"
+          >
+            <X size={13} className="flex-none" />
+            no
+          </button>
+        </span>
+      </div>
+    )
+  }
+
+  if (pending === 'delete') {
+    return (
+      <div
+        className={`flex w-full items-center justify-between px-3 py-1.5 text-[12px] font-medium ${className}`}
+        style={{ color: errorTint, backgroundColor: `color-mix(in srgb, ${errorTint} 16%, transparent)` }}
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <span className="min-w-0 flex-1 truncate">
+          {nHist === 1 ? 'delete 1 forever?' : `delete ${nHist} forever?`}
+        </span>
+        <span className="flex flex-none items-center gap-1.5">
+          <button
+            onClick={runDelete}
+            autoFocus
+            aria-label="Confirm delete"
+            className="flex flex-none items-center gap-1 rounded px-3 text-[12px] font-semibold opacity-90 transition-opacity hover:opacity-100"
+            style={{ color: errorTint }}
+          >
+            <Check size={13} className="flex-none" />
+            yes
+          </button>
+          <button
+            onClick={() => setPending(null)}
+            aria-label="Cancel"
+            className="flex flex-none items-center gap-1 rounded px-3 text-[12px] text-koma-fg opacity-70 transition-opacity hover:opacity-100"
+          >
+            <X size={13} className="flex-none" />
+            no
+          </button>
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={`flex w-full items-center gap-2 border-b border-koma-border bg-koma-panel2 px-3 py-1.5 text-[11.5px] text-koma-fg ${className}`}
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <span className="min-w-0 flex-1 truncate opacity-80">
+        {total} selected
+        {nCook > 0 && nHist > 0 ? ` · ${nCook} live · ${nHist} history` : ''}
+      </span>
+      {nCook > 0 && (
+        <button
+          type="button"
+          onClick={() => setPending('kill')}
+          className="flex flex-none items-center gap-1 rounded px-2 py-0.5 opacity-80 transition hover:bg-koma-hover hover:opacity-100"
+          title="Kill selected live sessions (stop daemon, keep on disk)"
+        >
+          <Power size={12} className="flex-none" />
+          Kill
+        </button>
+      )}
+      {nHist > 0 && (
+        <button
+          type="button"
+          onClick={() => setPending('delete')}
+          className="flex flex-none items-center gap-1 rounded px-2 py-0.5 opacity-80 transition hover:bg-koma-hover hover:opacity-100"
+          title="Delete selected history sessions forever"
+        >
+          <Trash2 size={12} className="flex-none" />
+          Delete
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={onClear}
+        className="flex-none rounded px-2 py-0.5 opacity-50 transition hover:bg-koma-hover hover:opacity-100"
+        title="Clear selection"
+      >
+        Clear
+      </button>
+    </div>
+  )
+}

--- a/src-webgui/src/components/SessionBulkBar.tsx
+++ b/src-webgui/src/components/SessionBulkBar.tsx
@@ -131,15 +131,35 @@ export function SessionBulkBar({
     )
   }
 
+  // Hub palette is narrow (~340px) and must fit Kill+Delete+Clear without
+  // eating the summary mid-word. Prefer the shortest mixed form that still
+  // shows both counts; full sentence is always on `title` for hover.
+  // e.g. visible "2 · 1L · 1H"  title "2 selected · 1 live · 1 history"
+  const summary =
+    nCook > 0 && nHist > 0
+      ? `${total} · ${nCook}L · ${nHist}H`
+      : nCook > 0
+        ? `${nCook} live`
+        : nHist > 0
+          ? `${nHist} history`
+          : `${total} selected`
+  const summaryTitle =
+    nCook > 0 && nHist > 0
+      ? `${total} selected · ${nCook} live · ${nHist} history`
+      : nCook > 0
+        ? `${nCook} live selected`
+        : nHist > 0
+          ? `${nHist} history selected`
+          : `${total} selected`
+
   return (
     <div
       className={`flex w-full items-center gap-2 border-b border-koma-border bg-koma-panel2 px-3 py-1.5 text-[11.5px] text-koma-fg ${className}`}
       onMouseDown={(e) => e.stopPropagation()}
       onClick={(e) => e.stopPropagation()}
     >
-      <span className="min-w-0 flex-1 truncate opacity-80">
-        {total} selected
-        {nCook > 0 && nHist > 0 ? ` · ${nCook} live · ${nHist} history` : ''}
+      <span className="min-w-0 flex-1 truncate opacity-80" title={summaryTitle}>
+        {summary}
       </span>
       {nCook > 0 && (
         <button

--- a/src-webgui/src/components/StartScreen.tsx
+++ b/src-webgui/src/components/StartScreen.tsx
@@ -81,6 +81,8 @@ export function StartScreen() {
       if (e.key !== 'Escape') return
       if (multiHas) {
         multiClear()
+        // Avoid leaving a browser focus ring on the last-clicked row.
+        if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
         return
       }
       if (armed) setArmed(null)
@@ -197,7 +199,7 @@ export function StartScreen() {
                     if (e.key === ' ') e.preventDefault()
                     if (!dying && !armed) openSession(id, c.name)
                   }}
-                  className={`group flex w-full cursor-pointer items-center justify-between rounded-lg text-left transition-colors ${
+                  className={`group flex w-full cursor-pointer items-center justify-between rounded-lg text-left transition-colors outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-koma-accent/50 ${
                     rowArmed ? '' : 'gap-2 px-3 py-2'
                   } ${dying ? 'pointer-events-none opacity-60' : ''} ${
                     rowArmed
@@ -264,7 +266,7 @@ export function StartScreen() {
                     if (e.key === ' ') e.preventDefault()
                     if (!dying && !armed) openSession(h.id, h.name)
                   }}
-                  className={`group flex w-full cursor-pointer items-center justify-between rounded-lg text-left transition-colors ${
+                  className={`group flex w-full cursor-pointer items-center justify-between rounded-lg text-left transition-colors outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-koma-accent/50 ${
                     rowArmed ? '' : 'gap-2 px-3 py-2'
                   } ${dying ? 'pointer-events-none opacity-60' : ''} ${
                     rowArmed

--- a/src-webgui/src/components/StartScreen.tsx
+++ b/src-webgui/src/components/StartScreen.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
 import { ArrowRight, Clock, FolderPlus, Info, Sparkles, Zap } from 'lucide-react'
 import { NewSessionMenu } from './NewSessionMenu'
 import { SessionRowActions, SessionRowConfirmStrip, type ArmedRow } from './SessionRowActions'
+import { SessionBulkBar } from './SessionBulkBar'
+import { useSessionMultiSelect } from './sessionListSelection'
 import { useKoma, isDying } from '../store/koma'
 
 // Measures the component's own width with a ResizeObserver (a container query in
@@ -45,8 +47,9 @@ function SectionLabel({ icon: Icon, children }: { icon: typeof Clock; children: 
 // (from the host's authoritative hub history/cooking mirror) + a New session
 // action (reuses the native folder-picker flow via GuiReq NewSession) + a short
 // "about Koma" panel. Responsive: stacked when narrow, side-by-side when wide.
-// The resume/change-session OVERLAY (ResumePalette) is unaffected — it stays the
-// attached-state affordance.
+//
+// Session rows (issue #126): plain click selects/highlights; Ctrl/Cmd toggles;
+// Shift ranges; double-click or Enter opens. Bulk Kill/Delete via SessionBulkBar.
 export function StartScreen() {
   const history = useKoma((s) => s.hub.history)
   const cooking = useKoma((s) => s.hub.cooking)
@@ -58,6 +61,7 @@ export function StartScreen() {
   // The single armed row (kill/delete confirm pill) across BOTH lists — arming
   // a different row disarms whichever was armed before.
   const [armed, setArmed] = useState<ArmedRow>(null)
+  const multi = useSessionMultiSelect()
 
   // The host only discovers live sessions on demand — nudge a fresh Hub on
   // mount and on a short interval so recent/live rows stay current (same cadence
@@ -68,16 +72,22 @@ export function StartScreen() {
     return () => window.clearInterval(id)
   }, [req])
 
-  // Escape cancels an armed row (there's no overlay to close here, unlike
-  // ResumePalette).
+  // Escape: clear multi-select first, then cancel an armed row.
+  const multiHas = multi.hasSelection
+  const multiClear = multi.clear
   useEffect(() => {
-    if (!armed) return
+    if (!armed && !multiHas) return
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setArmed(null)
+      if (e.key !== 'Escape') return
+      if (multiHas) {
+        multiClear()
+        return
+      }
+      if (armed) setArmed(null)
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [armed])
+  }, [armed, multiHas, multiClear])
 
   // Live (cooking) sessions first, then past history — the same source rows the
   // ResumePalette lists, minus the synthetic `kind: 'new'` placeholder.
@@ -85,6 +95,8 @@ export function StartScreen() {
     () => cooking.filter((c) => c.kind === 'session' && c.id),
     [cooking],
   )
+  const liveIds = useMemo(() => liveSessions.map((c) => c.id as string), [liveSessions])
+  const historyIds = useMemo(() => history.map((h) => h.id), [history])
 
   const openSession = (id: string, name: string) => {
     // Optimistic swap overlay (no host "swap started" push; attach can block for
@@ -96,7 +108,25 @@ export function StartScreen() {
   // attaches once a folder is confirmed (cancel would strand the loader).
   const newSession = () => req({ r: 'NewSession' })
 
+  const armRow = (row: ArmedRow) => {
+    multi.clear()
+    setArmed(row)
+  }
+
+  const onRowMouse = (
+    e: ReactMouseEvent,
+    kind: 'session' | 'history',
+    id: string,
+    ordered: string[],
+  ) => {
+    if (armed) setArmed(null)
+    multi.onRowClick(e, kind, id, ordered)
+  }
+
   const hasRecent = liveSessions.length > 0 || history.length > 0
+  const bulkCooking = multi.selectedIds('session')
+  const bulkHistory = multi.selectedIds('history')
+  const fgCooking = liveSessions.filter((c) => c.foreground && c.id).map((c) => c.id as string)
 
   const actions = (
     <div className="flex min-w-0 flex-1 flex-col gap-4">
@@ -124,37 +154,62 @@ export function StartScreen() {
         <NewSessionMenu className="pr-3" />
       </div>
 
-      <Card>
-        <SectionLabel icon={Clock}>Recent</SectionLabel>
+      <Card className="!p-0 overflow-hidden">
+        <div className="px-4 pt-4">
+          <SectionLabel icon={Clock}>Recent</SectionLabel>
+        </div>
+        {multi.hasSelection && (
+          <SessionBulkBar
+            cookingIds={bulkCooking}
+            historyIds={bulkHistory}
+            foregroundCookingIds={fgCooking}
+            onDone={() => multi.clear()}
+            onClear={() => multi.clear()}
+          />
+        )}
         {!hasRecent ? (
-          <div className="px-1 py-2 text-[12px] text-koma-fg opacity-35">No sessions yet — start a new one.</div>
+          <div className="px-5 pb-4 pt-2 text-[12px] text-koma-fg opacity-35">No sessions yet — start a new one.</div>
         ) : (
-          <div className="-mx-1 max-h-[40vh] overflow-y-auto">
+          <div className="max-h-[40vh] overflow-y-auto px-3 pb-3">
             {liveSessions.map((c) => {
-              const dying = !!c.id && isDying(dyingSessions, c.id, 'session')
-              const rowArmed = !!c.id && armed?.id === c.id && armed.kind === 'session'
+              const id = c.id as string
+              const dying = isDying(dyingSessions, id, 'session')
+              const rowArmed = armed?.id === id && armed.kind === 'session'
+              const sel = multi.isSelected('session', id)
               return (
                 <div
-                  key={c.id}
+                  key={id}
                   role="button"
                   tabIndex={dying || rowArmed ? -1 : 0}
-                  onClick={() => {
+                  aria-selected={sel}
+                  onClick={(e) => {
                     if (dying) return
-                    if (armed && armed.id === c.id && armed.kind === 'session') return
-                    c.id && openSession(c.id, c.name)
+                    if (rowArmed) return
+                    onRowMouse(e, 'session', id, liveIds)
+                  }}
+                  onDoubleClick={(e) => {
+                    if (dying || rowArmed) return
+                    e.preventDefault()
+                    openSession(id, c.name)
                   }}
                   onKeyDown={(e) => {
                     if (e.key !== 'Enter' && e.key !== ' ') return
                     if (e.key === ' ') e.preventDefault()
-                    if (!dying && !armed && c.id) openSession(c.id, c.name)
+                    if (!dying && !armed) openSession(id, c.name)
                   }}
                   className={`group flex w-full cursor-pointer items-center justify-between rounded-lg text-left transition-colors ${
-                    rowArmed ? '' : 'gap-2 px-3 py-2 hover:bg-koma-hover'
-                  } ${dying ? 'pointer-events-none opacity-60' : ''}`}
+                    rowArmed ? '' : 'gap-2 px-3 py-2'
+                  } ${dying ? 'pointer-events-none opacity-60' : ''} ${
+                    rowArmed
+                      ? ''
+                      : sel
+                        ? 'bg-koma-accent/15 hover:bg-koma-accent/20'
+                        : 'hover:bg-koma-hover'
+                  }`}
                 >
-                  {rowArmed && c.id ? (
+                  {rowArmed ? (
                     <SessionRowConfirmStrip
-                      id={c.id}
+                      id={id}
                       kind="session"
                       foreground={c.foreground}
                       onCancel={() => setArmed(null)}
@@ -162,9 +217,6 @@ export function StartScreen() {
                     />
                   ) : (
                     <>
-                      {/* Content cell — flex-1 min-w-0 so ALL text/status/folder
-                          chips truncate INSIDE this cell, never spilling into
-                          the fixed trailing action column next to it. */}
                       <div className="flex min-w-0 flex-1 items-center gap-2">
                         <span className="h-1.5 w-1.5 flex-none animate-pulse rounded-full bg-emerald-500" />
                         <span className="min-w-0 flex-1 truncate text-[12.5px] text-koma-fg">{c.name}</span>
@@ -179,15 +231,8 @@ export function StartScreen() {
                           </span>
                         )}
                       </div>
-                      {/* Trailing action cell — fixed ~28px, always reserved
-                          (opacity-toggled inside, never conditionally
-                          rendered) so text width never jumps on hover, and
-                          the destructive button's hit area is strictly this
-                          column, never the content cell's text. */}
                       <div className="flex w-7 flex-none items-center justify-center">
-                        {c.id && (
-                          <SessionRowActions id={c.id} kind="session" armed={armed} onArm={setArmed} />
-                        )}
+                        <SessionRowActions id={id} kind="session" armed={armed} onArm={armRow} />
                       </div>
                     </>
                   )}
@@ -197,14 +242,21 @@ export function StartScreen() {
             {history.map((h) => {
               const dying = isDying(dyingSessions, h.id, 'history')
               const rowArmed = armed?.id === h.id && armed.kind === 'history'
+              const sel = multi.isSelected('history', h.id)
               return (
                 <div
                   key={h.id}
                   role="button"
                   tabIndex={dying || rowArmed ? -1 : 0}
-                  onClick={() => {
+                  aria-selected={sel}
+                  onClick={(e) => {
                     if (dying) return
-                    if (armed && armed.id === h.id && armed.kind === 'history') return
+                    if (rowArmed) return
+                    onRowMouse(e, 'history', h.id, historyIds)
+                  }}
+                  onDoubleClick={(e) => {
+                    if (dying || rowArmed) return
+                    e.preventDefault()
                     openSession(h.id, h.name)
                   }}
                   onKeyDown={(e) => {
@@ -213,8 +265,14 @@ export function StartScreen() {
                     if (!dying && !armed) openSession(h.id, h.name)
                   }}
                   className={`group flex w-full cursor-pointer items-center justify-between rounded-lg text-left transition-colors ${
-                    rowArmed ? '' : 'gap-2 px-3 py-2 hover:bg-koma-hover'
-                  } ${dying ? 'pointer-events-none opacity-60' : ''}`}
+                    rowArmed ? '' : 'gap-2 px-3 py-2'
+                  } ${dying ? 'pointer-events-none opacity-60' : ''} ${
+                    rowArmed
+                      ? ''
+                      : sel
+                        ? 'bg-koma-accent/15 hover:bg-koma-accent/20'
+                        : 'hover:bg-koma-hover'
+                  }`}
                 >
                   {rowArmed ? (
                     <SessionRowConfirmStrip
@@ -234,13 +292,18 @@ export function StartScreen() {
                         )}
                       </div>
                       <div className="flex w-7 flex-none items-center justify-center">
-                        <SessionRowActions id={h.id} kind="history" armed={armed} onArm={setArmed} />
+                        <SessionRowActions id={h.id} kind="history" armed={armed} onArm={armRow} />
                       </div>
                     </>
                   )}
                 </div>
               )
             })}
+          </div>
+        )}
+        {hasRecent && (
+          <div className="border-t border-koma-border px-4 py-1.5 text-[10px] text-koma-fg opacity-35">
+            Click to select · Ctrl/⌘ click toggle · Shift range · Double-click or Enter to open
           </div>
         )}
       </Card>

--- a/src-webgui/src/components/sessionListSelection.ts
+++ b/src-webgui/src/components/sessionListSelection.ts
@@ -1,0 +1,137 @@
+import { useCallback, useState, type MouseEvent as ReactMouseEvent } from 'react'
+
+// Multi-select for Cooking / History session rows (issue #126).
+//
+// Interaction model (per user spec):
+//   - plain click          → select only this row (highlight), do NOT open
+//   - Ctrl/Cmd+click       → toggle this row in the selection set
+//   - Shift+click          → range-select within the same list kind from anchor
+//   - double-click / Enter → open/resume (handled by the row, not this hook)
+//
+// Keys are scoped by list kind so a cooking id and a history id never collide
+// in the set, and bulk Kill vs Delete can partition cleanly.
+
+export type SessionListKind = 'session' | 'history'
+
+export type SessionSelKey = `${SessionListKind}:${string}`
+
+export function selKey(kind: SessionListKind, id: string): SessionSelKey {
+  return `${kind}:${id}`
+}
+
+export function parseSelKey(key: SessionSelKey): { kind: SessionListKind; id: string } {
+  const i = key.indexOf(':')
+  return { kind: key.slice(0, i) as SessionListKind, id: key.slice(i + 1) }
+}
+
+export function useSessionMultiSelect() {
+  const [selected, setSelected] = useState<Set<SessionSelKey>>(() => new Set())
+  // Anchor for Shift+click range — last plain / ctrl click within a kind.
+  const [anchor, setAnchor] = useState<{ kind: SessionListKind; id: string } | null>(null)
+
+  const clear = useCallback(() => {
+    setSelected(new Set())
+    setAnchor(null)
+  }, [])
+
+  const isSelected = useCallback(
+    (kind: SessionListKind, id: string) => selected.has(selKey(kind, id)),
+    [selected],
+  )
+
+  /** Ordered ids currently selected for one list kind. */
+  const selectedIds = useCallback(
+    (kind: SessionListKind): string[] => {
+      const out: string[] = []
+      for (const k of selected) {
+        const p = parseSelKey(k)
+        if (p.kind === kind) out.push(p.id)
+      }
+      return out
+    },
+    [selected],
+  )
+
+  /**
+   * Handle a row click for selection. Returns true if the click was consumed
+   * as a selection change (caller should NOT open the session).
+   *
+   * `orderedIds` = visible row ids in paint order for this kind (filtered list).
+   */
+  const onRowClick = useCallback(
+    (
+      e: ReactMouseEvent,
+      kind: SessionListKind,
+      id: string,
+      orderedIds: string[],
+    ): boolean => {
+      // Ignore pure right-clicks (context menu is #127).
+      if (e.button !== 0) return false
+
+      const key = selKey(kind, id)
+      const mod = e.metaKey || e.ctrlKey
+
+      if (e.shiftKey && anchor && anchor.kind === kind) {
+        e.preventDefault()
+        const a = orderedIds.indexOf(anchor.id)
+        const b = orderedIds.indexOf(id)
+        if (a >= 0 && b >= 0) {
+          const [lo, hi] = a < b ? [a, b] : [b, a]
+          setSelected((prev) => {
+            const next = new Set(prev)
+            // Range replace within this kind; keep other kind's selection.
+            for (const k of prev) {
+              if (parseSelKey(k).kind === kind) next.delete(k)
+            }
+            for (let i = lo; i <= hi; i++) {
+              const rid = orderedIds[i]
+              if (rid) next.add(selKey(kind, rid))
+            }
+            return next
+          })
+        } else {
+          // Anchor not visible (filter changed) — fall back to single select.
+          setSelected(new Set([key]))
+          setAnchor({ kind, id })
+        }
+        return true
+      }
+
+      if (mod) {
+        e.preventDefault()
+        setSelected((prev) => {
+          const next = new Set(prev)
+          if (next.has(key)) next.delete(key)
+          else next.add(key)
+          return next
+        })
+        setAnchor({ kind, id })
+        return true
+      }
+
+      // Plain click: select only this row (highlight). Does not open.
+      e.preventDefault()
+      setSelected(new Set([key]))
+      setAnchor({ kind, id })
+      return true
+    },
+    [anchor],
+  )
+
+  const count = selected.size
+  const cookingCount = selectedIds('session').length
+  const historyCount = selectedIds('history').length
+
+  return {
+    selected,
+    count,
+    cookingCount,
+    historyCount,
+    isSelected,
+    selectedIds,
+    onRowClick,
+    clear,
+    /** Disarm helper for parents that also track a single armed kill/delete row. */
+    hasSelection: count > 0,
+  }
+}


### PR DESCRIPTION
## Summary

Session lists on the **start screen** and **change-session hub** now support multi-select and bulk kill/delete.

Fixes #126

## Behavior

| Input | Result |
|---|---|
| Plain click | Select + highlight (does **not** open) |
| Ctrl/⌘-click | Toggle in selection |
| Shift-click | Range within Cooking **or** History |
| Double-click / Enter | Open / resume |
| Bulk bar | **Kill** (live) / **Delete forever** (history) with yes/no confirm |
| Esc | Clear selection → cancel single-row arm → close hub |
| Trailing Power/Trash | Unchanged single-row flow |

## Implementation

- `sessionListSelection.ts` — selection hook (kind-scoped keys, range anchor)
- `SessionBulkBar.tsx` — bulk UI + confirm (same danger tint language as single-row strip)
- Wire-up in `StartScreen.tsx` + `ResumePalette.tsx`
- Help blurb in `HelpTab.tsx`
- Loops existing `KillSession` / `DeleteSession` reqs — **no new Rust API**

## Test plan

- [x] Start screen: plain click highlight, Ctrl toggle, Shift range
- [x] Bulk Delete forever on history (yes/no)
- [x] Double-click / Enter opens session
- [x] Change-session hub: multi-select + bulk Kill on cooking
- [x] Single-row trailing Power/Trash still works
- [x] Esc clears selection first
- [x] Built + exercised via local `koma-dev gui` (Fedora Bluefin / GNOME)

## Notes

Out of scope (see #127): right-click context menu.