### PR TITLE
fix: restore main-chat mouse-wheel scroll

### DIFF
--- a/src-agent/src/app/runtime/actions/mod.rs
+++ b/src-agent/src/app/runtime/actions/mod.rs
@@ -61,8 +61,8 @@ pub(in crate::app::runtime) use mcp::save_and_reload_mcp;
 pub(crate) use config_reload::{apply_global_catalogue_reload, save_config_and_broadcast};
 mod settings_creds;
 
-/// Apply mouse-capture mode to the terminal. Resolves `Auto` via env detection
-/// (`TERMUX_VERSION`), then sends the appropriate crossterm escape sequence.
+/// Apply mouse-capture mode to the terminal. Resolves `Auto` (always true),
+/// then sends the appropriate crossterm escape sequence.
 /// Called at session init and on settings save.
 pub(in crate::app::runtime) fn apply_mouse_capture(mode: crate::model::settings::MouseCapture) {
     use ratatui::crossterm::event::{DisableMouseCapture, EnableMouseCapture};

--- a/src-agent/src/app/runtime/client/mod.rs
+++ b/src-agent/src/app/runtime/client/mod.rs
@@ -666,9 +666,9 @@ pub fn client_run(opts: crate::cli::Opts) -> Result<()> {
     // anywhere after still restores the terminal. The guard persists ACROSS the loop so a
     // detach-then-swap re-attaches without re-entering the alt-screen.
     let _guard = TerminalGuard::enter()?;
-    // Enable mouse capture so scroll events arrive as Event::Mouse (the daemon path
-    // does this in lifecycle::run but the client path previously skipped it, leaving
-    // mouse scroll dead on all platforms).
+    // Enable mouse capture so scroll events arrive as Event::Mouse. Auto resolves
+    // to ON (the default). If the session's mouse_capture is Off, the first
+    // Snapshot in render_loop will re-apply it via a one-shot sync.
     crate::app::runtime::actions::apply_mouse_capture(
         crate::model::settings::MouseCapture::Auto,
     );

--- a/src-agent/src/app/runtime/client/render.rs
+++ b/src-agent/src/app/runtime/client/render.rs
@@ -104,6 +104,10 @@ pub(super) fn render_loop(
     // the shadow is NOT in the agents full-screen editor so each fresh open re-sends.
     let mut last_sent_wrap_w: Option<usize> = None;
 
+    // One-shot: re-apply the session's mouse_capture setting after the first Snapshot
+    // populates the shadow. Until then, the initial Auto (from `client_run`) is active.
+    let mut mouse_capture_synced = false;
+
     // Per-connection seq tracking (critique #1). `expected` is the seq the NEXT
     // frame should carry. `0` means "not yet seeded" — the first frame seeds it.
     let mut expected: u64 = 0;
@@ -191,6 +195,21 @@ pub(super) fn render_loop(
                 // Nothing more will ever arrive — leave the client.
                 Err(TryRecvError::Disconnected) => return Ok(ClientTransition::Exit { kill: false }),
             }
+        }
+
+        // One-shot: after the first Snapshot populates the shadow, re-apply the
+        // session's mouse_capture setting so an explicit `Off` overrides the
+        // startup `Auto`.
+        if !mouse_capture_synced && seeded {
+            mouse_capture_synced = true;
+            let mc = shadow
+                .rest
+                .fg()
+                .session
+                .as_ref()
+                .map(|s| s.settings.mouse_capture)
+                .unwrap_or_default();
+            crate::app::runtime::actions::apply_mouse_capture(mc);
         }
 
         // `/resume` hand-off: the daemon signalled `OpenSwapper` this drain pass. Hand

--- a/src-agent/src/app/runtime/event_loop/mod.rs
+++ b/src-agent/src/app/runtime/event_loop/mod.rs
@@ -194,18 +194,28 @@ pub(super) fn run_loop(
                         }
                     }
                     Event::Mouse(m) => {
-                        // Wheel scrolls the chat transcript only.
+                        // Wheel scrolls the chat transcript or the full-screen
+                        // sub-agent viewer (client-owned; mirrors the client path).
                         if matches!(state.mode(), Mode::Chat | Mode::Bash(_) | Mode::Todo(_)) {
+                            let viewer = state.rest.agent_viewer.is_some();
                             match m.kind {
                                 MouseEventKind::ScrollUp => {
                                     for _ in 0..3 {
-                                        state.rest.scroll_up();
+                                        if viewer {
+                                            state.rest.agent_viewer_scroll_up(1);
+                                        } else {
+                                            state.rest.scroll_up();
+                                        }
                                     }
                                     dirty = true;
                                 }
                                 MouseEventKind::ScrollDown => {
                                     for _ in 0..3 {
-                                        state.rest.scroll_down();
+                                        if viewer {
+                                            state.rest.agent_viewer_scroll_down(1);
+                                        } else {
+                                            state.rest.scroll_down();
+                                        }
                                     }
                                     dirty = true;
                                 }

--- a/src-agent/src/model/settings.rs
+++ b/src-agent/src/model/settings.rs
@@ -161,9 +161,14 @@ impl std::fmt::Display for InternetMode {
 
 /// Controls mouse-capture behaviour for the TUI.
 ///
-/// On touch terminals (Termux), mouse capture is needed for scroll gestures.
-/// On desktop, capture should stay OFF so native terminal selection works.
-/// `Auto` detects the environment once at startup; the user can override.
+/// Mouse capture is required for wheel-scroll to work in the main chat. Without
+/// it, most terminals emit CSI Up/Down for the wheel, which walks composer
+/// history instead of scrolling the transcript. The trade-off: native terminal
+/// drag-select requires capture OFF. Users who prefer native selection can set
+/// `Off` or use `/select` (which temporarily disables capture).
+///
+/// `Auto` enables capture on all platforms. `On` forces it on; `Off` forces it
+/// off (native drag-select; wheel becomes arrow keys).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum MouseCapture {
@@ -192,11 +197,11 @@ impl MouseCapture {
         }
     }
 
-    /// Resolve `Auto` based on environment detection (TERMUX_VERSION).
+    /// Resolve `Auto` — always enables capture (wheel scroll needs it).
     /// `On` / `Off` pass through unchanged.
     pub fn resolved(self) -> bool {
         match self {
-            Self::Auto => std::env::var_os("TERMUX_VERSION").is_some(),
+            Self::Auto => true,
             Self::On => true,
             Self::Off => false,
         }
@@ -360,9 +365,9 @@ pub struct Settings {
     /// field when the user calls `action="select"`.
     #[serde(default)]
     pub git_ssh_key: Option<String>,
-    /// Mouse-capture mode for the TUI. `Auto` (default) enables capture on
-    /// touch terminals (Termux) and disables it on desktop, so native terminal
-    /// selection works. `On` / `Off` override the detection. Resolved once at
+    /// Mouse-capture mode for the TUI. `Auto` (default) enables capture so
+    /// wheel-scroll works in the main chat. `On` forces capture on; `Off` forces
+    /// it off (native drag-select; wheel becomes arrow keys). Resolved once at
     /// session init and on settings save; not re-polled mid-session.
     #[serde(default)]
     pub mouse_capture: MouseCapture,


### PR DESCRIPTION
MouseCapture::Auto now resolves to capture ON on all platforms. Previously it was gated on TERMUX_VERSION, so desktop always disabled capture — wheel events became CSI Up/Down arrows, walking composer history instead of scrolling the transcript.

- Auto.resolved() returns true unconditionally
- Client render_loop re-applies session mouse_capture after first snapshot (respects explicit Off in settings)
- Standalone wheel routes to agent_viewer when open (mirrors client)
- Doc comments updated to explain the capture/selection trade-off