### PR TITLE
feat(api-backoff): retry transient inference errors with 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .serena/
 .env
 **/*.pyc
+.agents/
 
 # build artifacts — non-anchored so they match at ANY depth
 # (root-anchored /target missed src-agent/target etc.)

--- a/src-agent/src/app/runtime/event_loop/sessions/streaming.rs
+++ b/src-agent/src/app/runtime/event_loop/sessions/streaming.rs
@@ -7,7 +7,7 @@ use super::super::super::stream::{advance_turn, finish_stream};
 use super::super::drains::apply_compaction_result;
 use super::super::MIN_COMPACT_ANIM;
 
-/// Drain this session's `active_rx` stream (Token/Reasoning/Usage/ToolCalls/Done/Error/Compacted).
+/// Drain this session's `active_rx` stream (Token/Reasoning/Usage/ToolCalls/Done/Error/Retrying/Compacted).
 /// Returns true if any event was processed.
 pub(super) fn drain_stream(
     state: &mut AppState,
@@ -105,6 +105,14 @@ pub(super) fn drain_stream(
                     state.rest.pending_plan_seed = false;
                     still_streaming = false;
                     break;
+                }
+                StreamEvent::Retrying { attempt, max, delay_ms: _ } => {
+                    // Transient upstream failure; the stream task is sleeping
+                    // and will re-POST.  Update the status line but do NOT
+                    // finish the stream or clear any tool/approval state.
+                    state.rest.sessions[idx].status =
+                        format!("retrying {attempt}/{max}\u{2026}");
+                    // still_streaming remains true — keep draining.
                 }
                 StreamEvent::Compacted { summary, kept_tail } => {
                     // The model is done; the task is finished either way.

--- a/src-agent/src/app/subagent/engine.rs
+++ b/src-agent/src/app/subagent/engine.rs
@@ -647,7 +647,8 @@ async fn stream_step(
             | StreamEvent::Compacted { .. }
             | StreamEvent::HarnessVerdict { .. }
             | StreamEvent::EndpointsLoaded { .. }
-            | StreamEvent::EndpointsError { .. } => {}
+            | StreamEvent::EndpointsError { .. }
+            | StreamEvent::Retrying { .. } => {}
         }
     }
     // The sender task has nothing left to emit; await it so it's fully joined

--- a/src-agent/src/ipc/proto/stream.rs
+++ b/src-agent/src/ipc/proto/stream.rs
@@ -71,7 +71,9 @@ impl StreamEventWire {
                 reason: reason.clone(),
             },
             // Client-local UI events — never sent over the wire.
-            StreamEvent::EndpointsLoaded { .. } | StreamEvent::EndpointsError { .. } => {
+            StreamEvent::EndpointsLoaded { .. }
+            | StreamEvent::EndpointsError { .. }
+            | StreamEvent::Retrying { .. } => {
                 return None
             }
             // `reasoning_details` are accumulated + replayed WITHIN a single turn on

--- a/src-agent/src/service/mod.rs
+++ b/src-agent/src/service/mod.rs
@@ -50,6 +50,17 @@ pub enum StreamEvent {
     Done,
     /// The stream failed; `String` is the error to surface in the status line.
     Error(String),
+    /// A transient upstream error (5xx / 429 / connect failure) was detected
+    /// on the initial POST; the stream task will sleep and retry. Does NOT
+    /// end the turn — the TUI status line updates to show progress.
+    /// `attempt` is 1-based (the attempt *about to start* after the delay),
+    /// `max` is the total number of attempts allowed, `delay_ms` is the
+    /// sleep in milliseconds before the next try.
+    Retrying {
+        attempt: u32,
+        max: u32,
+        delay_ms: u64,
+    },
     /// `/compact` result: the `summary` plus the `kept_tail` snapshot captured
     /// at dispatch time (so compaction is applied against a stable tail).
     Compacted {

--- a/src-agent/src/service/openrouter/anthropic/oneshot.rs
+++ b/src-agent/src/service/openrouter/anthropic/oneshot.rs
@@ -5,7 +5,9 @@ use futures_util::StreamExt;
 
 use crate::dto::chat::ChatMessage;
 
-use super::super::helpers::clean_error;
+use super::super::helpers::{
+    backoff_delay, clean_error, is_retryable_send_err, is_retryable_status, MAX_ATTEMPTS,
+};
 use super::super::Conn;
 use super::super::OpenRouterClient;
 use super::request::{build_messages, thinking_params, AnthropicTool, MessagesRequest};
@@ -75,13 +77,38 @@ impl OpenRouterClient {
             stream: true,
         };
 
-        let rb = anthropic_headers(self.http.post(&url), bearer, false);
-        let resp = rb.json(&body).send().await?;
-        let status = resp.status();
-        if !status.is_success() {
-            let text = resp.text().await.unwrap_or_default();
-            return Err(anyhow!("{}", clean_error(status, &text)));
-        }
+        let resp: reqwest::Response = 'retry: {
+            for attempt in 1u32..=MAX_ATTEMPTS {
+                let send = anthropic_headers(self.http.post(&url), bearer, false)
+                    .json(&body)
+                    .send()
+                    .await;
+                match send {
+                    Ok(r) => {
+                        let status = r.status();
+                        if status.is_success() {
+                            break 'retry r;
+                        }
+                        let text = r.text().await.unwrap_or_default();
+                        if is_retryable_status(status) && attempt < MAX_ATTEMPTS {
+                            let d = backoff_delay(attempt);
+                            tokio::time::sleep(d).await;
+                            continue;
+                        }
+                        return Err(anyhow!("{}", clean_error(status, &text)));
+                    }
+                    Err(e) if is_retryable_send_err(&e) && attempt < MAX_ATTEMPTS => {
+                        let d = backoff_delay(attempt);
+                        tokio::time::sleep(d).await;
+                        continue;
+                    }
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                }
+            }
+            return Err(anyhow!("all retry attempts exhausted"));
+        };
 
         let mut stream = resp.bytes_stream();
         let mut buf: Vec<u8> = Vec::new();

--- a/src-agent/src/service/openrouter/anthropic/stream.rs
+++ b/src-agent/src/service/openrouter/anthropic/stream.rs
@@ -8,7 +8,10 @@ use crate::dto::chat::{ChatMessage, FunctionCall, ReasoningDetail, ToolCall};
 use crate::dto::openrouter::{ImageWireCtx, ToolDef};
 use crate::service::StreamEvent;
 
-use super::super::helpers::{clean_error, emit, sanitize_tool_acc};
+use super::super::helpers::{
+    backoff_delay, clean_error, emit, is_retryable_send_err, is_retryable_status,
+    sanitize_tool_acc, MAX_ATTEMPTS,
+};
 use super::super::Conn;
 use super::super::OpenRouterClient;
 use super::request::{build_messages, flatten_tools, thinking_params, MessagesRequest};
@@ -137,34 +140,82 @@ impl OpenRouterClient {
             stream: true,
         };
 
-        let rb = anthropic_headers(self.http.post(&url), bearer, thinking_on);
-        let resp = match rb.json(&body).send().await {
-            Ok(r) => r,
-            Err(e) => {
+        // ── 5xx / 429 retry with exponential backoff ─────────────────────
+        let resp: reqwest::Response = 'retry: {
+            for attempt in 1u32..=MAX_ATTEMPTS {
+                let send = anthropic_headers(self.http.post(&url), bearer, thinking_on)
+                    .json(&body)
+                    .send()
+                    .await;
+                let r = match send {
+                    Ok(r) => r,
+                    Err(e) if is_retryable_send_err(&e) && attempt < MAX_ATTEMPTS => {
+                        if let Some(ctx) = image_ctx.as_ref() {
+                            crate::model::store::append_error_log(
+                                &ctx.session_dir,
+                                "request send failed",
+                                &e.to_string(),
+                            );
+                        }
+                        let d = backoff_delay(attempt);
+                        emit(
+                            &tx,
+                            StreamEvent::Retrying {
+                                attempt: attempt + 1,
+                                max: MAX_ATTEMPTS,
+                                delay_ms: d.as_millis() as u64,
+                            },
+                        );
+                        tokio::time::sleep(d).await;
+                        continue;
+                    }
+                    Err(e) => {
+                        if let Some(ctx) = image_ctx.as_ref() {
+                            crate::model::store::append_error_log(
+                                &ctx.session_dir,
+                                "request send failed",
+                                &e.to_string(),
+                            );
+                        }
+                        emit(&tx, StreamEvent::Error(format!("request failed: {e}")));
+                        return Ok(());
+                    }
+                };
+
+                if r.status().is_success() {
+                    break 'retry r;
+                }
+
+                let status = r.status();
+                let text = r.text().await.unwrap_or_default();
                 if let Some(ctx) = image_ctx.as_ref() {
                     crate::model::store::append_error_log(
                         &ctx.session_dir,
-                        "request send failed",
-                        &e.to_string(),
+                        &format!("HTTP {status} from {} (model {model})", conn.endpoint),
+                        &text,
                     );
                 }
-                emit(&tx, StreamEvent::Error(format!("request failed: {e}")));
+
+                if is_retryable_status(status) && attempt < MAX_ATTEMPTS {
+                    let d = backoff_delay(attempt);
+                    emit(
+                        &tx,
+                        StreamEvent::Retrying {
+                            attempt: attempt + 1,
+                            max: MAX_ATTEMPTS,
+                            delay_ms: d.as_millis() as u64,
+                        },
+                    );
+                    tokio::time::sleep(d).await;
+                    continue;
+                }
+
+                emit(&tx, StreamEvent::Error(clean_error(status, &text)));
                 return Ok(());
             }
-        };
-        let status = resp.status();
-        if !status.is_success() {
-            let text = resp.text().await.unwrap_or_default();
-            if let Some(ctx) = image_ctx.as_ref() {
-                crate::model::store::append_error_log(
-                    &ctx.session_dir,
-                    &format!("HTTP {status} from {} (model {model})", conn.endpoint),
-                    &text,
-                );
-            }
-            emit(&tx, StreamEvent::Error(clean_error(status, &text)));
+            emit(&tx, StreamEvent::Error("all retry attempts exhausted".into()));
             return Ok(());
-        }
+        };
 
         let mut stream = resp.bytes_stream();
         let mut buf: Vec<u8> = Vec::new();

--- a/src-agent/src/service/openrouter/codex/oneshot.rs
+++ b/src-agent/src/service/openrouter/codex/oneshot.rs
@@ -5,7 +5,9 @@ use futures_util::StreamExt;
 
 use crate::dto::chat::ChatMessage;
 
-use super::super::helpers::clean_error;
+use super::super::helpers::{
+    backoff_delay, clean_error, is_retryable_send_err, is_retryable_status, MAX_ATTEMPTS,
+};
 use super::super::Conn;
 use super::super::OpenRouterClient;
 use super::request::{build_input, codex_effort, ResponsesReasoning, ResponsesRequest};
@@ -62,18 +64,43 @@ impl OpenRouterClient {
             text: text_format,
         };
 
-        let rb = codex_headers(
-            self.http.post(&url),
-            bearer,
-            account_id,
-            self.codex_session_id(),
-        );
-        let resp = rb.json(&body).send().await?;
-        let status = resp.status();
-        if !status.is_success() {
-            let text = resp.text().await.unwrap_or_default();
-            return Err(anyhow!("{}", clean_error(status, &text)));
-        }
+        let resp: reqwest::Response = 'retry: {
+            for attempt in 1u32..=MAX_ATTEMPTS {
+                let send = codex_headers(
+                    self.http.post(&url),
+                    bearer,
+                    account_id,
+                    self.codex_session_id(),
+                )
+                .json(&body)
+                .send()
+                .await;
+                match send {
+                    Ok(r) => {
+                        let status = r.status();
+                        if status.is_success() {
+                            break 'retry r;
+                        }
+                        let text = r.text().await.unwrap_or_default();
+                        if is_retryable_status(status) && attempt < MAX_ATTEMPTS {
+                            let d = backoff_delay(attempt);
+                            tokio::time::sleep(d).await;
+                            continue;
+                        }
+                        return Err(anyhow!("{}", clean_error(status, &text)));
+                    }
+                    Err(e) if is_retryable_send_err(&e) && attempt < MAX_ATTEMPTS => {
+                        let d = backoff_delay(attempt);
+                        tokio::time::sleep(d).await;
+                        continue;
+                    }
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                }
+            }
+            return Err(anyhow!("all retry attempts exhausted"));
+        };
 
         let mut stream = resp.bytes_stream();
         let mut buf: Vec<u8> = Vec::new();

--- a/src-agent/src/service/openrouter/codex/stream.rs
+++ b/src-agent/src/service/openrouter/codex/stream.rs
@@ -8,7 +8,10 @@ use crate::dto::chat::{ChatMessage, FunctionCall, ReasoningDetail, ToolCall};
 use crate::dto::openrouter::{ImageWireCtx, ToolDef};
 use crate::service::StreamEvent;
 
-use super::super::helpers::{clean_error, emit, sanitize_tool_acc};
+use super::super::helpers::{
+    backoff_delay, clean_error, emit, is_retryable_send_err, is_retryable_status,
+    sanitize_tool_acc, MAX_ATTEMPTS,
+};
 use super::super::Conn;
 use super::super::OpenRouterClient;
 use super::request::{
@@ -72,39 +75,87 @@ impl OpenRouterClient {
             text: None,
         };
 
-        let rb = codex_headers(
-            self.http.post(&url),
-            bearer,
-            account_id,
-            self.codex_session_id(),
-        );
-        let resp = match rb.json(&body).send().await {
-            Ok(r) => r,
-            Err(e) => {
+        // ── 5xx / 429 retry with exponential backoff ─────────────────────
+        let resp: reqwest::Response = 'retry: {
+            for attempt in 1u32..=MAX_ATTEMPTS {
+                let send = codex_headers(
+                    self.http.post(&url),
+                    bearer,
+                    account_id,
+                    self.codex_session_id(),
+                )
+                .json(&body)
+                .send()
+                .await;
+                let r = match send {
+                    Ok(r) => r,
+                    Err(e) if is_retryable_send_err(&e) && attempt < MAX_ATTEMPTS => {
+                        if let Some(ctx) = image_ctx.as_ref() {
+                            crate::model::store::append_error_log(
+                                &ctx.session_dir,
+                                "request send failed",
+                                &e.to_string(),
+                            );
+                        }
+                        let d = backoff_delay(attempt);
+                        emit(
+                            &tx,
+                            StreamEvent::Retrying {
+                                attempt: attempt + 1,
+                                max: MAX_ATTEMPTS,
+                                delay_ms: d.as_millis() as u64,
+                            },
+                        );
+                        tokio::time::sleep(d).await;
+                        continue;
+                    }
+                    Err(e) => {
+                        if let Some(ctx) = image_ctx.as_ref() {
+                            crate::model::store::append_error_log(
+                                &ctx.session_dir,
+                                "request send failed",
+                                &e.to_string(),
+                            );
+                        }
+                        emit(&tx, StreamEvent::Error(format!("request failed: {e}")));
+                        return Ok(());
+                    }
+                };
+
+                if r.status().is_success() {
+                    break 'retry r;
+                }
+
+                let status = r.status();
+                let text = r.text().await.unwrap_or_default();
                 if let Some(ctx) = image_ctx.as_ref() {
                     crate::model::store::append_error_log(
                         &ctx.session_dir,
-                        "request send failed",
-                        &e.to_string(),
+                        &format!("HTTP {status} from {} (model {model})", conn.endpoint),
+                        &text,
                     );
                 }
-                emit(&tx, StreamEvent::Error(format!("request failed: {e}")));
+
+                if is_retryable_status(status) && attempt < MAX_ATTEMPTS {
+                    let d = backoff_delay(attempt);
+                    emit(
+                        &tx,
+                        StreamEvent::Retrying {
+                            attempt: attempt + 1,
+                            max: MAX_ATTEMPTS,
+                            delay_ms: d.as_millis() as u64,
+                        },
+                    );
+                    tokio::time::sleep(d).await;
+                    continue;
+                }
+
+                emit(&tx, StreamEvent::Error(clean_error(status, &text)));
                 return Ok(());
             }
-        };
-        let status = resp.status();
-        if !status.is_success() {
-            let text = resp.text().await.unwrap_or_default();
-            if let Some(ctx) = image_ctx.as_ref() {
-                crate::model::store::append_error_log(
-                    &ctx.session_dir,
-                    &format!("HTTP {status} from {} (model {model})", conn.endpoint),
-                    &text,
-                );
-            }
-            emit(&tx, StreamEvent::Error(clean_error(status, &text)));
+            emit(&tx, StreamEvent::Error("all retry attempts exhausted".into()));
             return Ok(());
-        }
+        };
 
         let mut stream = resp.bytes_stream();
         let mut buf: Vec<u8> = Vec::new();

--- a/src-agent/src/service/openrouter/commandcode/oneshot.rs
+++ b/src-agent/src/service/openrouter/commandcode/oneshot.rs
@@ -6,7 +6,9 @@ use uuid::Uuid;
 
 use crate::dto::chat::ChatMessage;
 
-use super::super::helpers::clean_error;
+use super::super::helpers::{
+    backoff_delay, clean_error, is_retryable_send_err, is_retryable_status, MAX_ATTEMPTS,
+};
 use super::super::Conn;
 use super::super::OpenRouterClient;
 use super::ndjson::{parse_line, CcEvent};
@@ -67,23 +69,47 @@ impl OpenRouterClient {
             thread_id: Uuid::new_v4().to_string(),
         };
 
-        let rb = self
-            .http
-            .post(&url)
-            .header("Content-Type", "application/json")
-            .header("Authorization", format!("Bearer {bearer}"))
-            .header("x-command-code-version", super::CC_CLI_VERSION)
-            .header("x-cli-environment", "production")
-            .header("x-project-slug", "koma")
-            .header("x-taste-learning", "true")
-            .header("x-co-flag", "false");
-
-        let resp = rb.json(&body).send().await?;
-        let status = resp.status();
-        if !status.is_success() {
-            let text = resp.text().await.unwrap_or_default();
-            return Err(anyhow!("{}", clean_error(status, &text)));
-        }
+        let resp: reqwest::Response = 'retry: {
+            for attempt in 1u32..=MAX_ATTEMPTS {
+                let send = self
+                    .http
+                    .post(&url)
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {bearer}"))
+                    .header("x-command-code-version", super::CC_CLI_VERSION)
+                    .header("x-cli-environment", "production")
+                    .header("x-project-slug", "koma")
+                    .header("x-taste-learning", "true")
+                    .header("x-co-flag", "false")
+                    .json(&body)
+                    .send()
+                    .await;
+                match send {
+                    Ok(r) => {
+                        let status = r.status();
+                        if status.is_success() {
+                            break 'retry r;
+                        }
+                        let text = r.text().await.unwrap_or_default();
+                        if is_retryable_status(status) && attempt < MAX_ATTEMPTS {
+                            let d = backoff_delay(attempt);
+                            tokio::time::sleep(d).await;
+                            continue;
+                        }
+                        return Err(anyhow!("{}", clean_error(status, &text)));
+                    }
+                    Err(e) if is_retryable_send_err(&e) && attempt < MAX_ATTEMPTS => {
+                        let d = backoff_delay(attempt);
+                        tokio::time::sleep(d).await;
+                        continue;
+                    }
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                }
+            }
+            return Err(anyhow!("all retry attempts exhausted"));
+        };
 
         let mut stream = resp.bytes_stream();
         let mut buf: Vec<u8> = Vec::new();

--- a/src-agent/src/service/openrouter/commandcode/stream.rs
+++ b/src-agent/src/service/openrouter/commandcode/stream.rs
@@ -10,7 +10,10 @@ use crate::dto::chat::{ChatMessage, FunctionCall, ToolCall};
 use crate::dto::openrouter::{ImageWireCtx, ToolDef};
 use crate::service::StreamEvent;
 
-use super::super::helpers::{clean_error, emit, sanitize_tool_acc};
+use super::super::helpers::{
+    backoff_delay, clean_error, emit, is_retryable_send_err, is_retryable_status,
+    sanitize_tool_acc, MAX_ATTEMPTS,
+};
 use super::super::Conn;
 use super::super::OpenRouterClient;
 use super::ndjson::{parse_line, CcEvent};
@@ -73,30 +76,70 @@ impl OpenRouterClient {
             thread_id: Uuid::new_v4().to_string(),
         };
 
-        let rb = self
-            .http
-            .post(&url)
-            .header("Content-Type", "application/json")
-            .header("Authorization", format!("Bearer {bearer}"))
-            .header("x-command-code-version", super::CC_CLI_VERSION)
-            .header("x-cli-environment", "production")
-            .header("x-project-slug", slug_from_path(&body.config.working_dir))
-            .header("x-taste-learning", "true")
-            .header("x-co-flag", "false");
+        // ── 5xx / 429 retry with exponential backoff ─────────────────────
+        let resp: reqwest::Response = 'retry: {
+            for attempt in 1u32..=MAX_ATTEMPTS {
+                let send = self
+                    .http
+                    .post(&url)
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", format!("Bearer {bearer}"))
+                    .header("x-command-code-version", super::CC_CLI_VERSION)
+                    .header("x-cli-environment", "production")
+                    .header("x-project-slug", slug_from_path(&body.config.working_dir))
+                    .header("x-taste-learning", "true")
+                    .header("x-co-flag", "false")
+                    .json(&body)
+                    .send()
+                    .await;
+                let r = match send {
+                    Ok(r) => r,
+                    Err(e) if is_retryable_send_err(&e) && attempt < MAX_ATTEMPTS => {
+                        let d = backoff_delay(attempt);
+                        emit(
+                            &tx,
+                            StreamEvent::Retrying {
+                                attempt: attempt + 1,
+                                max: MAX_ATTEMPTS,
+                                delay_ms: d.as_millis() as u64,
+                            },
+                        );
+                        tokio::time::sleep(d).await;
+                        continue;
+                    }
+                    Err(e) => {
+                        emit(&tx, StreamEvent::Error(format!("request failed: {e}")));
+                        return Ok(());
+                    }
+                };
 
-        let resp = match rb.json(&body).send().await {
-            Ok(r) => r,
-            Err(e) => {
-                emit(&tx, StreamEvent::Error(format!("request failed: {e}")));
+                if r.status().is_success() {
+                    break 'retry r;
+                }
+
+                let status = r.status();
+                let text = r.text().await.unwrap_or_default();
+
+                if is_retryable_status(status) && attempt < MAX_ATTEMPTS {
+                    let d = backoff_delay(attempt);
+                    emit(
+                        &tx,
+                        StreamEvent::Retrying {
+                            attempt: attempt + 1,
+                            max: MAX_ATTEMPTS,
+                            delay_ms: d.as_millis() as u64,
+                        },
+                    );
+                    tokio::time::sleep(d).await;
+                    continue;
+                }
+
+                emit(&tx, StreamEvent::Error(clean_error(status, &text)));
                 return Ok(());
             }
-        };
-        let status = resp.status();
-        if !status.is_success() {
-            let text = resp.text().await.unwrap_or_default();
-            emit(&tx, StreamEvent::Error(clean_error(status, &text)));
+            emit(&tx, StreamEvent::Error("all retry attempts exhausted".into()));
             return Ok(());
-        }
+        };
 
         let mut stream = resp.bytes_stream();
         let mut buf: Vec<u8> = Vec::new();

--- a/src-agent/src/service/openrouter/helpers.rs
+++ b/src-agent/src/service/openrouter/helpers.rs
@@ -335,6 +335,92 @@ pub(super) fn clean_error(status: reqwest::StatusCode, body: &str) -> String {
     }
 }
 
+// ── Retry / backoff for transient inference errors ──────────────────────────
+
+/// Maximum number of attempts for a single inference request (the initial
+/// attempt plus up to two retries).
+pub(super) const MAX_ATTEMPTS: u32 = 3;
+
+/// Per-retry backoff in milliseconds (index 0 = delay before 2nd attempt).
+pub(super) const BACKOFF_MS: &[u64] = &[1000, 2000, 4000];
+
+/// Upper bound for the random jitter added on top of each backoff delay.
+const JITTER_MS: u64 = 500;
+
+/// True when an HTTP status warrants a retry: server errors (5xx) and
+/// rate-limit responses (429). Permanent client errors (4xx, except 429) are
+/// NOT retried.
+pub(super) fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+    status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+}
+
+/// True when a reqwest send-level failure is transient (connection refused,
+/// DNS lookup failure, connection reset, timeout, etc.). Builder errors and
+/// redirect loops are permanent and NOT retried.
+pub(super) fn is_retryable_send_err(err: &reqwest::Error) -> bool {
+    err.is_connect() || err.is_timeout()
+}
+
+/// Compute the sleep duration before the *next* attempt. `attempt` is
+/// 1-based: the delay after the 1st attempt (before the 2nd) is
+/// `BACKOFF_MS[0]`, etc. Includes jitter drawn from the current
+/// nanosecond tick so concurrent callers don't stampede.
+pub(super) fn backoff_delay(attempt: u32) -> std::time::Duration {
+    let idx = ((attempt as usize) - 1).min(BACKOFF_MS.len() - 1);
+    let base = BACKOFF_MS[idx];
+    // Cheap jitter: fold the current instant's sub-second nanos into
+    // [0, JITTER_MS). No external RNG dependency required.
+    let jitter = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos() as u64
+        % (JITTER_MS + 1);
+    std::time::Duration::from_millis(base + jitter)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod retry_tests {
+    use super::*;
+    use reqwest::StatusCode;
+
+    #[test]
+    fn retryable_statuses() {
+        // Retryable: server errors + rate limit
+        for code in [500, 502, 503, 520, 529, 429] {
+            let s = StatusCode::from_u16(code).unwrap();
+            assert!(is_retryable_status(s), "expected {code} to be retryable");
+        }
+        // NOT retryable: success + permanent client errors
+        for code in [200, 201, 204, 400, 401, 403, 404, 405, 422] {
+            let s = StatusCode::from_u16(code).unwrap();
+            assert!(
+                !is_retryable_status(s),
+                "expected {code} to NOT be retryable"
+            );
+        }
+    }
+
+    #[test]
+    fn backoff_delay_is_monotonic_and_bounded() {
+        let d1 = backoff_delay(1);
+        let d2 = backoff_delay(2);
+        let d3 = backoff_delay(3);
+        // Each base is larger than the previous.
+        assert!(d2 > d1, "d2={d2:?} should be > d1={d1:?}");
+        assert!(d3 > d2, "d3={d3:?} should be > d2={d2:?}");
+        // Upper bound: base + max jitter.
+        assert!(d3 <= std::time::Duration::from_millis(4000 + JITTER_MS));
+        // Lower bound: base + 0 jitter.
+        assert!(d1 >= std::time::Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn max_attempts_is_three() {
+        assert_eq!(MAX_ATTEMPTS, 3);
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod apply_tool_call_delta_tests {

--- a/src-agent/src/service/openrouter/oneshot.rs
+++ b/src-agent/src/service/openrouter/oneshot.rs
@@ -6,8 +6,9 @@ use anyhow::{anyhow, Result};
 use super::client::OpenRouterClient;
 use super::codex::to_text_format;
 use super::helpers::{
-    accepts_reasoning_exclude, auth_headers, clean_error, parse_blob_ids, parse_summary,
-    provider_routing_for,
+    accepts_reasoning_exclude, auth_headers, backoff_delay, clean_error,
+    is_retryable_send_err, is_retryable_status, parse_blob_ids, parse_summary,
+    provider_routing_for, MAX_ATTEMPTS,
 };
 use super::types::Conn;
 use crate::dto::chat::{ChatMessage, Role};
@@ -120,27 +121,57 @@ impl OpenRouterClient {
             max_tokens: None,
         };
 
-        let response = auth_headers(
-            self.http.post(&url),
-            &conn,
-            &bearer,
-            self.codex_session_id(),
-        )
-        .json(&body)
-        .send()
-        .await?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let text = response.text().await.unwrap_or_default();
-            if let Some(out) =
-                commandcode_oneshot_fallback(self, conn, &bearer, model, messages, status, &text)
-                    .await?
-            {
-                return Ok(out);
+        let response: reqwest::Response = 'retry: {
+            for attempt in 1u32..=MAX_ATTEMPTS {
+                let send = auth_headers(
+                    self.http.post(&url),
+                    &conn,
+                    &bearer,
+                    self.codex_session_id(),
+                )
+                .json(&body)
+                .send()
+                .await;
+                match send {
+                    Ok(r) => {
+                        let status = r.status();
+                        if status.is_success() {
+                            break 'retry r;
+                        }
+                        let text = r.text().await.unwrap_or_default();
+                        if is_retryable_status(status) && attempt < MAX_ATTEMPTS {
+                            let d = backoff_delay(attempt);
+                            tokio::time::sleep(d).await;
+                            continue;
+                        }
+                        // Final attempt or non-retryable: check commandcode 403 fallback
+                        if let Some(out) = commandcode_oneshot_fallback(
+                            self,
+                            conn,
+                            &bearer,
+                            model,
+                            messages,
+                            status,
+                            &text,
+                        )
+                        .await?
+                        {
+                            return Ok(out);
+                        }
+                        return Err(anyhow!("{}", clean_error(status, &text)));
+                    }
+                    Err(e) if is_retryable_send_err(&e) && attempt < MAX_ATTEMPTS => {
+                        let d = backoff_delay(attempt);
+                        tokio::time::sleep(d).await;
+                        continue;
+                    }
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                }
             }
-            return Err(anyhow!("{}", clean_error(status, &text)));
-        }
+            return Err(anyhow!("all retry attempts exhausted"));
+        };
         remember_commandcode_provider_v1(&conn);
 
         let chat_response: ChatResponse = response.json().await?;
@@ -226,27 +257,57 @@ impl OpenRouterClient {
             max_tokens: None,
         };
 
-        let response = auth_headers(
-            self.http.post(&url),
-            &conn,
-            &bearer,
-            self.codex_session_id(),
-        )
-        .json(&body)
-        .send()
-        .await?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let text = response.text().await.unwrap_or_default();
-            if let Some(out) =
-                commandcode_oneshot_fallback(self, conn, &bearer, model, messages, status, &text)
-                    .await?
-            {
-                return Ok(out);
+        let response: reqwest::Response = 'retry: {
+            for attempt in 1u32..=MAX_ATTEMPTS {
+                let send = auth_headers(
+                    self.http.post(&url),
+                    &conn,
+                    &bearer,
+                    self.codex_session_id(),
+                )
+                .json(&body)
+                .send()
+                .await;
+                match send {
+                    Ok(r) => {
+                        let status = r.status();
+                        if status.is_success() {
+                            break 'retry r;
+                        }
+                        let text = r.text().await.unwrap_or_default();
+                        if is_retryable_status(status) && attempt < MAX_ATTEMPTS {
+                            let d = backoff_delay(attempt);
+                            tokio::time::sleep(d).await;
+                            continue;
+                        }
+                        // Final attempt or non-retryable: check commandcode 403 fallback
+                        if let Some(out) = commandcode_oneshot_fallback(
+                            self,
+                            conn,
+                            &bearer,
+                            model,
+                            messages,
+                            status,
+                            &text,
+                        )
+                        .await?
+                        {
+                            return Ok(out);
+                        }
+                        return Err(anyhow!("{}", clean_error(status, &text)));
+                    }
+                    Err(e) if is_retryable_send_err(&e) && attempt < MAX_ATTEMPTS => {
+                        let d = backoff_delay(attempt);
+                        tokio::time::sleep(d).await;
+                        continue;
+                    }
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                }
             }
-            return Err(anyhow!("{}", clean_error(status, &text)));
-        }
+            return Err(anyhow!("all retry attempts exhausted"));
+        };
         remember_commandcode_provider_v1(&conn);
 
         let chat_response: ChatResponse = response.json().await?;
@@ -404,31 +465,61 @@ impl OpenRouterClient {
             max_tokens: Some(2_000),
         };
 
-        let response = auth_headers(
-            self.http.post(&url),
-            &conn,
-            &bearer,
-            self.codex_session_id(),
-        )
-        .json(&body)
-        .send()
-        .await?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let text = response.text().await.unwrap_or_default();
-            if let Some(out) =
-                commandcode_oneshot_fallback(self, conn, &bearer, model, messages, status, &text)
-                    .await?
-            {
-                let trimmed = out.trim();
-                if trimmed.is_empty() {
-                    return Err(anyhow!("empty classifier reply"));
+        let response: reqwest::Response = 'retry: {
+            for attempt in 1u32..=MAX_ATTEMPTS {
+                let send = auth_headers(
+                    self.http.post(&url),
+                    &conn,
+                    &bearer,
+                    self.codex_session_id(),
+                )
+                .json(&body)
+                .send()
+                .await;
+                match send {
+                    Ok(r) => {
+                        let status = r.status();
+                        if status.is_success() {
+                            break 'retry r;
+                        }
+                        let text = r.text().await.unwrap_or_default();
+                        if is_retryable_status(status) && attempt < MAX_ATTEMPTS {
+                            let d = backoff_delay(attempt);
+                            tokio::time::sleep(d).await;
+                            continue;
+                        }
+                        // Final attempt or non-retryable: check commandcode 403 fallback
+                        if let Some(out) = commandcode_oneshot_fallback(
+                            self,
+                            conn,
+                            &bearer,
+                            model,
+                            messages,
+                            status,
+                            &text,
+                        )
+                        .await?
+                        {
+                            let trimmed = out.trim();
+                            if trimmed.is_empty() {
+                                return Err(anyhow!("empty classifier reply"));
+                            }
+                            return Ok(trimmed.to_string());
+                        }
+                        return Err(anyhow!("{}", clean_error(status, &text)));
+                    }
+                    Err(e) if is_retryable_send_err(&e) && attempt < MAX_ATTEMPTS => {
+                        let d = backoff_delay(attempt);
+                        tokio::time::sleep(d).await;
+                        continue;
+                    }
+                    Err(e) => {
+                        return Err(e.into());
+                    }
                 }
-                return Ok(trimmed.to_string());
             }
-            return Err(anyhow!("{}", clean_error(status, &text)));
-        }
+            return Err(anyhow!("all retry attempts exhausted"));
+        };
         remember_commandcode_provider_v1(&conn);
 
         let chat_response: ChatResponse = response.json().await?;
@@ -578,27 +669,57 @@ impl OpenRouterClient {
             max_tokens: None,
         };
 
-        let response = auth_headers(
-            self.http.post(&url),
-            &conn,
-            &bearer,
-            self.codex_session_id(),
-        )
-        .json(&body)
-        .send()
-        .await?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let text = response.text().await.unwrap_or_default();
-            if let Some(out) =
-                commandcode_oneshot_fallback(self, conn, &bearer, model, messages, status, &text)
-                    .await?
-            {
-                return parse_summary(&out);
+        let response: reqwest::Response = 'retry: {
+            for attempt in 1u32..=MAX_ATTEMPTS {
+                let send = auth_headers(
+                    self.http.post(&url),
+                    &conn,
+                    &bearer,
+                    self.codex_session_id(),
+                )
+                .json(&body)
+                .send()
+                .await;
+                match send {
+                    Ok(r) => {
+                        let status = r.status();
+                        if status.is_success() {
+                            break 'retry r;
+                        }
+                        let text = r.text().await.unwrap_or_default();
+                        if is_retryable_status(status) && attempt < MAX_ATTEMPTS {
+                            let d = backoff_delay(attempt);
+                            tokio::time::sleep(d).await;
+                            continue;
+                        }
+                        // Final attempt or non-retryable: check commandcode 403 fallback
+                        if let Some(out) = commandcode_oneshot_fallback(
+                            self,
+                            conn,
+                            &bearer,
+                            model,
+                            messages,
+                            status,
+                            &text,
+                        )
+                        .await?
+                        {
+                            return parse_summary(&out);
+                        }
+                        return Err(anyhow!("{}", clean_error(status, &text)));
+                    }
+                    Err(e) if is_retryable_send_err(&e) && attempt < MAX_ATTEMPTS => {
+                        let d = backoff_delay(attempt);
+                        tokio::time::sleep(d).await;
+                        continue;
+                    }
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                }
             }
-            return Err(anyhow!("{}", clean_error(status, &text)));
-        }
+            return Err(anyhow!("all retry attempts exhausted"));
+        };
         remember_commandcode_provider_v1(&conn);
 
         let chat_response: ChatResponse = response.json().await?;
@@ -761,32 +882,59 @@ impl OpenRouterClient {
             max_tokens: Some(2_000),
         };
 
-        // Best-effort: any failure returns an empty selection rather than erroring.
-        let response = match auth_headers(
-            self.http.post(&url),
-            &conn,
-            &bearer,
-            self.codex_session_id(),
-        )
-        .json(&body)
-        .send()
-        .await
-        {
-            Ok(r) => r,
-            Err(_) => return Ok(Vec::new()),
-        };
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let text = response.text().await.unwrap_or_default();
-            if let Ok(Some(out)) =
-                commandcode_oneshot_fallback(self, conn, &bearer, model, messages, status, &text)
-                    .await
-            {
-                return Ok(parse_blob_ids(&out));
+        // Best-effort: retries first, then any final failure returns an empty
+        // selection rather than erroring.
+        let response: reqwest::Response = 'retry_pick: {
+            for attempt in 1u32..=MAX_ATTEMPTS {
+                let send = auth_headers(
+                    self.http.post(&url),
+                    &conn,
+                    &bearer,
+                    self.codex_session_id(),
+                )
+                .json(&body)
+                .send()
+                .await;
+                match send {
+                    Ok(r) => {
+                        let status = r.status();
+                        if status.is_success() {
+                            break 'retry_pick r;
+                        }
+                        let text = r.text().await.unwrap_or_default();
+                        if is_retryable_status(status) && attempt < MAX_ATTEMPTS {
+                            let d = backoff_delay(attempt);
+                            tokio::time::sleep(d).await;
+                            continue;
+                        }
+                        // Final attempt or non-retryable: check commandcode 403 fallback
+                        if let Ok(Some(out)) = commandcode_oneshot_fallback(
+                            self,
+                            conn,
+                            &bearer,
+                            model,
+                            messages,
+                            status,
+                            &text,
+                        )
+                        .await
+                        {
+                            return Ok(parse_blob_ids(&out));
+                        }
+                        return Ok(Vec::new());
+                    }
+                    Err(e) if is_retryable_send_err(&e) && attempt < MAX_ATTEMPTS => {
+                        let d = backoff_delay(attempt);
+                        tokio::time::sleep(d).await;
+                        continue;
+                    }
+                    Err(_) => {
+                        return Ok(Vec::new());
+                    }
+                }
             }
-            return Ok(Vec::new());
-        }
+            return Err(anyhow!("all retry attempts exhausted"));
+        };
         remember_commandcode_provider_v1(&conn);
 
         let chat_response: ChatResponse = match response.json().await {

--- a/src-agent/src/service/openrouter/stream.rs
+++ b/src-agent/src/service/openrouter/stream.rs
@@ -14,8 +14,9 @@ use crate::service::StreamEvent;
 
 use super::client::OpenRouterClient;
 use super::helpers::{
-    apply_tool_call_delta, auth_headers, clean_error, emit, is_openrouter, provider_routing_for,
-    reasoning_config, sanitize_tool_acc,
+    apply_tool_call_delta, auth_headers, backoff_delay, clean_error, emit, is_openrouter,
+    is_retryable_send_err, is_retryable_status, provider_routing_for, reasoning_config,
+    sanitize_tool_acc, MAX_ATTEMPTS,
 };
 use super::think_split::{Emit as ThinkEmit, ThinkSplit};
 use super::types::Conn;
@@ -179,90 +180,135 @@ impl OpenRouterClient {
             max_tokens: Some(32_000),
         };
 
-        let resp = auth_headers(
-            self.http.post(&url),
-            &conn,
-            &bearer,
-            self.codex_session_id(),
-        )
-        .json(&body)
-        .send()
-        .await;
-        let resp = match resp {
-            Ok(r) => r,
-            Err(e) => {
+        // ── 5xx / 429 retry with exponential backoff ─────────────────────
+        let resp: reqwest::Response = 'retry: {
+            for attempt in 1u32..=MAX_ATTEMPTS {
+                let send = auth_headers(
+                    self.http.post(&url),
+                    &conn,
+                    &bearer,
+                    self.codex_session_id(),
+                )
+                .json(&body)
+                .send()
+                .await;
+                let r = match send {
+                    Ok(r) => r,
+                    Err(e) if is_retryable_send_err(&e) && attempt < MAX_ATTEMPTS => {
+                        if let Some(ctx) = image_ctx.as_ref() {
+                            crate::model::store::append_error_log(
+                                &ctx.session_dir,
+                                "request send failed",
+                                &e.to_string(),
+                            );
+                        }
+                        let d = backoff_delay(attempt);
+                        emit(
+                            &tx,
+                            StreamEvent::Retrying {
+                                attempt: attempt + 1,
+                                max: MAX_ATTEMPTS,
+                                delay_ms: d.as_millis() as u64,
+                            },
+                        );
+                        tokio::time::sleep(d).await;
+                        continue;
+                    }
+                    Err(e) => {
+                        if let Some(ctx) = image_ctx.as_ref() {
+                            crate::model::store::append_error_log(
+                                &ctx.session_dir,
+                                "request send failed",
+                                &e.to_string(),
+                            );
+                        }
+                        emit(&tx, StreamEvent::Error(format!("request failed: {e}")));
+                        return Ok(());
+                    }
+                };
+
+                if r.status().is_success() {
+                    break 'retry r;
+                }
+
+                let status = r.status();
+                let text = r.text().await.unwrap_or_default();
                 if let Some(ctx) = image_ctx.as_ref() {
                     crate::model::store::append_error_log(
                         &ctx.session_dir,
-                        "request send failed",
-                        &e.to_string(),
+                        &format!("HTTP {status} from {} (model {model})", conn.endpoint),
+                        &text,
                     );
                 }
-                emit(&tx, StreamEvent::Error(format!("request failed: {e}")));
-                return Ok(());
-            }
-        };
 
-        let status = resp.status();
-        if !status.is_success() {
-            let text = resp.text().await.unwrap_or_default();
-            if let Some(ctx) = image_ctx.as_ref() {
-                crate::model::store::append_error_log(
-                    &ctx.session_dir,
-                    &format!("HTTP {status} from {} (model {model})", conn.endpoint),
-                    &text,
-                );
-            }
-            // koma-free is rate-limited per install against a shared free-tier
-            // bucket; a 429 means it is busy/exhausted (Retry-After ignored on
-            // purpose). Surface a human hint instead of the raw upstream JSON.
-            if status == reqwest::StatusCode::TOO_MANY_REQUESTS
-                && conn.api_type == ApiType::KomaFree
-            {
-                emit(
-                    &tx,
-                    StreamEvent::Error(
-                        "koma free tier is busy right now - retry in a moment, or set up a provider/custom model in /settings".to_string(),
-                    ),
-                );
+                // CommandCode 403 transport switch: permanent plan denial, NOT retried.
+                if !conn.oauth_uuid.is_empty()
+                    && crate::service::oauth::commandcode::is_provider_api_denied(status, &text)
+                    && conn.endpoint.contains("api.commandcode.ai/provider/v1")
+                {
+                    crate::service::oauth::commandcode::remember_chat_pref(
+                        conn.oauth_uuid,
+                        crate::service::oauth::commandcode::CHAT_NDJSON,
+                    );
+                    let ndjson_endpoint =
+                        crate::service::oauth::registry::COMMANDCODE_CHAT_BASE;
+                    let ndjson_conn = Conn {
+                        endpoint: ndjson_endpoint,
+                        api_key: conn.api_key,
+                        api_type: ApiType::CommandCode,
+                        account_id: conn.account_id,
+                        oauth_uuid: conn.oauth_uuid,
+                        install_id: conn.install_id,
+                    };
+                    return self
+                        .commandcode_stream_complete(
+                            ndjson_conn,
+                            &bearer,
+                            model,
+                            messages,
+                            advertise,
+                            mcp_tools,
+                            image_ctx,
+                            tx,
+                        )
+                        .await;
+                }
+
+                // Retryable + attempts remaining → sleep + retry
+                if is_retryable_status(status) && attempt < MAX_ATTEMPTS {
+                    let d = backoff_delay(attempt);
+                    emit(
+                        &tx,
+                        StreamEvent::Retrying {
+                            attempt: attempt + 1,
+                            max: MAX_ATTEMPTS,
+                            delay_ms: d.as_millis() as u64,
+                        },
+                    );
+                    tokio::time::sleep(d).await;
+                    continue;
+                }
+
+                // FINAL failure — KomaFree 429 friendly message (last attempt only)
+                if status == reqwest::StatusCode::TOO_MANY_REQUESTS
+                    && conn.api_type == ApiType::KomaFree
+                {
+                    emit(
+                        &tx,
+                        StreamEvent::Error(
+                            "koma free tier is busy right now - retry in a moment, or set up a provider/custom model in /settings".to_string(),
+                        ),
+                    );
+                    return Ok(());
+                }
+
+                // General final error
+                emit(&tx, StreamEvent::Error(clean_error(status, &text)));
                 return Ok(());
             }
-            // Command Code API-first: on a Go-plan 403 against provider/v1, remember
-            // NDJSON and retry once via `/alpha/generate` so the user never sees the
-            // plan error on a first chat after OAuth.
-            if !conn.oauth_uuid.is_empty()
-                && crate::service::oauth::commandcode::is_provider_api_denied(status, &text)
-                && conn.endpoint.contains("api.commandcode.ai/provider/v1")
-            {
-                crate::service::oauth::commandcode::remember_chat_pref(
-                    conn.oauth_uuid,
-                    crate::service::oauth::commandcode::CHAT_NDJSON,
-                );
-                let ndjson_endpoint = crate::service::oauth::registry::COMMANDCODE_CHAT_BASE;
-                let ndjson_conn = Conn {
-                    endpoint: ndjson_endpoint,
-                    api_key: conn.api_key,
-                    api_type: ApiType::CommandCode,
-                    account_id: conn.account_id,
-                    oauth_uuid: conn.oauth_uuid,
-                    install_id: conn.install_id,
-                };
-                return self
-                    .commandcode_stream_complete(
-                        ndjson_conn,
-                        &bearer,
-                        model,
-                        messages,
-                        advertise,
-                        mcp_tools,
-                        image_ctx,
-                        tx,
-                    )
-                    .await;
-            }
-            emit(&tx, StreamEvent::Error(clean_error(status, &text)));
+            emit(&tx, StreamEvent::Error("all retry attempts exhausted".into()));
             return Ok(());
-        }
+        };
 
         // Command Code provider/v1 succeeded — remember so we keep hitting it.
         if !conn.oauth_uuid.is_empty() && conn.endpoint.contains("api.commandcode.ai/provider/v1") {


### PR DESCRIPTION
…backoff

Add retry with exponential backoff (1s/2s/4s + jitter) for transient HTTP failures (5xx, 429, connect, timeout) across all 12 inference call sites. Max 3 attempts. New StreamEvent::Retrying variant for live TUI status. Permanent errors (4xx, builder) fail immediately.

Covers openrouter/{oneshot,stream}, anthropic/{oneshot,stream}, codex/{oneshot,stream}, commandcode/{oneshot,stream}. Graceful error returns replace all production panics (no unreachable!). Unit tests for retryable status classification and backoff bounds.