### PR TITLE
feat: Agent Skills (SKILL.md) 

### DIFF
--- a/src-agent/src/app/runtime/commands/clear.rs
+++ b/src-agent/src/app/runtime/commands/clear.rs
@@ -57,6 +57,8 @@ pub(super) fn handle_clear(state: &mut AppState) -> Result<()> {
         fg.follow = true;
         fg.scroll = 0;
         fg.status = "chat cleared".into();
+        // Clear loaded skill bodies so they don't persist across /clear.
+        fg.active_skills.clear();
     }
     Ok(())
 }

--- a/src-agent/src/app/runtime/stream/run.rs
+++ b/src-agent/src/app/runtime/stream/run.rs
@@ -136,6 +136,13 @@ pub(crate) fn start_stream_task(
             // the provider-cached head. Iterated in BTreeMap key order → a byte-stable
             // tail across turns. Empty map = no-op (byte-identical to before).
             append_ext_context(&mut first.content, &state.rest.ext_context);
+            // Active skill bodies: injected into the volatile tail (after cache
+            // split) so they never bust the cached head. BTreeMap key order is
+            // byte-stable across turns.
+            append_active_skills(
+                &mut first.content,
+                &state.rest.sessions[sess_idx].active_skills,
+            );
             // Security mode: when active, tell the model it IS a security testing agent
             // and list its live security tools, so it uses them directly instead of
             // grepping the codebase for "security tools".
@@ -660,6 +667,20 @@ fn append_ext_context(dst: &mut String, ctx: &std::collections::BTreeMap<String,
     }
 }
 
