### PR TITLE
fix: skill loader - dir-form companions readable after load

### DIFF
--- a/src-agent/src/app/mode/mod.rs
+++ b/src-agent/src/app/mode/mod.rs
@@ -36,6 +36,7 @@ mod rewind;
 pub mod security;
 mod session_hub;
 pub mod settings;
+pub mod skill_cmd;
 pub mod store;
 pub mod todo;
 
@@ -52,6 +53,8 @@ pub use todo::{parse_todo_file, TodoState};
 // re-touching this line. `allow` silences the meanwhile-unused warning.
 pub use effort::EffortPickerState;
 pub use model_cmd::{ModelCmdState, ModelCmdSub};
+#[allow(unused_imports)]
+pub use skill_cmd::{SkillCmdState, SkillFilterChip, SkillEntry};
 #[allow(unused_imports)]
 pub use help::{HelpEntry, HelpKind, HelpState};
 pub use key_input::KeyInputForm;
@@ -297,4 +300,9 @@ pub enum Mode {
     /// shows the selected item's content, status, and priority. The model writes
     /// todos via the `checklist` tool; the user views them here.
     Todo(Box<TodoState>),
+    /// Skill hub overlay (`/skill`): a searchable, filterable list of skills from
+    /// the session's registry. Users can toggle skills on/off from the hub. The
+    /// inner [`SkillCmdState`] holds the query, chip filter, entry list, and
+    /// cursor. Boxed to keep `Mode` small, consistent with the other list variants.
+    Skill(Box<SkillCmdState>),
 }

--- a/src-agent/src/app/mode/skill_cmd.rs
+++ b/src-agent/src/app/mode/skill_cmd.rs
@@ -1,0 +1,127 @@
+//! [`SkillCmdState`] — the working state for the `/skill` hub overlay.
+//!
+//! A searchable, filterable list of skills loaded from the session's
+//! [`SkillRegistry`](crate::model::skill::SkillRegistry). Users can toggle
+//! skills on/off from the hub.
+
+use std::collections::BTreeSet;
+
+use crate::model::skill::SkillRegistry;
+
+/// Filter chip displayed above the skill list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillFilterChip {
+    /// Show all skills.
+    All,
+    /// Show only active (loaded) skills.
+    Active,
+}
+
+/// A single row in the skill hub.
+#[derive(Debug, Clone)]
+pub struct SkillEntry {
+    /// Skill name.
+    pub name: String,
+    /// One-line description.
+    pub description: String,
+    /// Whether this skill is currently loaded into active_skills.
+    pub is_active: bool,
+}
+
+/// Working state for the `/skill` hub overlay.
+///
+/// `all` holds every skill from the registry; `filtered_idx` is a subset of
+/// indices into `all` that match `query` + the active chip filter.
+/// `selected` is an index into `filtered_idx` (not into `all`).
+#[derive(Debug, Clone)]
+pub struct SkillCmdState {
+    /// The user's live search string (updated on every keypress).
+    pub query: String,
+    /// Active filter chip.
+    pub chip: SkillFilterChip,
+    /// Every skill entry, unfiltered, in display order.
+    pub all: Vec<SkillEntry>,
+    /// Indices into `all` of entries that match the current `query` + chip.
+    pub filtered_idx: Vec<usize>,
+    /// Cursor position within `filtered_idx`.
+    pub selected: usize,
+}
+
+impl SkillCmdState {
+    /// Build the skill hub state from the session's registry + active set.
+    pub fn new(registry: &SkillRegistry, active_skills: &BTreeSet<String>) -> Self {
+        let all: Vec<SkillEntry> = registry
+            .list()
+            .into_iter()
+            .map(|def| SkillEntry {
+                name: def.name.clone(),
+                description: def.description.clone(),
+                is_active: active_skills.contains(&def.name),
+            })
+            .collect();
+        let mut s = Self {
+            query: String::new(),
+            chip: SkillFilterChip::All,
+            all,
+            filtered_idx: vec![],
+            selected: 0,
+        };
+        s.refilter();
+        s
+    }
+
+    /// Rebuild `filtered_idx` from `all` using the current `query` and `chip`.
+    pub fn refilter(&mut self) {
+        let q = self.query.to_lowercase();
+        self.filtered_idx = self
+            .all
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| {
+                // Chip filter
+                match self.chip {
+                    SkillFilterChip::Active if !e.is_active => return false,
+                    _ => {}
+                }
+                // Query filter
+                q.is_empty()
+                    || e.name.to_lowercase().contains(&q)
+                    || e.description.to_lowercase().contains(&q)
+            })
+            .map(|(i, _)| i)
+            .collect();
+        // Clamp
+        if self.selected >= self.filtered_idx.len() {
+            self.selected = self.filtered_idx.len().saturating_sub(1);
+        }
+    }
+
+    /// Move the cursor up one row (clamps at 0).
+    pub fn move_up(&mut self) {
+        self.selected = self.selected.saturating_sub(1);
+    }
+
+    /// Move the cursor down one row (clamps at the last filtered entry).
+    pub fn move_down(&mut self) {
+        if self.selected + 1 < self.filtered_idx.len() {
+            self.selected += 1;
+        }
+    }
+
+    /// Return the name of the currently highlighted skill, or `None` when the
+    /// filtered list is empty.
+    pub fn selected_name(&self) -> Option<&str> {
+        self.filtered_idx
+            .get(self.selected)
+            .and_then(|&i| self.all.get(i))
+            .map(|e| e.name.as_str())
+    }
+
+    /// Update the `is_active` flag for a skill and refilter.
+    pub fn set_active(&mut self, name: &str, active: bool) {
+        if let Some(entry) = self.all.iter_mut().find(|e| e.name == name) {
+            entry.is_active = active;
+        }
+        self.refilter();
+    }
+}

--- a/src-agent/src/app/runtime/actions/mod.rs
+++ b/src-agent/src/app/runtime/actions/mod.rs
@@ -369,6 +369,28 @@ pub(in crate::app::runtime) fn apply_action(
             bash::handle_bash_kill(id, state)?;
         }
 
+        Action::CloseSkill => {
+            *state.mode_mut() = crate::app::mode::Mode::Chat;
+        }
+
+        Action::SkillToggle(name) => {
+            let sess_idx = state.rest.foreground;
+            let is_active = state.rest.sessions[sess_idx].active_skills.contains_key(&name);
+            if is_active {
+                let msg = super::commands::skill_cmd::deactivate_skill(state, sess_idx, &name);
+                state.rest.fg_mut().status = msg;
+            } else {
+                match super::commands::skill_cmd::activate_skill(state, sess_idx, &name) {
+                    Ok(msg) => state.rest.fg_mut().status = msg,
+                    Err(e) => state.rest.fg_mut().status = format!("error: {e}"),
+                }
+            }
+            // Refresh the hub state's is_active flags
+            if let crate::app::mode::Mode::Skill(s) = state.mode_mut() {
+                s.set_active(&name, !is_active);
+            }
+        }
+
         Action::CloseHelp => {
             *state.mode_mut() = crate::app::mode::Mode::Chat;
         }