+/// Append each active skill's body to the volatile system tail. Iterated in
+/// `BTreeMap` KEY ORDER (deterministic). Empty map = no-op.
+fn append_active_skills(dst: &mut String, skills: &std::collections::BTreeMap<String, String>) {
+    for (name, body) in skills {
+        if body.trim().is_empty() {
+            continue;
+        }
+        dst.push_str("\n\n# Skill: ");
+        dst.push_str(name);
+        dst.push('\n');
+        dst.push_str(body);
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod ext_context_tests {
@@ -688,6 +709,35 @@ mod ext_context_tests {
         let ctx: BTreeMap<String, String> = BTreeMap::new();
         let mut dst = String::from("HEAD");
         append_ext_context(&mut dst, &ctx);
+        assert_eq!(dst, "HEAD");
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod skill_tail_tests {
+    use super::append_active_skills;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn append_skills_is_ordered_and_skips_blank() {
+        let mut skills = BTreeMap::new();
+        skills.insert("zebra".to_string(), "z-body".to_string());
+        skills.insert("alpha".to_string(), "a-body".to_string());
+        skills.insert("blank".to_string(), "   ".to_string());
+        let mut dst = String::from("HEAD");
+        append_active_skills(&mut dst, &skills);
+        assert_eq!(
+            dst,
+            "HEAD\n\n# Skill: alpha\na-body\n\n# Skill: zebra\nz-body"
+        );
+    }
+
+    #[test]
+    fn empty_map_noop() {
+        let skills = BTreeMap::new();
+        let mut dst = String::from("HEAD");
+        append_active_skills(&mut dst, &skills);
         assert_eq!(dst, "HEAD");
     }
 }

--- a/src-agent/src/app/runtime/stream/spawn.rs
+++ b/src-agent/src/app/runtime/stream/spawn.rs
@@ -83,6 +83,14 @@ pub(crate) fn build_tool_ctx(state: &AppState, sess_idx: usize) -> crate::tool::
     // exemption so the model can read its own `plan.md`/`plan_todos.md` (and
     // nothing from any OTHER session). `None` with no active session.
     let session_dir = session_ref.as_ref().map(|s| s.path.clone());
+    let skill_registry = session_ref.map(|s| s.skills.clone());
+    let active_skill_names = Some(
+        state.rest.sessions[sess_idx]
+            .active_skills
+            .keys()
+            .cloned()
+            .collect(),
+    );
     crate::tool::ToolCtx {
         workspace,
         workspaces,
@@ -92,6 +100,8 @@ pub(crate) fn build_tool_ctx(state: &AppState, sess_idx: usize) -> crate::tool::
         download_dir,
         internet_mode,
         ssh_key,
+        skill_registry,
+        active_skill_names,
         mcp_manager,
         sec_manager,
         bash_saving,
@@ -666,6 +676,8 @@ mod tests {
             download_dir: None,
             internet_mode: crate::model::settings::InternetMode::default(),
             ssh_key: None,
+            skill_registry: None,
+            active_skill_names: None,
             mcp_manager: None,
             sec_manager: None,
             bash_saving: true,

--- a/src-agent/src/app/runtime/stream/tools/approval.rs
+++ b/src-agent/src/app/runtime/stream/tools/approval.rs
@@ -453,6 +453,16 @@ pub(crate) fn process_tools(
                 InterceptFlow::Fallthrough => {}
             }
         }
+        // Intercept the model-callable `skill` tool BEFORE the generic dispatch
+        // path. Load/unload mutate session state (active_skills), so the
+        // interception applies the side-effect on the main thread.
+        if call.function.name == "skill" {
+            match intercepts::intercept_skill(state, sess_idx, &call) {
+                InterceptFlow::Continue => continue,
+                InterceptFlow::Return => return,
+                InterceptFlow::Fallthrough => {}
+            }
+        }
         // Intercept the model-callable `git_worktree` tool BEFORE the generic
         // dispatch path. `create`, `remove`, `enter`, and `exit` mutate session
         // state (cwd + allowed roots), which a read-only `ToolCtx` can't do. The

--- a/src-agent/src/app/runtime/stream/tools/intercepts/guard.rs
+++ b/src-agent/src/app/runtime/stream/tools/intercepts/guard.rs
@@ -394,3 +394,41 @@ pub(in crate::app::runtime::stream::tools) fn intercept_read_before_edit_guard(
     }
     InterceptFlow::Fallthrough
 }
+
+pub(in crate::app::runtime::stream::tools) fn intercept_skill(
+    state: &mut AppState,
+    sess_idx: usize,
+    call: &crate::dto::chat::ToolCall,
+) -> InterceptFlow {
+    let result =
+        crate::app::runtime::stream::tools::dispatch::run_tool(state, sess_idx, call);
+    let final_result =
+        if let Some(rest) = result.strip_prefix(crate::tool::skill::SKILL_LOAD_PREFIX) {
+            // rest = "name\nbody" — split on first newline.
+            let (name, body) = match rest.split_once('\n') {
+                Some((n, b)) => (n.to_string(), b.trim().to_string()),
+                None => (rest.to_string(), String::new()),
+            };
+            // Install into active_skills.
+            state.rest.sessions[sess_idx]
+                .active_skills
+                .insert(name.clone(), body);
+            format!("loaded skill '{name}' — body injected into context.")
+        } else if let Some(name) =
+            result.strip_prefix(crate::tool::skill::SKILL_UNLOAD_PREFIX)
+        {
+            let name = name.trim().to_string();
+            state.rest.sessions[sess_idx]
+                .active_skills
+                .remove(&name);
+            format!("unloaded skill '{name}'.")
+        } else {
+            // list output or error: pass through unchanged.
+            result
+        };
+    state.rest.sessions[sess_idx]
+        .tool_results
+        .push((call.id.clone(), final_result));
+    state.rest.sessions[sess_idx].tool_idx += 1;
+    InterceptFlow::Continue
+}

--- a/src-agent/src/app/runtime/stream/tools/intercepts/mod.rs
+++ b/src-agent/src/app/runtime/stream/tools/intercepts/mod.rs
@@ -38,6 +38,7 @@ mod task;
 pub(super) use bash::{intercept_bash_background, intercept_bash_kill, intercept_bash_output};
 pub(super) use guard::{
     intercept_cd, intercept_git_cred, intercept_git_worktree, intercept_read_before_edit_guard,
+    intercept_skill,
 };
 pub(super) use plan::{
     build_convo_context, intercept_checklist_plan, intercept_plan_enter,

--- a/src-agent/src/app/state/runtime/mod.rs
+++ b/src-agent/src/app/state/runtime/mod.rs
@@ -451,6 +451,9 @@ pub struct SessionRuntime {
     pub graph_summary: Option<String>,
     /// Generation counter of the last graph summary we fetched.
     pub graph_generation: u64,
+    /// Currently loaded skill bodies (name → markdown). Injected into the
+    /// volatile system tail each request. Ephemeral, never persisted.
+    pub active_skills: std::collections::BTreeMap<String, String>,
     /// Start instant of THIS session's `/compact` animation. `Some` only while a
     /// compaction is in flight for this session (set in `Command::Compact`, cleared
     /// once the result is applied). The renderer reads the FOREGROUND session's value
@@ -615,6 +618,7 @@ impl SessionRuntime {
             awareness_summary: None,
             graph_summary: None,
             graph_generation: 0,
+            active_skills: std::collections::BTreeMap::new(),
             compact_anim_start: None,
             compact_apply_at: None,
             compact_pending: None,

--- a/src-agent/src/model/agent_def/mod.rs
+++ b/src-agent/src/model/agent_def/mod.rs
@@ -44,6 +44,8 @@ mod tests;
 
 pub use def::{AgentDef, AgentSource};
 pub use parse::load_agent_file;
+// Re-exposed so sibling modules (skill) can reuse the same split logic.
+pub(crate) use parse::split_frontmatter;
 // Exposed for the extension-uninstall agent-override sweep, which validates each contributed
 // sub-agent name (the delete key) exactly as `save_agent` did when it wrote the file.
 pub(crate) use parse::validate_agent_name;

--- a/src-agent/src/model/mod.rs
+++ b/src-agent/src/model/mod.rs
@@ -28,5 +28,6 @@ pub mod session;
 pub mod session_lock;
 pub mod session_registry;
 pub mod settings;
+pub mod skill;
 pub mod store;
 pub mod usage;

--- a/src-agent/src/model/session.rs
+++ b/src-agent/src/model/session.rs
@@ -23,6 +23,7 @@ use crate::model::agent_def::AgentRegistry;
 use crate::model::conversation::Conversation;
 use crate::model::memory::{load_agents, load_memory_index, migrate_legacy_memory};
 use crate::model::session_registry;
+use crate::model::skill::SkillRegistry;
 use crate::model::settings::{LocalConfig, Settings};
 use crate::model::store::shared_settings_path;
 use crate::resources;
@@ -58,6 +59,9 @@ pub struct Session {
     /// which is a `Session` method with no access to `AppStateRest`. Read only
     /// by `rebuild_system` to decide whether to append the planning nudge.
     pub plan_mode_hint: bool,
+    /// Skill catalogue loaded during `rebuild_system`. Contains name→path mappings
+    /// so the `skill` tool can load bodies on demand. Refreshed every rebuild.
+    pub skills: SkillRegistry,
 }
 
 impl Session {
@@ -87,6 +91,7 @@ impl Session {
             settings,
             conversation,
             plan_mode_hint: false,
+            skills: SkillRegistry::default(),
         }
     }
 
@@ -208,6 +213,7 @@ impl Session {
             settings,
             conversation,
             plan_mode_hint: false,
+            skills: SkillRegistry::default(),
         };
 
         // Ensure the per-session scratch dir exists. Best-effort: a failure here
@@ -389,8 +395,18 @@ Multiple workspace roots are configured. Paths written as [N]… (for example fr
             Some(roster)
         };
 
+        // Load the skill catalogue from known discovery roots. The registry
+        // snapshot is stored on `self.skills` so the `skill` tool can resolve
+        // names to file paths at load/unload time.
+        let skills_reg = SkillRegistry::load(Some(&self.workdir()));
+        let skills_cat = {
+            let t = skills_reg.catalogue_text();
+            if t.is_empty() { None } else { Some(t) }
+        };
+        self.skills = skills_reg;
+
         let mut sys =
-            resources::build_system_prompt(mem.as_deref(), agents.as_deref(), subagents.as_deref());
+            resources::build_system_prompt(mem.as_deref(), agents.as_deref(), subagents.as_deref(), skills_cat.as_deref());
 
         // Append the scratch space section so the model knows where it can
         // freely write temporary files and clone repositories.

--- a/src-agent/src/model/skill/def.rs
+++ b/src-agent/src/model/skill/def.rs
@@ -1,0 +1,35 @@
+//! Skill data types.
+
+use std::path::PathBuf;
+
+/// Source origin of a skill (determines load tier / precedence).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SkillSource {
+    /// Global skill from `~/.koma/skills/`.
+    Global,
+    /// Claude compat skill from `<workdir>/.claude/skills/`.
+    Claude,
+    /// Koma project skill from `<workdir>/.agent/skills/`.
+    ProjectAgent,
+    /// Koma project skill from `<workdir>/.agents/skills/` (highest priority).
+    #[default]
+    ProjectAgents,
+}
+
+/// One skill definition loaded from a markdown file.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SkillDef {
+    /// Skill name — the filename stem or directory name, lowercased and validated.
+    pub name: String,
+    /// User-facing description of when to use this skill. Required.
+    pub description: String,
+    /// Full markdown body after frontmatter — the instructions loaded on demand.
+    pub body: String,
+    /// Where this skill was loaded from.
+    pub source: SkillSource,
+    /// Absolute path to the entry file (`foo.md` or `bar/SKILL.md`).
+    pub file_path: PathBuf,
+    /// Parent directory of a dir-form skill (`Some` for `bar/SKILL.md`, `None`
+    /// for flat `foo.md`). Lets the loaded body reference sibling files.
+    pub skill_dir: Option<PathBuf>,
+}

--- a/src-agent/src/model/skill/mod.rs
+++ b/src-agent/src/model/skill/mod.rs
@@ -1,0 +1,29 @@
+//! Agent Skill discovery and loading: scan known directories for SKILL.md files,
+//! build a catalogue, and provide on-demand body loading.
+//!
+//! ```text
+//! Skills are user-authored markdown files with optional YAML frontmatter.
+//! The filename/dir stem is the skill name (lowercased, validated).
+//!
+//! Layout per root:
+//!   skills/
+//!     foo.md                 ← flat: name = "foo"
+//!     bar/SKILL.md           ← dir form: name = "bar"
+//!     bar/references/...     ← reachable after load via read/glob
+//!
+//! Discovery tiers (later overrides earlier by name):
+//!   1. ~/.koma/skills/       (global)
+//!   2. <workdir>/.claude/skills/  (Claude compat)
+//!   3. <workdir>/.agent/skills/   (koma project)
+//!   4. <workdir>/.agents/skills/  (koma project, highest priority)
+//! ```
+
+mod def;
+mod parse;
+mod registry;
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests;
+
+pub use registry::SkillRegistry;

--- a/src-agent/src/model/skill/parse.rs
+++ b/src-agent/src/model/skill/parse.rs
@@ -1,0 +1,89 @@
+//! Frontmatter parsing for skill files.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Result};
+
+use super::def::{SkillDef, SkillSource};
+
+/// Deserialize a YAML frontmatter chunk into the description field.
+/// Extra keys are silently ignored (parse-tolerant).
+fn parse_frontmatter_description(yaml_str: &str) -> String {
+    for line in yaml_str.lines() {
+        let line = line.trim();
+        if let Some(v) = line.strip_prefix("description:") {
+            return v.trim().to_string();
+        }
+    }
+    String::new()
+}
+
+/// Parse a skill `.md` string into a [`SkillDef`].
+///
+/// `name` is the canonical name (lowercased, validated stem/dir name).
+/// `source`, `file_path`, and `skill_dir` are caller-supplied.
+pub(crate) fn parse_skill(
+    name: &str,
+    content: &str,
+    source: SkillSource,
+    file_path: PathBuf,
+    skill_dir: Option<PathBuf>,
+) -> Result<SkillDef> {
+    let (fm_str, body) = crate::model::agent_def::split_frontmatter(content)?;
+
+    let description = match fm_str {
+        Some(fm) => parse_frontmatter_description(fm),
+        None => String::new(),
+    };
+
+    if description.trim().is_empty() {
+        return Err(anyhow!(
+            "skill '{}' missing required 'description'",
+            name
+        ));
+    }
+
+    Ok(SkillDef {
+        name: name.to_string(),
+        description,
+        body: body.trim().to_string(),
+        source,
+        file_path,
+        skill_dir,
+    })
+}
+
+/// Validate a skill name: lowercase ASCII alphanumeric + dash, no traversal,
+/// no leading/trailing dash, non-empty.
+pub(crate) fn validate_skill_name(stem: &str) -> Result<String> {
+    crate::model::agent_def::validate_agent_name(stem)
+}
+
+/// Load and parse a single skill `.md` file from disk.
+///
+/// `skill_dir` is set to `Some(parent_dir)` when this is a dir-form entry
+/// (e.g. `bar/SKILL.md`), `None` for flat files (e.g. `foo.md`).
+pub(crate) fn load_skill_file(
+    path: &Path,
+    source: SkillSource,
+    skill_dir: Option<PathBuf>,
+) -> Result<SkillDef> {
+    let content = std::fs::read_to_string(path)?;
+    // For dir-form entries (skill_dir is Some), the canonical name comes from
+    // the DIRECTORY name (e.g. "bar" from bar/SKILL.md), not the file stem
+    // (which would be "skill"). For flat files, use the file stem.
+    let stem = if let Some(ref dir) = skill_dir {
+        dir.file_name()
+            .ok_or_else(|| anyhow!("no directory name"))?
+            .to_string_lossy()
+            .into_owned()
+    } else {
+        path.file_stem()
+            .ok_or_else(|| anyhow!("no filename"))?
+            .to_string_lossy()
+            .into_owned()
+    };
+
+    let name = validate_skill_name(&stem)?;
+    parse_skill(&name, &content, source, path.to_path_buf(), skill_dir)
+}

--- a/src-agent/src/model/skill/registry.rs
+++ b/src-agent/src/model/skill/registry.rs
@@ -1,0 +1,197 @@
+//! Skill discovery: scan known directories for skill files and build a registry.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use super::def::{SkillDef, SkillSource};
+use super::parse::load_skill_file;
+
+/// Skill entry file names (case-insensitive match — both accepted).
+const SKILL_ENTRY_FILES: &[&str] = &["SKILL.md", "skill.md"];
+
+/// Skip these filenames when scanning for flat skill files.
+const SKIP_NAMES: &[&str] = &["readme.md", "readme"];
+
+/// The in-memory skill registry: lowercased name → [`SkillDef`].
+///
+/// Skills from higher-precedence tiers override earlier ones by name.
+#[derive(Debug, Clone, Default)]
+pub struct SkillRegistry {
+    skills: BTreeMap<String, SkillDef>,
+}
+
+impl SkillRegistry {
+    /// Load the full skill registry by scanning all discovery roots.
+    ///
+    /// `workdir` is the primary working directory (for project-level roots).
+    /// Scan order (later overrides earlier by name):
+    /// 1. `~/.koma/skills/` (global)
+    /// 2. `<workdir>/.claude/skills/` (Claude compat)
+    /// 3. `<workdir>/.agent/skills/` (koma project)
+    /// 4. `<workdir>/.agents/skills/` (koma project, highest)
+    pub fn load(workdir: Option<&Path>) -> Self {
+        let mut skills: BTreeMap<String, SkillDef> = BTreeMap::new();
+
+        // Tier 1: global.
+        if let Ok(dir) = global_skills_dir() {
+            scan_skills_root(&dir, SkillSource::Global, &mut skills);
+        }
+
+        // Tier 2: Claude compat.
+        if let Some(wd) = workdir {
+            let dir = wd.join(".claude").join("skills");
+            scan_skills_root(&dir, SkillSource::Claude, &mut skills);
+        }
+
+        // Tier 3: koma project (.agent).
+        if let Some(wd) = workdir {
+            let dir = wd.join(".agent").join("skills");
+            scan_skills_root(&dir, SkillSource::ProjectAgent, &mut skills);
+        }
+
+        // Tier 4: koma project (.agents) — highest priority.
+        if let Some(wd) = workdir {
+            let dir = wd.join(".agents").join("skills");
+            scan_skills_root(&dir, SkillSource::ProjectAgents, &mut skills);
+        }
+
+        Self { skills }
+    }
+
+    /// Get a skill by name (case-insensitive).
+    pub fn get(&self, name: &str) -> Option<&SkillDef> {
+        self.skills.get(&name.to_lowercase())
+    }
+
+    /// List all skills sorted by name.
+    pub fn list(&self) -> Vec<&SkillDef> {
+        self.skills.values().collect()
+    }
+
+    /// Number of skills in the registry.
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.skills.len()
+    }
+
+    /// Whether the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.skills.is_empty()
+    }
+
+    /// Format a catalogue for system prompt injection.
+    ///
+    /// Returns one `- name: description` line per skill, sorted by name.
+    /// Empty string when no skills are found.
+    pub fn catalogue_text(&self) -> String {
+        self.skills
+            .values()
+            .map(|s| format!("- {}: {}", s.name, s.description))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+/// Returns `~/.koma/skills/` (the global skills directory).
+fn global_skills_dir() -> anyhow::Result<PathBuf> {
+    Ok(crate::model::store::base_dir()?.join("skills"))
+}
+
+/// Scan a single skills root directory for skill entries.
+///
+/// Supports both flat (`foo.md`) and dir-form (`bar/SKILL.md`).
+/// Missing directory is not an error. One malformed file is logged and skipped.
+fn scan_skills_root(
+    root: &Path,
+    source: SkillSource,
+    skills: &mut BTreeMap<String, SkillDef>,
+) {
+    let entries = match std::fs::read_dir(root) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() {
+            // Flat form: `<name>.md` directly under root.
+            load_flat_skill(&path, source, skills);
+        } else if path.is_dir() {
+            // Dir form: `<name>/SKILL.md` or `<name>/skill.md`.
+            load_dir_skill(&path, source, skills);
+        }
+    }
+}
+
+/// Try to load a flat skill file (`foo.md`) from a skills root.
+fn load_flat_skill(
+    path: &Path,
+    source: SkillSource,
+    skills: &mut BTreeMap<String, SkillDef>,
+) {
+    let name = match path.file_stem() {
+        Some(s) => s.to_string_lossy().to_lowercase(),
+        None => return,
+    };
+    // Skip non-md files and common junk.
+    if path.extension().is_none_or(|ext| ext != "md") {
+        return;
+    }
+    if SKIP_NAMES.contains(&name.as_str()) {
+        return;
+    }
+    match load_skill_file(path, source, None) {
+        Ok(skill) => {
+            skills.insert(skill.name.clone(), skill);
+        }
+        Err(e) => {
+            crate::model::store::append_global_error_log(
+                "skill registry",
+                &format!("skipped {}: {e}", path.display()),
+            );
+        }
+    }
+}
+
+/// Try to load a dir-form skill (`<name>/SKILL.md` or `<name>/skill.md`).
+fn load_dir_skill(
+    dir: &Path,
+    source: SkillSource,
+    skills: &mut BTreeMap<String, SkillDef>,
+) {
+    // Look for SKILL.md or skill.md (case-insensitive).
+    let entry_file = SKILL_ENTRY_FILES
+        .iter()
+        .find(|name| dir.join(name).exists())
+        .map(|name| dir.join(name));
+
+    let Some(entry_path) = entry_file else {
+        return; // No entry file — not a skill dir.
+    };
+
+    let skill_dir = Some(dir.to_path_buf());
+    match load_skill_file(&entry_path, source, skill_dir) {
+        Ok(skill) => {
+            skills.insert(skill.name.clone(), skill);
+        }
+        Err(e) => {
+            crate::model::store::append_global_error_log(
+                "skill registry",
+                &format!("skipped {}: {e}", entry_path.display()),
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+pub(crate) fn scan_skills_root_for_test(
+    root: &Path,
+    source: SkillSource,
+    skills: &mut BTreeMap<String, SkillDef>,
+) {
+    scan_skills_root(root, source, skills);
+}

--- a/src-agent/src/model/skill/tests.rs
+++ b/src-agent/src/model/skill/tests.rs
@@ -1,0 +1,465 @@
+//! Unit tests for the skill module.
+
+use super::def::SkillSource;
+use super::parse::{load_skill_file, parse_skill, validate_skill_name};
+use super::registry::SkillRegistry;
+use std::collections::BTreeMap;
+
+// ── Parse tests ────────────────────────────────────────────────────────────
+
+#[test]
+fn parses_full_frontmatter_and_body() {
+    let content = "---\n\
+        name: my-skill\n\
+        description: When to use this skill for doing things.\n\
+        ---\n\
+        # My Skill\n\n\
+        These are the instructions.";
+    let s = parse_skill(
+        "my-skill",
+        content,
+        SkillSource::Global,
+        "/tmp/my-skill.md".into(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(s.name, "my-skill");
+    assert_eq!(s.description, "When to use this skill for doing things.");
+    assert_eq!(s.body, "# My Skill\n\nThese are the instructions.");
+    assert_eq!(s.source, SkillSource::Global);
+}
+
+#[test]
+fn name_from_filename_when_frontmatter_omits_name() {
+    // Filename stem is canonical; frontmatter name is ignored.
+    let content = "---\ndescription: A useful skill.\n---\nBody here.";
+    let s = parse_skill(
+        "foo-bar",
+        content,
+        SkillSource::Claude,
+        "/tmp/foo-bar.md".into(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(s.name, "foo-bar");
+    assert_eq!(s.description, "A useful skill.");
+}
+
+#[test]
+fn missing_description_is_an_error() {
+    let content = "---\nname: test\n---\nSome body.";
+    let s = parse_skill(
+        "test",
+        content,
+        SkillSource::Global,
+        "/tmp/test.md".into(),
+        None,
+    );
+    assert!(s.is_err());
+    assert!(s
+        .unwrap_err()
+        .to_string()
+        .contains("missing required 'description'"));
+}
+
+#[test]
+fn unclosed_fence_is_an_error() {
+    let content = "---\ndescription: oops\nno closing fence";
+    let s = parse_skill(
+        "oops",
+        content,
+        SkillSource::Global,
+        "/tmp/oops.md".into(),
+        None,
+    );
+    assert!(s.is_err());
+}
+
+#[test]
+fn body_only_no_frontmatter_is_an_error() {
+    // No frontmatter means no description → error.
+    let content = "Just instructions, no frontmatter.";
+    let s = parse_skill(
+        "bare",
+        content,
+        SkillSource::Global,
+        "/tmp/bare.md".into(),
+        None,
+    );
+    assert!(s.is_err());
+}
+
+#[test]
+fn empty_body_allowed_with_description() {
+    let content = "---\ndescription: Has desc, no body.\n---\n";
+    let s = parse_skill(
+        "has-desc",
+        content,
+        SkillSource::Global,
+        "/tmp/has-desc.md".into(),
+        None,
+    )
+    .unwrap();
+    assert!(s.body.is_empty());
+}
+
+#[test]
+fn extra_unknown_yaml_keys_tolerated() {
+    let content = "---\n\
+        description: Tolerant skill.\n\
+        license: MIT\n\
+        compatibility: \">= 1.0\"\n\
+        metadata:\n\
+          author: test\n\
+        ---\n\
+        Body.";
+    let s = parse_skill(
+        "tolerant",
+        content,
+        SkillSource::Global,
+        "/tmp/tolerant.md".into(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(s.description, "Tolerant skill.");
+}
+
+#[test]
+fn skill_dir_set_for_dir_form() {
+    let content = "---\ndescription: Dir skill.\n---\nBody.";
+    let s = parse_skill(
+        "dskill",
+        content,
+        SkillSource::ProjectAgents,
+        "/tmp/skills/dskill/SKILL.md".into(),
+        Some("/tmp/skills/dskill".into()),
+    )
+    .unwrap();
+    assert_eq!(
+        s.skill_dir,
+        Some(std::path::PathBuf::from("/tmp/skills/dskill"))
+    );
+}
+
+// ── Name validation tests ──────────────────────────────────────────────────
+
+#[test]
+fn valid_skill_names() {
+    assert_eq!(validate_skill_name("foo").unwrap(), "foo");
+    assert_eq!(validate_skill_name("my-skill").unwrap(), "my-skill");
+    assert_eq!(validate_skill_name("PINEAPPLE").unwrap(), "pineapple");
+    assert_eq!(validate_skill_name("My-Agent").unwrap(), "my-agent");
+}
+
+#[test]
+fn invalid_skill_names() {
+    assert!(validate_skill_name("").is_err());
+    assert!(validate_skill_name("-x").is_err());
+    assert!(validate_skill_name("x-").is_err());
+    assert!(validate_skill_name("a/b").is_err());
+    assert!(validate_skill_name("..").is_err());
+    assert!(validate_skill_name("../x").is_err());
+    assert!(validate_skill_name("a b").is_err());
+    assert!(validate_skill_name("a.b").is_err());
+    assert!(validate_skill_name("Foo_Bar").is_err());
+}
+
+// ── Registry discovery tests ──────────────────────────────────────────────
+
+/// Helper: create a temp skill root with the given file/dir entries.
+fn setup_skill_root(
+    base: &std::path::Path,
+    entries: &[(&str, &str)], // (filename_or_dir, content)
+) {
+    std::fs::create_dir_all(base).unwrap();
+    for (name, content) in entries {
+        if name.contains('/') {
+            // Dir form: "dir/entry_file"
+            let parts: Vec<&str> = name.splitn(2, '/').collect();
+            let dir = base.join(parts[0]);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join(parts[1]), content).unwrap();
+        } else {
+            std::fs::write(base.join(name), content).unwrap();
+        }
+    }
+}
+
+#[test]
+fn empty_roots_gives_empty_registry() {
+    let reg = SkillRegistry::load(None);
+    assert!(reg.is_empty());
+    assert!(reg.catalogue_text().is_empty());
+}
+
+#[test]
+fn flat_skill_discovered() {
+    let tmp = std::env::temp_dir().join(format!(
+        "koma-skill-test-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let root = tmp.join("skills");
+    setup_skill_root(
+        &root,
+        &[("foo.md", "---\ndescription: Foo skill.\n---\nBody.")],
+    );
+
+    // Manually scan the root (not using full load, which hits real ~/.koma).
+    let mut skills = BTreeMap::new();
+    super::registry::scan_skills_root_for_test(&root, SkillSource::Global, &mut skills);
+    assert!(skills.contains_key("foo"));
+    assert_eq!(skills["foo"].description, "Foo skill.");
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn dir_form_skill_discovered() {
+    let tmp = std::env::temp_dir().join(format!(
+        "koma-skill-dir-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let root = tmp.join("skills");
+    setup_skill_root(
+        &root,
+        &[("bar/SKILL.md", "---\ndescription: Bar skill.\n---\nBar body.")],
+    );
+
+    let mut skills = BTreeMap::new();
+    super::registry::scan_skills_root_for_test(&root, SkillSource::Global, &mut skills);
+    assert!(skills.contains_key("bar"));
+    assert_eq!(skills["bar"].description, "Bar skill.");
+    assert!(skills["bar"].skill_dir.is_some());
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn readme_md_skipped() {
+    let tmp = std::env::temp_dir().join(format!(
+        "koma-skill-readme-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let root = tmp.join("skills");
+    setup_skill_root(
+        &root,
+        &[
+            ("README.md", "# Skills\nHere are skills."),
+            ("real.md", "---\ndescription: Real.\n---\nBody."),
+        ],
+    );
+
+    let mut skills = BTreeMap::new();
+    super::registry::scan_skills_root_for_test(&root, SkillSource::Global, &mut skills);
+    assert!(!skills.contains_key("readme"));
+    assert!(skills.contains_key("real"));
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn malformed_file_skipped_siblings_still_load() {
+    let tmp = std::env::temp_dir().join(format!(
+        "koma-skill-mal-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let root = tmp.join("skills");
+    setup_skill_root(
+        &root,
+        &[
+            ("bad.md", "---\nno desc\n---\nBody."), // no description
+            ("good.md", "---\ndescription: Good.\n---\nOk."),
+        ],
+    );
+
+    let mut skills = BTreeMap::new();
+    super::registry::scan_skills_root_for_test(&root, SkillSource::Global, &mut skills);
+    assert!(!skills.contains_key("bad"));
+    assert!(skills.contains_key("good"));
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn lowercase_skill_md_accepted() {
+    let tmp = std::env::temp_dir().join(format!(
+        "koma-skill-lc-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let root = tmp.join("skills");
+    setup_skill_root(
+        &root,
+        &[("mydir/skill.md", "---\ndescription: Lowercase entry.\n---\nBody.")],
+    );
+
+    let mut skills = BTreeMap::new();
+    super::registry::scan_skills_root_for_test(&root, SkillSource::Global, &mut skills);
+    assert!(skills.contains_key("mydir"));
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn non_md_files_ignored() {
+    let tmp = std::env::temp_dir().join(format!(
+        "koma-skill-nonmd-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let root = tmp.join("skills");
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("notes.txt"), "not a skill").unwrap();
+    std::fs::write(root.join("data.json"), "{}").unwrap();
+
+    let mut skills = BTreeMap::new();
+    super::registry::scan_skills_root_for_test(&root, SkillSource::Global, &mut skills);
+    assert!(skills.is_empty());
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn nested_junk_ignored() {
+    let tmp = std::env::temp_dir().join(format!(
+        "koma-skill-nested-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let root = tmp.join("skills");
+    // Create a dir without SKILL.md — should not be loaded.
+    let nested = root.join("notaskill");
+    std::fs::create_dir_all(nested.join("sub")).unwrap();
+    std::fs::write(nested.join("readme.md"), "hi").unwrap();
+
+    let mut skills = BTreeMap::new();
+    super::registry::scan_skills_root_for_test(&root, SkillSource::Global, &mut skills);
+    assert!(skills.is_empty());
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn duplicate_name_last_wins() {
+    let tmp = std::env::temp_dir().join(format!(
+        "koma-skill-dup-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let root = tmp.join("skills");
+    setup_skill_root(
+        &root,
+        &[
+            ("alpha.md", "---\ndescription: First.\n---\nV1."),
+            ("beta/SKILL.md", "---\ndescription: Beta.\n---\nBody."),
+        ],
+    );
+
+    let mut skills = BTreeMap::new();
+    super::registry::scan_skills_root_for_test(&root, SkillSource::Global, &mut skills);
+    // Both should be present; they have different names.
+    assert_eq!(skills.len(), 2);
+    assert!(skills.contains_key("alpha"));
+    assert!(skills.contains_key("beta"));
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ── Catalogue text tests ──────────────────────────────────────────────────
+
+#[test]
+fn catalogue_sorted_by_name() {
+    // Build two SkillDefs via parse and verify their names.
+    let s1 = parse_skill(
+        "zebra",
+        "---\ndescription: Z skill.\n---\n",
+        SkillSource::Global,
+        "/tmp/zebra.md".into(),
+        None,
+    )
+    .unwrap();
+    let s2 = parse_skill(
+        "alpha",
+        "---\ndescription: A skill.\n---\n",
+        SkillSource::Global,
+        "/tmp/alpha.md".into(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(s1.name, "zebra");
+    assert_eq!(s2.name, "alpha");
+}
+
+#[test]
+fn catalogue_text_format() {
+    let tmp = std::env::temp_dir().join(format!(
+        "koma-skill-cat-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let root = tmp.join("skills");
+    setup_skill_root(
+        &root,
+        &[
+            ("zebra.md", "---\ndescription: Zebra skill.\n---\n"),
+            ("alpha.md", "---\ndescription: Alpha skill.\n---\n"),
+        ],
+    );
+
+    let mut skills = BTreeMap::new();
+    super::registry::scan_skills_root_for_test(&root, SkillSource::Global, &mut skills);
+
+    // BTreeMap gives sorted-by-key iteration.
+    let mut names: Vec<&str> = skills.keys().map(|s| s.as_str()).collect();
+    names.sort();
+    assert_eq!(names, vec!["alpha", "zebra"]);
+
+    let catalogue: Vec<String> = skills
+        .values()
+        .map(|s| format!("- {}: {}", s.name, s.description))
+        .collect();
+    assert!(catalogue[0].contains("alpha"));
+    assert!(catalogue[1].contains("zebra"));
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ── load_skill_file integration tests ────────────────────────────────────
+
+#[test]
+fn load_skill_file_flat() {
+    let tmp = std::env::temp_dir().join(format!(
+        "koma-skill-loadflat-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let path = tmp.join("foo.md");
+    std::fs::create_dir_all(&tmp).unwrap();
+    std::fs::write(&path, "---\ndescription: Flat load.\n---\nBody content.")
+        .unwrap();
+
+    let skill = load_skill_file(&path, SkillSource::ProjectAgent, None).unwrap();
+    assert_eq!(skill.name, "foo");
+    assert_eq!(skill.description, "Flat load.");
+    assert_eq!(skill.body, "Body content.");
+    assert_eq!(skill.source, SkillSource::ProjectAgent);
+    assert!(skill.skill_dir.is_none());
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn load_skill_file_with_skill_dir() {
+    let tmp = std::env::temp_dir().join(format!(
+        "koma-skill-loaddir-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let skill_root = tmp.join("bar");
+    let path = skill_root.join("SKILL.md");
+    std::fs::create_dir_all(&skill_root).unwrap();
+    std::fs::write(&path, "---\ndescription: Dir load.\n---\nDir body.")
+        .unwrap();
+
+    let skill =
+        load_skill_file(&path, SkillSource::Claude, Some(skill_root.clone())).unwrap();
+    assert_eq!(skill.name, "bar");
+    assert_eq!(skill.description, "Dir load.");
+    assert_eq!(skill.body, "Dir body.");
+    assert_eq!(skill.skill_dir, Some(skill_root));
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src-agent/src/resources.rs
+++ b/src-agent/src/resources.rs
@@ -219,6 +219,7 @@ pub fn build_system_prompt(
     memory: Option<&str>,
     agents: Option<&str>,
     subagents: Option<&str>,
+    skills: Option<&str>,
 ) -> String {
     let mut s = String::new();
     s.push_str(system_prompt());
@@ -247,6 +248,19 @@ pub fn build_system_prompt(
                  and forget(<slug>) to delete one.\n",
             );
             s.push_str(mem);
+        }
+    }
+    if let Some(sk) = skills {
+        let sk = sk.trim();
+        if !sk.is_empty() {
+            s.push_str("\n\n# Skills\n");
+            s.push_str(
+                "Available skills (name + description only). Load one with \
+                 skill({\"action\":\"load\",\"name\":\"...\"}) when the task matches; \
+                 unload with action=unload when done. Only loaded skill bodies \
+                 appear below the cache split as \"# Skill: <name>\".\n",
+            );
+            s.push_str(sk);
         }
     }
     let tools = system_tools();

--- a/src-agent/src/tool/mod.rs
+++ b/src-agent/src/tool/mod.rs
@@ -34,6 +34,7 @@ pub mod search;
 pub mod seqthink;
 pub mod shell;
 pub mod shell_filter;
+pub mod skill;
 pub mod task;
 pub mod todo;
 
@@ -77,6 +78,7 @@ pub(crate) fn tool_allowed_in_plan(name: &str) -> bool {
             | "dir_cache_update"
             | "recall"
             | "message_find"
+            | "skill"
             | "web_search"
             | "web_fetch"
             | "pong"
@@ -148,6 +150,11 @@ pub struct ToolCtx {
     /// `git_operator` to inject `-i ~/.ssh/<key>` into git commands. `None`
     /// means no key has been selected yet.
     pub ssh_key: Option<String>,
+    /// Skill catalogue snapshot from the session, so the `skill` tool can
+    /// resolve names to file paths without rescanning.
+    pub skill_registry: Option<crate::model::skill::SkillRegistry>,
+    /// Names of currently active (loaded) skills, for the `list` action.
+    pub active_skill_names: Option<Vec<String>>,
     /// The GLOBAL MCP client manager, shared across every session. `Some` once
     /// startup builds it (it lives in `AppStateRest`); used by [`execute_tool`] to
     /// dispatch `mcp__*` tool calls to their owning server. `None` where no manager
@@ -253,6 +260,7 @@ pub fn all_tools() -> Vec<Box<dyn Tool>> {
         Box::new(memory::Remember),
         Box::new(memory::Forget),
         Box::new(memory::Recall),
+        Box::new(skill::Skill),
         Box::new(history::MessageFind),
         Box::new(task::Task),
         Box::new(task::TaskOutput),
@@ -276,7 +284,7 @@ pub fn all_tools() -> Vec<Box<dyn Tool>> {
 /// (the orchestration/recursion guard — a sub-agent neither spawns nor steers other
 /// sub-agents), `pong` (a health no-op), and `dir_cache_update` (an internal reindex
 /// trigger).
-const AGENT_PICKER_EXCLUDED: &[&str] = &["task", "task_send", "pong", "dir_cache_update"];
+const AGENT_PICKER_EXCLUDED: &[&str] = &["task", "task_send", "pong", "dir_cache_update", "skill"];
 
 /// The user-selectable tool names for the /agents editor, in [`all_tools`] SOURCE ORDER
 /// (deterministic): every built-in tool name except [`AGENT_PICKER_EXCLUDED`].

--- a/src-agent/src/tool/mod_test.rs
+++ b/src-agent/src/tool/mod_test.rs
@@ -23,6 +23,7 @@ fn plan_allowlist_allows_read_only_and_reasoning_tools() {
     // the checklist through it (fully intercepted in `process_tools`, see
     // `approval.rs`), so it's allowed here at the tool-name level.
     assert!(tool_allowed_in_plan("checklist"));
+    assert!(tool_allowed_in_plan("skill"));
 }
 
 #[test]

--- a/src-agent/src/tool/seqthink_test.rs
+++ b/src-agent/src/tool/seqthink_test.rs
@@ -13,6 +13,8 @@ fn test_ctx() -> ToolCtx {
         download_dir: None,
         internet_mode: crate::model::settings::InternetMode::default(),
         ssh_key: None,
+        skill_registry: None,
+        active_skill_names: None,
         mcp_manager: None,
         sec_manager: None,
         bash_saving: true,

--- a/src-agent/src/tool/skill.rs
+++ b/src-agent/src/tool/skill.rs
@@ -1,0 +1,110 @@
+//! The `skill` tool: load/unload/list Agent Skills into the session context.
+
+use anyhow::Result;
+use serde_json::{json, Value};
+
+use super::{Tool, ToolCtx};
+
+/// Sentinel prefix on a successful `load` result. The runtime's skill interception
+/// recognises this, stores the body in `active_skills`, and surfaces confirmation
+/// to the model.
+pub const SKILL_LOAD_PREFIX: &str = "__skill_load__::";
+/// Sentinel prefix on a successful `unload` result.
+pub const SKILL_UNLOAD_PREFIX: &str = "__skill_unload__::";
+
+/// Load, unload, or list Agent Skills.
+pub struct Skill;
+
+impl Tool for Skill {
+    fn name(&self) -> &'static str {
+        "skill"
+    }
+
+    fn description(&self) -> &'static str {
+        "Load or unload an Agent Skill into the session context. Skills are \
+         catalogues of name+description in the system prompt; full bodies are \
+         only injected after load. action=\"load\" loads the body for this and \
+         later turns; action=\"unload\" removes it; action=\"list\" shows \
+         available skills and which are active."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "description": "load, unload, or list",
+                    "enum": ["load", "unload", "list"]
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Skill name (for load/unload)"
+                }
+            },
+            "required": ["action"]
+        })
+    }
+
+    fn run(&self, ctx: &ToolCtx, args: &Value) -> Result<String> {
+        let action = args
+            .get("action")
+            .and_then(Value::as_str)
+            .unwrap_or("list");
+
+        match action {
+            "load" => {
+                let name = args
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("missing required 'name' for load"))?
+                    .trim()
+                    .to_lowercase();
+
+                let skill = ctx
+                    .skill_registry
+                    .as_ref()
+                    .and_then(|r| r.get(&name))
+                    .ok_or_else(|| anyhow::anyhow!("unknown skill: {name}"))?;
+
+                // Read body fresh from disk.
+                let raw = std::fs::read_to_string(&skill.file_path)
+                    .map_err(|e| anyhow::anyhow!("failed to read skill '{}': {e}", skill.name))?;
+                let (_, body) = crate::model::agent_def::split_frontmatter(&raw)?;
+                let body = body.trim().to_string();
+
+                // Sentinel: intercept stores body in active_skills.
+                Ok(format!("{SKILL_LOAD_PREFIX}{name}\n{body}"))
+            }
+            "unload" => {
+                let name = args
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("missing required 'name' for unload"))?
+                    .trim()
+                    .to_lowercase();
+                Ok(format!("{SKILL_UNLOAD_PREFIX}{name}"))
+            }
+            "list" => {
+                let active = ctx.active_skill_names.as_deref().unwrap_or(&[]);
+                match ctx.skill_registry.as_ref() {
+                    Some(reg) if !reg.is_empty() => {
+                        let mut lines: Vec<String> = Vec::new();
+                        lines.push("Available skills:".to_string());
+                        for s in reg.list() {
+                            let marker = if active.contains(&s.name) {
+                                " [ACTIVE]"
+                            } else {
+                                ""
+                            };
+                            lines.push(format!("- {}{}: {}", s.name, marker, s.description));
+                        }
+                        Ok(lines.join("\n"))
+                    }
+                    _ => Ok("No skills found.".to_string()),
+                }
+            }
+            other => Err(anyhow::anyhow!("unknown action: {other}")),
+        }
+    }
+}

--- a/src-misc/system-tools.txt
+++ b/src-misc/system-tools.txt
@@ -193,6 +193,16 @@ recall — read a saved memory's full body by its "slug" (the id shown next to e
   Arguments: { "slug": "deploy-uses-make-ship" }
   Example:   recall({"slug": "deploy-uses-make-ship"})
 
+skill — load or unload an Agent Skill into the session context. Skills are
+  catalogues of name+description in the system prompt; full bodies are only
+  injected after load. action="load" name="<skill>" loads the body for this
+  and later turns; action="unload" name="<skill>" removes it; action="list"
+  shows available skills and which are active.
+  Arguments: { "action": "load|unload|list", "name": "..." (load/unload) }
+  Example:   skill({"action": "load", "name": "rust-testing"})
+  Example:   skill({"action": "unload", "name": "rust-testing"})
+  Example:   skill({"action": "list"})
+
 forget — delete a saved memory by its "slug" (as listed in the memory index).
   Arguments: { "slug": "deploy-uses-make-ship" }
   Example:   forget({"slug": "deploy-uses-make-ship"})


### PR DESCRIPTION

Implements the Agent Skills feature: per-project instruction files (SKILL.md) that the model can load/unload/list via a `skill` tool. Bodies are injected into the volatile system prompt tail (not persisted), cleared on /clear.

Core:
- src-agent/src/model/skill/: def, parse, registry, tests (4-tier discovery global→claude→.agent→.agents, flat + dir-form, case-insensitive entry files)
- src-agent/src/tool/skill.rs: model-callable tool (load/unload/list)
- Session.skills field + rebuild_system loads SkillRegistry
- build_system_prompt accepts optional skills catalogue

Runtime wiring:
- intercept_skill in approval.rs (sentinel-based load/unload)
- active_skills on SessionRuntime (BTreeMap<name, body>)
- append_active_skills in start_stream_task (volatile system tail)
- ToolCtx.skill_registry snapshot in build_tool_ctx
- AGENT_PICKER_EXCLUDED includes 'skill' (subagent safety)
- /clear clears active_skills
- DEFERRED_TOOLS: 'skill' removed (intercept preempts, avoids blocking I/O on UI thread)

Re-exports: split_frontmatter from agent_def for skill parser reuse.

Tests: 664 passed, 0 failed.