--- a/src-agent/src/app/runtime/client/shadow.rs
+++ b/src-agent/src/app/runtime/client/shadow.rs
@@ -371,6 +371,7 @@ pub(super) fn apply_snapshot(shadow: &mut AppState, snap: StateSnapshot) {
         ModeSnapshot::Bash(b) => Mode::Bash(Box::new(shadow_bash(*b))),
         ModeSnapshot::Todo(t) => Mode::Todo(Box::new(shadow_todo(*t))),
         ModeSnapshot::Help(h) => Mode::Help(Box::new(shadow_help(*h))),
+        ModeSnapshot::Skill(s) => Mode::Skill(Box::new(shadow_skill_cmd(*s))),
         ModeSnapshot::Effort(e) => Mode::Effort(Box::new(shadow_effort(e))),
         ModeSnapshot::Model(m) => Mode::Model(Box::new(shadow_model_cmd(*m))),
         ModeSnapshot::Usage(u) => {

--- a/src-agent/src/app/runtime/client_shadow/modes.rs
+++ b/src-agent/src/app/runtime/client_shadow/modes.rs
@@ -30,7 +30,7 @@ use crate::ipc::proto::{
     ExtScreenSnapshot, ExtStoreRowWire, ExtStoreSnapshot, ExtensionsSnapshot, HelpSnapshot,
     KeyInputSnapshot, LoadingSnapshot, McpSnapshot, ModelCmdSnapshot, OnboardProviderSnapshot,
     OnboardSnapshot, PickerSnapshot, RewindSnapshot, SecuritySnapshot, SessionHubSnapshot,
-    TextEditorSnapshot, ToolPickerSnapshot, WarmStatusWire,
+    SkillCmdSnapshot, TextEditorSnapshot, ToolPickerSnapshot, WarmStatusWire,
 };
 use crate::model::app_config::McpTransport;
 use crate::model::store::SessionMeta;
@@ -559,6 +559,33 @@ pub(crate) fn shadow_ext_store(s: ExtStoreSnapshot) -> ExtStoreState {
         installing: s.installing,
         install_error: s.install_error,
         komarun_connected: s.komarun_connected,
+    }
+}
+
+/// Rebuild the `/skill` hub ([`SkillCmdState`]) from its projection.
+///
+/// Mirrors [`shadow_help`]: built as a struct literal so the daemon's query +
+/// filtered_idx + selected + chip are preserved exactly. Render-only — every key
+/// is forwarded to the daemon.
+pub(crate) fn shadow_skill_cmd(s: SkillCmdSnapshot) -> crate::app::mode::SkillCmdState {
+    use crate::app::mode::skill_cmd::{SkillCmdState, SkillEntry, SkillFilterChip};
+    crate::app::mode::SkillCmdState {
+        query: s.query,
+        chip: match s.chip.as_str() {
+            "active" => SkillFilterChip::Active,
+            _ => SkillFilterChip::All,
+        },
+        all: s
+            .all
+            .into_iter()
+            .map(|e| SkillEntry {
+                name: e.name,
+                description: e.description,
+                is_active: e.is_active,
+            })
+            .collect(),
+        filtered_idx: s.filtered_idx,
+        selected: s.selected,
     }
 }
 

--- a/src-agent/src/app/runtime/commands/mod.rs
+++ b/src-agent/src/app/runtime/commands/mod.rs
@@ -37,6 +37,7 @@ pub(crate) mod model_cmd;
 pub(crate) mod extensions;
 mod misc;
 pub(crate) mod new_session;
+pub(crate) mod skill_cmd;
 // `pub(crate)` so the shared `kick_off_health_probe` helper is reachable from BOTH the
 // `/security` command (panel open) and the input-path self-heal (controller), which must
 // start the non-blocking health probe with identical semantics.
@@ -78,6 +79,7 @@ pub(super) fn apply_slash(
         Command::Task(args) => task::handle_task(args, state, client, handle)?,
         Command::Model(args) => model_cmd::handle_model(args, state)?,
         Command::Bash => bash::handle_bash(state)?,
+        Command::Skill(args) => skill_cmd::handle_skill(args, state)?,
         Command::Todo => todo::handle_todo(state)?,
         Command::Cd(path) => cd::handle_cd(path, state, client, handle)?,
         Command::AddDir(path) => cd::handle_adddir(path, state)?,

--- a/src-agent/src/app/runtime/commands/skill_cmd.rs
+++ b/src-agent/src/app/runtime/commands/skill_cmd.rs
@@ -1,0 +1,136 @@
+//! `/skill` command handler: activate/deactivate skills + open the hub.
+
+use anyhow::Result;
+
+use crate::app::mode::{Mode, SkillCmdState};
+use crate::app::state::AppState;
+
+/// Handle the `/skill` slash command: open the skill hub overlay.
+///
+/// Pre-seeds the hub's search query with any trailing argument.
+pub(super) fn handle_skill(args: String, state: &mut AppState) -> Result<()> {
+    let Some(session) = state.rest.fg().session.as_ref() else {
+        state.rest.fg_mut().status = "no active session".into();
+        return Ok(());
+    };
+    let registry = session.skills.clone();
+    if registry.is_empty() {
+        state.rest.fg_mut().status = "no skills found".into();
+        return Ok(());
+    }
+    let active: std::collections::BTreeSet<String> =
+        state.rest.fg().active_skills.keys().cloned().collect();
+    let mut st = SkillCmdState::new(&registry, &active);
+    // Pre-seed query from args
+    if !args.trim().is_empty() {
+        st.query = args.trim().to_string();
+        st.refilter();
+    }
+    *state.mode_mut() = Mode::Skill(Box::new(st));
+    Ok(())
+}
+
+/// Activate (load) a skill by name from the registry into active_skills.
+/// Returns a status message. Errors are returned as Err.
+pub(crate) fn activate_skill(
+    state: &mut AppState,
+    sess_idx: usize,
+    name: &str,
+) -> Result<String> {
+    let skill_def = state.rest.sessions[sess_idx]
+        .session
+        .as_ref()
+        .and_then(|sess| sess.skills.get(name))
+        .ok_or_else(|| anyhow::anyhow!("skill '{}' not found in registry", name))?
+        .clone();
+
+    // Check if already active
+    if state.rest.sessions[sess_idx]
+        .active_skills
+        .contains_key(&skill_def.name)
+    {
+        return Ok(format!("skill '{}' is already loaded", skill_def.name));
+    }
+
+    let body = skill_def.body.clone();
+    let skill_dir = skill_def.skill_dir.clone();
+
+    // Build companion inventory when dir-form (same logic as intercept_skill in guard.rs)
+    let companion_msg = skill_dir.as_ref().map(|dir| {
+        list_companions(dir, &skill_def.name)
+    });
+
+    state.rest.sessions[sess_idx]
+        .active_skills
+        .insert(
+            skill_def.name.clone(),
+            crate::app::state::ActiveSkill { body, skill_dir },
+        );
+
+    Ok(match companion_msg {
+        Some(msg) => msg,
+        None => format!("loaded skill '{}' — body injected into context.", skill_def.name),
+    })
+}
+
+/// Deactivate (unload) a skill by name from active_skills.
+pub(crate) fn deactivate_skill(
+    state: &mut AppState,
+    sess_idx: usize,
+    name: &str,
+) -> String {
+    state.rest.sessions[sess_idx].active_skills.remove(name);
+    format!("unloaded skill '{name}'.")
+}
+
+/// List companion files in a skill directory — inlined from
+/// `guard::list_companions` (which has limited visibility). Lists non-recursive
+/// one level + one level of subdirs, excluding the entry file.
+fn list_companions(skill_dir: &std::path::Path, skill_name: &str) -> String {
+    use std::fs;
+    const ENTRY_FILES: &[&str] = &["SKILL.md", "skill.md"];
+    const MAX_ENTRIES: usize = 50;
+
+    let mut companions: Vec<String> = Vec::new();
+
+    if let Ok(read_dir) = fs::read_dir(skill_dir) {
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            let file_name = entry.file_name().to_string_lossy().to_string();
+            if path.is_file() && !ENTRY_FILES.contains(&file_name.as_str()) {
+                companions.push(file_name);
+            } else if path.is_dir() {
+                if let Ok(sub) = fs::read_dir(&path) {
+                    for sub_entry in sub.flatten() {
+                        if sub_entry.path().is_file() {
+                            let sub_name = format!(
+                                "{}/{}",
+                                file_name,
+                                sub_entry.file_name().to_string_lossy()
+                            );
+                            companions.push(sub_name);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    companions.sort();
+    let truncated = companions.len() > MAX_ENTRIES;
+    companions.truncate(MAX_ENTRIES);
+
+    let dir_display = skill_dir.display();
+    let mut msg = format!("loaded skill '{skill_name}' — {dir_display}/");
+    if companions.is_empty() {
+        msg.push_str(" (no companion files)");
+    } else {
+        msg.push_str(" + companions:\n");
+        for c in &companions {
+            msg.push_str(&format!("  {c}\n"));
+        }
+        if truncated {
+            msg.push_str("  …\n");
+        }
+    }
+    msg
+}

--- a/src-agent/src/app/runtime/stream/run.rs
+++ b/src-agent/src/app/runtime/stream/run.rs
@@ -669,15 +669,18 @@ fn append_ext_context(dst: &mut String, ctx: &std::collections::BTreeMap<String,
 
 /// Append each active skill's body to the volatile system tail. Iterated in
 /// `BTreeMap` KEY ORDER (deterministic). Empty map = no-op.
-fn append_active_skills(dst: &mut String, skills: &std::collections::BTreeMap<String, String>) {
-    for (name, body) in skills {
-        if body.trim().is_empty() {
+fn append_active_skills(
+    dst: &mut String,
+    skills: &std::collections::BTreeMap<String, crate::app::state::ActiveSkill>,
+) {
+    for (name, skill) in skills {
+        if skill.body.trim().is_empty() {
             continue;
         }
         dst.push_str("\n\n# Skill: ");
         dst.push_str(name);
         dst.push('\n');
-        dst.push_str(body);
+        dst.push_str(&skill.body);
     }
 }
 
@@ -717,14 +720,24 @@ mod ext_context_tests {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod skill_tail_tests {
     use super::append_active_skills;
+    use crate::app::state::ActiveSkill;
     use std::collections::BTreeMap;
 
     #[test]
     fn append_skills_is_ordered_and_skips_blank() {
         let mut skills = BTreeMap::new();
-        skills.insert("zebra".to_string(), "z-body".to_string());
-        skills.insert("alpha".to_string(), "a-body".to_string());
-        skills.insert("blank".to_string(), "   ".to_string());
+        skills.insert(
+            "zebra".to_string(),
+            ActiveSkill { body: "z-body".to_string(), skill_dir: None },
+        );
+        skills.insert(
+            "alpha".to_string(),
+            ActiveSkill { body: "a-body".to_string(), skill_dir: None },
+        );
+        skills.insert(
+            "blank".to_string(),
+            ActiveSkill { body: "   ".to_string(), skill_dir: None },
+        );
         let mut dst = String::from("HEAD");
         append_active_skills(&mut dst, &skills);
         assert_eq!(

--- a/src-agent/src/app/runtime/stream/spawn.rs
+++ b/src-agent/src/app/runtime/stream/spawn.rs
@@ -91,6 +91,11 @@ pub(crate) fn build_tool_ctx(state: &AppState, sess_idx: usize) -> crate::tool::
             .cloned()
             .collect(),
     );
+    let active_skill_dirs: Vec<std::path::PathBuf> = state.rest.sessions[sess_idx]
+        .active_skills
+        .values()
+        .filter_map(|s| s.skill_dir.clone())
+        .collect();
     crate::tool::ToolCtx {
         workspace,
         workspaces,
@@ -102,6 +107,7 @@ pub(crate) fn build_tool_ctx(state: &AppState, sess_idx: usize) -> crate::tool::
         ssh_key,
         skill_registry,
         active_skill_names,
+        active_skill_dirs,
         mcp_manager,
         sec_manager,
         bash_saving,
@@ -678,6 +684,7 @@ mod tests {
             ssh_key: None,
             skill_registry: None,
             active_skill_names: None,
+            active_skill_dirs: Vec::new(),
             mcp_manager: None,
             sec_manager: None,
             bash_saving: true,

--- a/src-agent/src/app/runtime/stream/tools/intercepts/guard.rs
+++ b/src-agent/src/app/runtime/stream/tools/intercepts/guard.rs
@@ -409,11 +409,27 @@ pub(in crate::app::runtime::stream::tools) fn intercept_skill(
                 Some((n, b)) => (n.to_string(), b.trim().to_string()),
                 None => (rest.to_string(), String::new()),
             };
+            // Look up skill_dir from the skill registry on the session.
+            let skill_dir = state.rest.sessions[sess_idx]
+                .session
+                .as_ref()
+                .and_then(|sess| sess.skills.get(&name))
+                .and_then(|s| s.skill_dir.clone());
+            // Build companion inventory when dir-form.
+            let companion_msg = skill_dir.as_ref().map(|dir| {
+                list_companions(dir, &name)
+            });
             // Install into active_skills.
             state.rest.sessions[sess_idx]
                 .active_skills
-                .insert(name.clone(), body);
-            format!("loaded skill '{name}' — body injected into context.")
+                .insert(name.clone(), crate::app::state::ActiveSkill {
+                    body,
+                    skill_dir,
+                });
+            match companion_msg {
+                Some(msg) => msg,
+                None => format!("loaded skill '{name}' — body injected into context."),
+            }
         } else if let Some(name) =
             result.strip_prefix(crate::tool::skill::SKILL_UNLOAD_PREFIX)
         {
@@ -431,4 +447,133 @@ pub(in crate::app::runtime::stream::tools) fn intercept_skill(
         .push((call.id.clone(), final_result));
     state.rest.sessions[sess_idx].tool_idx += 1;
     InterceptFlow::Continue
+}
+
+/// List companion files in a skill directory (non-recursive one level + one
+/// level of subdirs), excluding the entry file (`SKILL.md`/`skill.md`).
+/// Returns the full user-facing load confirmation message.
+fn list_companions(skill_dir: &std::path::Path, skill_name: &str) -> String {
+    use std::fs;
+    const ENTRY_FILES: &[&str] = &["SKILL.md", "skill.md"];
+    const MAX_ENTRIES: usize = 50;
+
+    let mut companions: Vec<String> = Vec::new();
+
+    if let Ok(read_dir) = fs::read_dir(skill_dir) {
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            let file_name = entry.file_name().to_string_lossy().to_string();
+            if path.is_file() && !ENTRY_FILES.contains(&file_name.as_str()) {
+                companions.push(file_name);
+            } else if path.is_dir() {
+                // One-level subdirs (e.g. references/).
+                if let Ok(sub) = fs::read_dir(&path) {
+                    for sub_entry in sub.flatten() {
+                        if sub_entry.path().is_file() {
+                            let sub_name = format!(
+                                "{}/{}",
+                                file_name,
+                                sub_entry.file_name().to_string_lossy()
+                            );
+                            companions.push(sub_name);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    companions.sort();
+    let truncated = companions.len() > MAX_ENTRIES;
+    companions.truncate(MAX_ENTRIES);
+
+    let dir_display = skill_dir.display();
+    let mut msg = format!(
+        "loaded skill '{skill_name}' — body injected into context.\n\
+         skill_dir: {dir_display}"
+    );
+    if companions.is_empty() {
+        msg.push_str("\n(no companion files in skill directory)");
+    } else {
+        msg.push_str("\ncompanions (use the `read` tool with absolute paths under skill_dir):\n");
+        for c in &companions {
+            msg.push_str(&format!("  - {c}\n"));
+        }
+        if truncated {
+            msg.push_str("  ... (truncated at 50 entries)\n");
+        }
+    }
+    msg
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::list_companions;
+
+    #[test]
+    fn lists_companions_and_skips_entry_files() {
+        let tmp = std::env::temp_dir().join(format!(
+            "koma-guard-test-companions-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(tmp.join("SKILL.md"), "# skill body").unwrap();
+        std::fs::write(tmp.join("helper.md"), "helper content").unwrap();
+        std::fs::write(tmp.join("notes.txt"), "notes").unwrap();
+
+        let msg = list_companions(&tmp, "test-skill");
+        assert!(msg.contains("loaded skill 'test-skill'"));
+        assert!(msg.contains("skill_dir:"));
+        assert!(msg.contains("- helper.md"));
+        assert!(msg.contains("- notes.txt"));
+        // SKILL.md must NOT appear as a companion.
+        assert!(!msg.contains("- SKILL.md"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn lists_subdir_companions_one_level_deep() {
+        let tmp = std::env::temp_dir().join(format!(
+            "koma-guard-test-subdir-{}",
+            std::process::id()
+        ));
+        let refs = tmp.join("references");
+        std::fs::create_dir_all(&refs).unwrap();
+        std::fs::write(tmp.join("SKILL.md"), "# skill").unwrap();
+        std::fs::write(refs.join("api.md"), "api ref").unwrap();
+        std::fs::write(refs.join("deep.md"), "deep").unwrap();
+
+        let msg = list_companions(&tmp, "subdir-skill");
+        assert!(msg.contains("- references/api.md"));
+        assert!(msg.contains("- references/deep.md"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn flat_skill_dir_shows_no_companions() {
+        let tmp = std::env::temp_dir().join(format!(
+            "koma-guard-test-empty-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(tmp.join("SKILL.md"), "# skill").unwrap();
+        // No other files.
+
+        let msg = list_companions(&tmp, "empty-skill");
+        assert!(msg.contains("(no companion files in skill directory)"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn nonexistent_dir_shows_no_companions() {
+        let fake = std::path::PathBuf::from(format!(
+            "/tmp/koma-guard-test-nonexistent-{}",
+            std::process::id()
+        ));
+        let msg = list_companions(&fake, "ghost");
+        assert!(msg.contains("(no companion files in skill directory)"));
+    }
 }

--- a/src-agent/src/app/state/mod.rs
+++ b/src-agent/src/app/state/mod.rs
@@ -39,6 +39,7 @@ pub use types::{AgentMode, ToastKind};
 // outside this module while there is a single foreground session.
 #[allow(unused_imports)]
 pub use runtime::SessionRuntime;
+pub use runtime::ActiveSkill;
 // The extension-injection turn budget (cost-DoS guard): shared by the deferred-drain
 // injection gate and the `chat.prompt` broker so both consult the SAME ceiling.
 pub use runtime::EXT_TURN_BUDGET;

--- a/src-agent/src/app/state/rest.rs
+++ b/src-agent/src/app/state/rest.rs
@@ -96,6 +96,7 @@ pub struct AppStateRest {
     pub hub_history_offset: std::cell::Cell<usize>,
     pub rewind_offset: std::cell::Cell<usize>,
     pub todo_offset: std::cell::Cell<usize>,
+    pub skill_offset: std::cell::Cell<usize>,
     pub key_input_results_offset: std::cell::Cell<usize>,
     pub settings_dir_picker_offset: std::cell::Cell<usize>,
     /// Persisted scroll offset for the Appearance category's palette box list
@@ -530,6 +531,7 @@ impl AppStateRest {
             hub_history_offset: std::cell::Cell::new(0),
             rewind_offset: std::cell::Cell::new(0),
             todo_offset: std::cell::Cell::new(0),
+            skill_offset: std::cell::Cell::new(0),
             key_input_results_offset: std::cell::Cell::new(0),
             settings_dir_picker_offset: std::cell::Cell::new(0),
             settings_palette_offset: std::cell::Cell::new(0),

--- a/src-agent/src/app/state/runtime/mod.rs
+++ b/src-agent/src/app/state/runtime/mod.rs
@@ -56,6 +56,19 @@ use super::types::ToastKind;
 /// re-exported through `app::state` so both consumers share the ONE constant.
 pub const EXT_TURN_BUDGET: u32 = 10;
 
+/// Currently loaded skill: the body injected into context, plus an optional
+/// `skill_dir` for dir-form skills (`bar/SKILL.md` sets `Some(bar/)`; flat
+/// `foo.md` sets `None`). `skill_dir` is used at load time to list companion
+/// files and later to grant read-only access through `resolve_read`.
+#[derive(Debug, Clone)]
+pub struct ActiveSkill {
+    /// Markdown body injected into the volatile system tail.
+    pub body: String,
+    /// Dir-form only: absolute path to the skill's parent directory.
+    /// `None` for flat skills.
+    pub skill_dir: Option<PathBuf>,
+}
+
 /// Per-session execution state. Always non-empty in [`super::AppStateRest::sessions`];
 /// the foreground one is reached through `fg()` / `fg_mut()`.
 pub struct SessionRuntime {
@@ -451,9 +464,9 @@ pub struct SessionRuntime {
     pub graph_summary: Option<String>,
     /// Generation counter of the last graph summary we fetched.
     pub graph_generation: u64,
-    /// Currently loaded skill bodies (name → markdown). Injected into the
+    /// Currently loaded skill bodies (name → [`ActiveSkill`]). Injected into the
     /// volatile system tail each request. Ephemeral, never persisted.
-    pub active_skills: std::collections::BTreeMap<String, String>,
+    pub active_skills: std::collections::BTreeMap<String, ActiveSkill>,
     /// Start instant of THIS session's `/compact` animation. `Some` only while a
     /// compaction is in flight for this session (set in `Command::Compact`, cleared
     /// once the result is applied). The renderer reads the FOREGROUND session's value

--- a/src-agent/src/controller/command.rs
+++ b/src-agent/src/controller/command.rs
@@ -48,6 +48,7 @@ pub const COMMANDS: &[(&str, &str)] = &[
     ),
     ("/bash", "Manage background bash jobs"),
     ("/todo", "View the session task list"),
+    ("/skill", "Load or unload agent skills"),
     ("/cd", "Change the session working directory"),
     ("/adddir", "Add a directory to the workspace roots"),
     ("/compact", "Summarize and compact the conversation"),
@@ -175,6 +176,9 @@ pub enum Command {
     /// Switch session or agent model. Inner string is the raw remainder after
     /// `/model` — subcommand dispatch happens in the handler.
     Model(String),
+    /// Open the `/skill` hub overlay. Inner string is the raw remainder after
+    /// `/skill` — pre-seeds the hub's search query if non-empty.
+    Skill(String),
     /// An unrecognised command verb; holds the raw verb for display.
     Unknown(String),
 }
@@ -232,6 +236,7 @@ pub fn parse(line: &str) -> Command {
         "security" => Command::Security,
         "task" => Command::Task(rest.to_string()),
         "model" => Command::Model(rest.to_string()),
+        "skill" => Command::Skill(rest.to_string()),
         "bash" => Command::Bash,
         "todo" => Command::Todo,
         "cd" => Command::Cd(rest.to_string()),

--- a/src-agent/src/controller/input/action.rs
+++ b/src-agent/src/controller/input/action.rs
@@ -353,4 +353,9 @@ pub enum Action {
     /// tool_call_id present) and lets the park gate in `deferred.rs`
     /// (`pending_subagent_calls.is_empty()`) resume the turn automatically.
     BackgroundAllSubagents,
+    // --- Skill hub actions ---
+    /// Esc in the `/skill` hub — close it and return to Chat.
+    CloseSkill,
+    /// Enter on a row in `/skill` — toggle load/unload. Inner String is the skill name.
+    SkillToggle(String),
 }

--- a/src-agent/src/controller/input/mod.rs
+++ b/src-agent/src/controller/input/mod.rs
@@ -32,6 +32,7 @@ mod rewind;
 mod security;
 mod session_hub;
 mod settings;
+mod skill_cmd;
 mod store;
 mod todo;
 mod usage;
@@ -111,6 +112,7 @@ pub fn handle_key(state: &mut AppState, key: KeyEvent) -> Action {
         Mode::Security(s) => security::handle_security(s, &mut state.rest, key),
         Mode::Bash(b) => bash::handle_bash(b, &mut state.rest, key),
         Mode::Todo(t) => todo::handle_todo(t, &mut state.rest, key),
+        Mode::Skill(s) => skill_cmd::handle_skill_cmd(s, &mut state.rest, key),
         Mode::Help(h) => help::handle_help(h, &mut state.rest, key),
         Mode::Effort(e) => handle_effort(e, &mut state.rest, key),
         Mode::Model(m) => model_cmd::handle_model_cmd(m, &mut state.rest, key),

--- a/src-agent/src/controller/input/paste.rs
+++ b/src-agent/src/controller/input/paste.rs
@@ -160,6 +160,12 @@ pub fn handle_paste(state: &mut AppState, text: &str) {
             paste_single_line(text, |c| h.query.push(c));
             h.refilter();
         }
+        Mode::Skill(s) => {
+            // The `/skill` hub has a live search field: paste feeds the
+            // query and re-runs the filter, exactly as a typed char does.
+            paste_single_line(text, |c| s.query.push(c));
+            s.refilter();
+        }
         Mode::OnboardProvider(op) => {
             use crate::app::mode::onboard_provider::OnboardProviderStep;
             use crate::app::mode::settings::OAuthFlowState;

--- a/src-agent/src/controller/input/skill_cmd.rs
+++ b/src-agent/src/controller/input/skill_cmd.rs
@@ -1,0 +1,74 @@
+//! Key handler for the `/skill` hub overlay (`Mode::Skill`).
+//!
+//! An omnisearch filter + chip-select surface:
+//!
+//! - Printable char → push to `query`, refilter.
+//! - Backspace → pop from `query`, refilter.
+//! - Up/Down → move the selection over the filtered list.
+//! - Enter → toggle the selected skill (load ↔ unload).
+//! - Tab/Left/Right → cycle the filter chip (all ↔ active).
+//! - Esc → close back to Chat.
+
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::app::mode::{SkillCmdState, SkillFilterChip};
+use crate::app::state::AppStateRest;
+
+use super::Action;
+
+/// Handle a key press inside the `/skill` hub overlay.
+pub fn handle_skill_cmd(
+    st: &mut SkillCmdState,
+    _rest: &mut AppStateRest,
+    key: KeyEvent,
+) -> Action {
+    match key.code {
+        KeyCode::Esc => Action::CloseSkill,
+
+        KeyCode::Up => {
+            st.move_up();
+            Action::None
+        }
+        KeyCode::Down => {
+            st.move_down();
+            Action::None
+        }
+
+        KeyCode::Enter => match st.selected_name() {
+            Some(name) => Action::SkillToggle(name.to_string()),
+            None => Action::None,
+        },
+
+        // Tab or Left/Right cycles chip
+        KeyCode::Tab | KeyCode::Right => {
+            st.chip = match st.chip {
+                SkillFilterChip::All => SkillFilterChip::Active,
+                SkillFilterChip::Active => SkillFilterChip::All,
+            };
+            st.refilter();
+            Action::None
+        }
+        KeyCode::Left => {
+            st.chip = match st.chip {
+                SkillFilterChip::All => SkillFilterChip::Active,
+                SkillFilterChip::Active => SkillFilterChip::All,
+            };
+            st.refilter();
+            Action::None
+        }
+
+        KeyCode::Backspace => {
+            st.query.pop();
+            st.refilter();
+            Action::None
+        }
+
+        KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            st.query.push(c);
+            st.refilter();
+            Action::None
+        }
+
+        _ => Action::None,
+    }
+}

--- a/src-agent/src/ipc/proto/mod.rs
+++ b/src-agent/src/ipc/proto/mod.rs
@@ -897,6 +897,7 @@ pub enum ModeSnapshot {
     Bash(Box<BashSnapshot>),
     Todo(Box<TodoSnapshot>),
     Help(Box<HelpSnapshot>),
+    Skill(Box<SkillCmdSnapshot>),
     Effort(EffortSnapshot),
     Model(Box<ModelCmdSnapshot>),
     Usage(Box<UsageSnapshot>),

--- a/src-agent/src/ipc/proto/snapshot/panels.rs
+++ b/src-agent/src/ipc/proto/snapshot/panels.rs
@@ -235,6 +235,31 @@ pub struct TodoItemSnapshot {
     pub locked: bool,
 }
 
+/// A serde-safe projection of one skill entry for the `/skill` hub.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct SkillEntrySnapshot {
+    pub name: String,
+    pub description: String,
+    pub is_active: bool,
+}
+
+/// A serde-safe projection of the `/skill` hub overlay.
+///
+/// Mirrors [`crate::app::mode::skill_cmd::SkillCmdState`] field-for-field. Each
+/// entry rides as a `SkillEntrySnapshot`, so a thin client rebuilds and renders
+/// the skill hub instead of a blank Chat screen.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct SkillCmdSnapshot {
+    pub query: String,
+    /// Wire token: "all" | "active"
+    pub chip: String,
+    pub all: Vec<SkillEntrySnapshot>,
+    pub filtered_idx: Vec<usize>,
+    pub selected: usize,
+}
+
 /// A serde-safe projection of the `/todo` task-panel.
 ///
 /// Mirrors [`BashSnapshot`]'s shape (list + cursor): the todo items + the LIST

--- a/src-agent/src/ipc/snapshot/projection/modes.rs
+++ b/src-agent/src/ipc/snapshot/projection/modes.rs
@@ -14,6 +14,7 @@ use crate::app::mode::security::SecurityState;
 use crate::app::mode::settings::{
     ModelDraft, ModelModal, OAuthDraft, PathPicker, PickerMode, ProviderDraft,
 };
+use crate::app::mode::skill_cmd::{SkillCmdState, SkillFilterChip};
 use crate::app::mode::store::{ExtStoreState, StoreRow};
 use crate::app::mode::{
     CookingEntry, EffortPickerState, HistoryEntry, HubPane, KeyInputForm, LoadingState, Mode,
@@ -32,8 +33,8 @@ use crate::ipc::proto::{
     ModelModalSnapshot, OAuthDraftSnapshot, OnboardProviderSnapshot, OnboardSnapshot,
     PathPickerSnapshot, PickerSnapshot, ProviderDraftSnapshot, ProviderModalSnapshot,
     RewindEntrySnapshot, RewindSnapshot, RolePickerSnapshot, SecuritySnapshot, SessionHubSnapshot,
-    SessionMetaSnapshot, SettingsSnapshot, TextEditorSnapshot, TodoItemSnapshot, TodoSnapshot,
-    ToolPickerSnapshot, UsageSnapshot, WarmStatusWire,
+    SessionMetaSnapshot, SettingsSnapshot, SkillCmdSnapshot, SkillEntrySnapshot, TextEditorSnapshot,
+    TodoItemSnapshot, TodoSnapshot, ToolPickerSnapshot, UsageSnapshot, WarmStatusWire,
 };
 
 pub fn mode_snapshot(state: &AppState) -> ModeSnapshot {
@@ -85,6 +86,7 @@ pub fn mode_snapshot(state: &AppState) -> ModeSnapshot {
         // + cursor, so a thin client rebuilds and renders the searchable help screen
         // instead of a blank Chat screen.
         Mode::Help(h) => ModeSnapshot::Help(Box::new(help_snapshot(h))),
+        Mode::Skill(s) => ModeSnapshot::Skill(Box::new(skill_cmd_snapshot(s))),
         Mode::Effort(e) => ModeSnapshot::Effort(effort_snapshot(e)),
         Mode::Model(m) => ModeSnapshot::Model(Box::new(model_cmd_snapshot(m))),
         Mode::Usage(nav) => ModeSnapshot::Usage(Box::new(usage_snapshot(nav, state))),
@@ -826,6 +828,28 @@ pub fn help_snapshot(h: &HelpState) -> HelpSnapshot {
         selected: h.selected,
         current_version: h.current_version.clone(),
         update: h.update.clone(),
+    }
+}
+
+pub fn skill_cmd_snapshot(s: &SkillCmdState) -> SkillCmdSnapshot {
+    SkillCmdSnapshot {
+        query: s.query.clone(),
+        chip: match s.chip {
+            SkillFilterChip::All => "all",
+            SkillFilterChip::Active => "active",
+        }
+        .to_string(),
+        all: s
+            .all
+            .iter()
+            .map(|e| SkillEntrySnapshot {
+                name: e.name.clone(),
+                description: e.description.clone(),
+                is_active: e.is_active,
+            })
+            .collect(),
+        filtered_idx: s.filtered_idx.clone(),
+        selected: s.selected,
     }
 }
 

--- a/src-agent/src/resources.rs
+++ b/src-agent/src/resources.rs
@@ -258,7 +258,9 @@ pub fn build_system_prompt(
                 "Available skills (name + description only). Load one with \
                  skill({\"action\":\"load\",\"name\":\"...\"}) when the task matches; \
                  unload with action=unload when done. Only loaded skill bodies \
-                 appear below the cache split as \"# Skill: <name>\".\n",
+                 appear below the cache split as \"# Skill: <name>\". \
+                 Dir-form skills list companion files in the load result; \
+                 read them with `read` using absolute paths under skill_dir.\n",
             );
             s.push_str(sk);
         }

--- a/src-agent/src/tool/fs/read.rs
+++ b/src-agent/src/tool/fs/read.rs
@@ -35,7 +35,7 @@ impl Tool for Read {
     }
     fn run(&self, ctx: &ToolCtx, args: &Value) -> Result<String> {
         let rel = arg_str(args, "path")?;
-        let path = resolve_read(&ctx.workspaces, rel, ctx.session_dir.as_deref())?;
+        let path = resolve_read(&ctx.workspaces, rel, ctx.session_dir.as_deref(), &ctx.active_skill_dirs)?;
         if path.is_dir() {
             bail!("'{rel}' is a directory, not a file");
         }

--- a/src-agent/src/tool/mod.rs
+++ b/src-agent/src/tool/mod.rs
@@ -555,7 +555,8 @@ pub fn resolve_read(
         // the session dir before the containment check.
         if let Some(session_dir) = session_dir {
             let normalized = partial_canonicalize(as_path);
-            if normalized.starts_with(session_dir) {
+            let session_canon = canonicalize_or_verbatim(session_dir);
+            if normalized.starts_with(&session_canon) {
                 return Ok(normalized);
             }
         }
@@ -564,7 +565,8 @@ pub fn resolve_read(
         // the session_dir check above — `..` tricks can't escape.
         for skill_dir in active_skill_dirs {
             let normalized = partial_canonicalize(as_path);
-            if normalized.starts_with(skill_dir) {
+            let skill_canon = canonicalize_or_verbatim(skill_dir);
+            if normalized.starts_with(&skill_canon) {
                 return Ok(normalized);
             }
         }
@@ -617,6 +619,12 @@ pub fn resolve_read(
         }
     }
     Ok(primary)
+}
+
+/// Canonicalize a path, falling back to verbatim if the OS can't resolve it
+/// (e.g. the parent directory doesn't exist yet).
+fn canonicalize_or_verbatim(p: &Path) -> PathBuf {
+    p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
 }
 
 /// Partial-canonicalize a path: walk up to the longest existing prefix,

--- a/src-agent/src/tool/mod.rs
+++ b/src-agent/src/tool/mod.rs
@@ -182,6 +182,11 @@ pub struct ToolCtx {
     /// `None` when no session is active (or for headless/test constructions), in
     /// which case the exemption is simply skipped.
     pub session_dir: Option<PathBuf>,
+    /// Absolute paths of currently loaded dir-form skill directories. Granted
+    /// read-only access by [`resolve_read`] (mirroring the `session_dir`
+    /// exemption). Built from `active_skills` values where `skill_dir` is
+    /// `Some`. Emptied on unload. Write/edit/delete stay refused.
+    pub active_skill_dirs: Vec<PathBuf>,
 }
 
 /// Parse a `[N]` workspace-index prefix from the start of a path string.
@@ -530,6 +535,7 @@ pub fn resolve_read(
     workspaces: &[PathBuf],
     rel: &str,
     session_dir: Option<&Path>,
+    active_skill_dirs: &[PathBuf],
 ) -> Result<PathBuf> {
     // Absolute scratch-root paths: let resolve() handle the bypass.
     let as_path = Path::new(rel);
@@ -548,31 +554,17 @@ pub fn resolve_read(
         // bypass above, so `..` tricks can't walk the candidate back out of
         // the session dir before the containment check.
         if let Some(session_dir) = session_dir {
-            let normalized = match as_path.canonicalize() {
-                Ok(p) => p,
-                Err(_) => {
-                    let mut existing = as_path;
-                    let mut tail: Vec<std::ffi::OsString> = Vec::new();
-                    while !existing.exists() {
-                        match existing.file_name() {
-                            Some(n) => tail.push(n.to_os_string()),
-                            None => break,
-                        }
-                        match existing.parent() {
-                            Some(p) => existing = p,
-                            None => break,
-                        }
-                    }
-                    let mut base = existing
-                        .canonicalize()
-                        .unwrap_or_else(|_| existing.to_path_buf());
-                    for seg in tail.iter().rev() {
-                        base.push(seg);
-                    }
-                    base
-                }
-            };
+            let normalized = partial_canonicalize(as_path);
             if normalized.starts_with(session_dir) {
+                return Ok(normalized);
+            }
+        }
+        // Active skill dir bypass: read-only access to loaded dir-form skill
+        // directories. Same partial-canonicalize + starts_with containment as
+        // the session_dir check above — `..` tricks can't escape.
+        for skill_dir in active_skill_dirs {
+            let normalized = partial_canonicalize(as_path);
+            if normalized.starts_with(skill_dir) {
                 return Ok(normalized);
             }
         }
@@ -625,6 +617,36 @@ pub fn resolve_read(
         }
     }
     Ok(primary)
+}
+
+/// Partial-canonicalize a path: walk up to the longest existing prefix,
+/// re-append the non-existent tail. Prevents `..` tricks from escaping
+/// containment checks.
+fn partial_canonicalize(as_path: &Path) -> PathBuf {
+    match as_path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => {
+            let mut existing = as_path;
+            let mut tail: Vec<std::ffi::OsString> = Vec::new();
+            while !existing.exists() {
+                match existing.file_name() {
+                    Some(n) => tail.push(n.to_os_string()),
+                    None => break,
+                }
+                match existing.parent() {
+                    Some(p) => existing = p,
+                    None => break,
+                }
+            }
+            let mut base = existing
+                .canonicalize()
+                .unwrap_or_else(|_| existing.to_path_buf());
+            for seg in tail.iter().rev() {
+                base.push(seg);
+            }
+            base
+        }
+    }
 }
 
 /// Pure tool dispatcher: given a ready [`ToolCtx`] and a [`ToolCall`], loop

--- a/src-agent/src/tool/mod_test.rs
+++ b/src-agent/src/tool/mod_test.rs
@@ -39,3 +39,86 @@ fn plan_git_subcommand_denies_mutating() {
     assert!(!plan_git_subcommand_allowed("push"));
     assert!(!plan_git_subcommand_allowed("checkout"));
 }
+
+// --- resolve_read skill-dir exemption tests ---
+
+#[test]
+fn resolve_read_allows_abs_path_under_active_skill_dir() {
+    let tmp = std::env::temp_dir().join(format!(
+        "koma-skill-test-allow-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+    std::fs::write(tmp.join("helper.md"), "content").unwrap();
+
+    let workspaces = vec![std::env::temp_dir().join("koma-nonexistent-workspace")];
+    let skill_dirs = vec![tmp.clone()];
+    let path = resolve_read(&workspaces, tmp.join("helper.md").to_str().unwrap(), None, &skill_dirs);
+    assert!(path.is_ok(), "should allow read under active skill dir");
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn resolve_read_denies_abs_path_under_inactive_skill_dir() {
+    let tmp = std::env::temp_dir().join(format!(
+        "koma-skill-test-deny-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+    std::fs::write(tmp.join("secret.md"), "content").unwrap();
+
+    let workspaces = vec![std::env::temp_dir().join("koma-nonexistent-workspace")];
+    // Empty skill_dirs — skill is NOT active.
+    let skill_dirs: Vec<PathBuf> = vec![];
+    let result = resolve_read(&workspaces, tmp.join("secret.md").to_str().unwrap(), None, &skill_dirs);
+    assert!(result.is_err(), "should deny read when skill dir is not active");
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn resolve_read_skill_dir_escape_via_dotdot_is_denied() {
+    let base = std::env::temp_dir().join(format!(
+        "koma-skill-test-escape-{}",
+        std::process::id()
+    ));
+    let skill_dir = base.join("skill");
+    let outside = base.join("outside");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::write(outside.join("secret.md"), "content").unwrap();
+
+    let workspaces = vec![std::env::temp_dir().join("koma-nonexistent-workspace")];
+    let skill_dirs = vec![skill_dir.clone()];
+    // Attempt to read outside/secret.md via skill_dir/../outside/secret.md.
+    let escaped = skill_dir
+        .join("..")
+        .join("outside")
+        .join("secret.md");
+    let result = resolve_read(
+        &workspaces,
+        escaped.to_str().unwrap(),
+        None,
+        &skill_dirs,
+    );
+    assert!(result.is_err(), "dotdot escape from skill dir must be denied");
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[test]
+fn resolve_write_still_denies_skill_dir() {
+    // resolve() (used by write/edit/delete) must NOT have the skill dir exemption.
+    let tmp = std::env::temp_dir().join(format!(
+        "koma-skill-test-write-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+
+    let workspaces = vec![std::env::temp_dir().join("koma-nonexistent-workspace")];
+    let result = resolve(&workspaces, tmp.join("file.md").to_str().unwrap());
+    assert!(result.is_err(), "resolve() must deny paths outside workspaces");
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src-agent/src/tool/search.rs
+++ b/src-agent/src/tool/search.rs
@@ -51,7 +51,7 @@ impl Tool for Grep {
         };
 
         let search_path = args.get("path").and_then(Value::as_str).unwrap_or(".");
-        let base = resolve_read(&ctx.workspaces, search_path, ctx.session_dir.as_deref())?;
+        let base = resolve_read(&ctx.workspaces, search_path, ctx.session_dir.as_deref(), &ctx.active_skill_dirs)?;
 
         // Optional glob filter.
         let glob_matcher: Option<globset::GlobMatcher> =
@@ -175,7 +175,7 @@ impl Tool for Glob {
             .ok_or_else(|| anyhow::anyhow!("missing required string argument 'pattern'"))?;
 
         let base_rel = args.get("path").and_then(Value::as_str).unwrap_or(".");
-        let _base = resolve_read(&ctx.workspaces, base_rel, ctx.session_dir.as_deref())?; // sandbox check
+        let base_abs = resolve_read(&ctx.workspaces, base_rel, ctx.session_dir.as_deref(), &ctx.active_skill_dirs)?;
 
         let matcher = globset::Glob::new(pattern)
             .map_err(|e| anyhow::anyhow!("invalid glob '{pattern}': {e}"))?
@@ -183,23 +183,33 @@ impl Tool for Glob {
 
         const MAX_RESULTS: usize = 200;
 
-        // Prefer the live dir cache — it's already gitignore-aware and sorted.
-        let cache_files: Vec<String> = {
+        // Check if base is inside a workspace root — if not (e.g. under an
+        // active skill dir), we must walk from base_abs directly instead of
+        // filtering the workspace dir cache.
+        let base_in_workspace = ctx.workspaces.iter().any(|ws| {
+            let ws = ws.canonicalize().unwrap_or_else(|_| ws.clone());
+            base_abs.starts_with(&ws)
+        });
+
+        // Prefer the live dir cache when the base is inside a workspace —
+        // it's already gitignore-aware and sorted.
+        let cache_files: Vec<String> = if base_in_workspace {
             let cache = ctx
                 .dir_cache
                 .read()
                 .map_err(|_| anyhow::anyhow!("dir cache unavailable"))?;
             cache.files.clone()
+        } else {
+            Vec::new()
         };
 
-        let mut results: Vec<String> = if !cache_files.is_empty() {
+        let mut results: Vec<String> = if base_in_workspace && !cache_files.is_empty() {
             cache_files
                 .into_iter()
                 .filter(|f| matcher.is_match(f.as_str()))
                 .collect()
         } else {
-            // Cache empty: fall back to a fresh walk from the base path.
-            let base_abs = resolve_read(&ctx.workspaces, base_rel, ctx.session_dir.as_deref())?;
+            // Cache empty or base outside workspace: walk from base_abs.
             let mut v: Vec<String> = Vec::new();
             for entry in ignore::WalkBuilder::new(&base_abs).build().flatten() {
                 if entry.file_type().is_some_and(|t| t.is_file()) {

--- a/src-agent/src/tool/seqthink_test.rs
+++ b/src-agent/src/tool/seqthink_test.rs
@@ -15,6 +15,7 @@ fn test_ctx() -> ToolCtx {
         ssh_key: None,
         skill_registry: None,
         active_skill_names: None,
+        active_skill_dirs: Vec::new(),
         mcp_manager: None,
         sec_manager: None,
         bash_saving: true,

--- a/src-agent/src/tool/skill.rs
+++ b/src-agent/src/tool/skill.rs
@@ -25,7 +25,9 @@ impl Tool for Skill {
          catalogues of name+description in the system prompt; full bodies are \
          only injected after load. action=\"load\" loads the body for this and \
          later turns; action=\"unload\" removes it; action=\"list\" shows \
-         available skills and which are active."
+         available skills and which are active. Dir-form skills (bar/SKILL.md) \
+         list companion files in the load result — use `read` with absolute \
+         paths under skill_dir to access them."
     }
 
     fn parameters(&self) -> Value {

--- a/src-agent/src/view/mod.rs
+++ b/src-agent/src/view/mod.rs
@@ -33,6 +33,7 @@ pub mod security;
 pub mod session_hub;
 pub mod session_picker;
 pub mod settings;
+pub mod skill_cmd;
 pub mod store;
 pub mod theme;
 pub mod todo;
@@ -227,6 +228,19 @@ pub fn draw(frame: &mut Frame, state: &AppState) {
                 &t.items,
                 t.selected,
                 t.completed_count(),
+                &palette,
+            );
+        }
+        Mode::Skill(s) => {
+            let resolved_model = resolved_main_model(&state.rest);
+            chat::draw(frame, &state.rest, &resolved_model, &palette);
+            let chunks = chat::layout_chunks(&state.rest, frame.area());
+            skill_cmd::render_overlay(
+                frame,
+                chunks[4],
+                chunks[1],
+                s,
+                &state.rest,
                 &palette,
             );
         }

--- a/src-agent/src/view/skill_cmd.rs
+++ b/src-agent/src/view/skill_cmd.rs
@@ -1,0 +1,208 @@
+//! View — skill hub overlay (`/skill`).
+//!
+//! Renders as an overlay anchored above the composer (same pattern as `/bash`,
+//! `/todo`, `/model`). Layout:
+//!
+//! 1. Header: ` skills ` on a `Borders::BOTTOM` rule (dim).
+//! 2. Search line: the live `query` with a block cursor.
+//! 3. Chip row: `[X]all  [ ]active` filter toggles.
+//! 4. Filtered list: name + `[active]` badge + description.
+//! 5. Footer: full-width inverse hint bar.
+
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Margin, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+use crate::app::mode::{SkillCmdState, SkillFilterChip};
+use crate::app::state::AppStateRest;
+use crate::view::theme::Palette;
+
+/// Width the name column is padded to (so descriptions align in a column).
+const NAME_W: usize = 24;
+
+/// Render the skill hub overlay.
+///
+/// `input_rect` is the composer rect (from `chat::layout_chunks()[4]`).
+/// `transcript_rect` is the transcript rect (from `chat::layout_chunks()[1]`).
+pub fn render_overlay(
+    frame: &mut Frame,
+    input_rect: Rect,
+    transcript_rect: Rect,
+    st: &SkillCmdState,
+    rest: &AppStateRest,
+    palette: &Palette,
+) {
+    // Compute the overlay rect: anchored above the composer, extending upward
+    // into the transcript area. Same approach as bash/todo overlays.
+    let overlay_height = 14u16.min(transcript_rect.height);
+    let overlay_y = input_rect.y.saturating_sub(overlay_height);
+    let overlay_rect = Rect {
+        x: input_rect.x,
+        y: overlay_y,
+        width: input_rect.width,
+        height: overlay_height,
+    };
+
+    // Clear the overlay background
+    crate::view::clear_and_fill(frame, overlay_rect, palette.bg);
+
+    // Inner vertical zones: header | search | chips | list | footer
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2),  // header text + BOTTOM border
+            Constraint::Length(1),  // search line
+            Constraint::Length(1),  // chip row
+            Constraint::Min(0),    // filtered list
+            Constraint::Length(1), // footer hint
+        ])
+        .split(overlay_rect);
+
+    // --- Header ---
+    let header_block = Block::new()
+        .borders(Borders::BOTTOM)
+        .border_style(Style::default().fg(palette.dim));
+    let header_inner = header_block.inner(outer[0]);
+    frame.render_widget(header_block, outer[0]);
+    frame.render_widget(
+        Paragraph::new(Span::styled(
+            "skills",
+            Style::default().fg(palette.dim),
+        )),
+        header_inner.inner(Margin {
+            horizontal: 2,
+            vertical: 0,
+        }),
+    );
+
+    // --- Search line (live query + block cursor) ---
+    let search_inner = outer[1].inner(Margin {
+        horizontal: 2,
+        vertical: 0,
+    });
+    let search_line = Line::from(vec![
+        Span::styled("› ", Style::default().fg(palette.dim)),
+        Span::styled(
+            st.query.as_str(),
+            Style::default().fg(palette.fg),
+        ),
+        Span::styled("█", Style::default().fg(palette.accent)),
+    ]);
+    frame.render_widget(Paragraph::new(search_line), search_inner);
+
+    // --- Chip row ---
+    let chip_inner = outer[2].inner(Margin {
+        horizontal: 2,
+        vertical: 0,
+    });
+    let all_style = match st.chip {
+        SkillFilterChip::All => Style::default()
+            .fg(palette.sel_fg)
+            .bg(palette.sel_bg)
+            .add_modifier(Modifier::BOLD),
+        SkillFilterChip::Active => Style::default().fg(palette.dim),
+    };
+    let active_style = match st.chip {
+        SkillFilterChip::Active => Style::default()
+            .fg(palette.sel_fg)
+            .bg(palette.sel_bg)
+            .add_modifier(Modifier::BOLD),
+        SkillFilterChip::All => Style::default().fg(palette.dim),
+    };
+    let chip_line = Line::from(vec![
+        Span::styled("[X]", all_style),
+        Span::styled("all ", all_style),
+        Span::styled("[ ]", active_style),
+        Span::styled("active", active_style),
+    ]);
+    frame.render_widget(Paragraph::new(chip_line), chip_inner);
+
+    // --- Filtered list (windowed) ---
+    let list_inner = outer[3].inner(Margin {
+        horizontal: 2,
+        vertical: 0,
+    });
+    let max_vis = list_inner.height as usize;
+
+    if st.filtered_idx.is_empty() {
+        frame.render_widget(
+            Paragraph::new(Span::styled(
+                "no matches",
+                Style::default().fg(palette.dim),
+            )),
+            list_inner,
+        );
+    } else if max_vis > 0 {
+        let sel = st.selected.min(st.filtered_idx.len() - 1);
+        let (start, end) = crate::view::scroll::scroll_window(
+            &rest.skill_offset,
+            sel,
+            st.filtered_idx.len(),
+            max_vis,
+        );
+
+        let rows: Vec<Line> = st.filtered_idx[start..end]
+            .iter()
+            .enumerate()
+            .map(|(vi, &ai)| {
+                let i = start + vi;
+                let entry = &st.all[ai];
+                let name_col = format!(" {:<NAME_W$}", entry.name);
+                let badge = if entry.is_active {
+                    " [active] "
+                } else {
+                    "          "
+                };
+                if i == sel {
+                    let hl = Style::default().fg(palette.sel_fg).bg(palette.sel_bg);
+                    Line::from(vec![
+                        Span::styled(name_col, hl),
+                        Span::styled(badge, hl),
+                        Span::styled(&entry.description, hl),
+                    ])
+                } else {
+                    let name_style = if entry.is_active {
+                        Style::default().fg(palette.accent)
+                    } else {
+                        Style::default().fg(palette.fg)
+                    };
+                    let badge_style = if entry.is_active {
+                        Style::default().fg(palette.success)
+                    } else {
+                        Style::default().fg(palette.dim)
+                    };
+                    Line::from(vec![
+                        Span::styled(name_col, name_style),
+                        Span::styled(badge, badge_style),
+                        Span::styled(entry.description.clone(), Style::default().fg(palette.dim)),
+                    ])
+                }
+            })
+            .collect();
+
+        frame.render_widget(Paragraph::new(rows), list_inner);
+    }
+
+    // --- Footer: full-width inverse hint bar ---
+    let footer_rect = outer[4];
+    if footer_rect.width > 0 {
+        let hint = "enter toggle · ←/→ filter · esc close";
+        let bar_style = Style::default()
+            .fg(palette.sel_fg)
+            .bg(palette.sel_bg)
+            .add_modifier(Modifier::BOLD);
+        let padded = format!(
+            " {:<width$}",
+            hint,
+            width = footer_rect.width.saturating_sub(1) as usize
+        );
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::raw(padded))).style(bar_style),
+            footer_rect,
+        );
+    }
+}


### PR DESCRIPTION
Problems:
- skill(load) only injected the entry body; skill_dir was discovered but never stored or used, so companion files were unreachable.
- resolve_read blocked all paths outside workspaces, including loaded skill directories.
- glob filtered only the workspace dir_cache, so skill dirs outside workspaces never appeared.

Changes:
- New ActiveSkill struct (body + skill_dir) replaces bare String.
- intercept_skill stores skill_dir, scans companions, returns rich load message with absolute path and file listing.
- ToolCtx gains active_skill_dirs; build_tool_ctx populates it.
- resolve_read accepts active_skill_dirs; paths under active skill dirs allowed read-only. write/edit/delete unchanged.
- Glob walks from base_abs when outside workspace roots.
- Tool/prompt descriptions updated.
- 8 new unit tests for skill-dir access and companion listing.

672 tests pass, 0 failures.