### PR TITLE
feat: dynamic koma-premium model catalogue from KomaRun /models API

### DIFF
--- a/src-agent/src/app/resolve.rs
+++ b/src-agent/src/app/resolve.rs
@@ -386,11 +386,7 @@ fn from_entry(
     // OpenAI-compat catalogue/API base (`COMMANDCODE_API_BASE` + `/chat/completions`).
     // `meta().chat_endpoint` stays the API base (API-first default).
     let endpoint = if conn.provider == OAuthProvider::KomaRun
-        && crate::service::catalogue_overlay::models_for(
-            crate::service::oauth::registry::KOMA_PREMIUM_CHAT_ENDPOINT,
-        )
-        .iter()
-        .any(|m| m.id == entry.model_id)
+        && crate::service::catalogue_overlay::is_premium_model(&entry.model_id)
     {
         crate::service::oauth::registry::KOMA_PREMIUM_CHAT_ENDPOINT.to_string()
     } else if conn.provider == OAuthProvider::CommandCode {

--- a/src-agent/src/app/runtime/actions/oauth.rs
+++ b/src-agent/src/app/runtime/actions/oauth.rs
@@ -141,7 +141,13 @@ fn apply_login_result(rest: &mut AppStateRest, conn: OAuthConn, handle: &tokio::
     });
     let conn_uuid = conn.uuid.clone();
     let conn_provider = conn.provider;
+    let conn_token = conn.access_token.clone();
     rest.config.oauth_conns.push(conn);
+    // Fire background refresh of the dynamic premium model catalogue for KomaRun
+    // (paste path; force=true so the fresh token is used immediately).
+    if conn_provider == crate::model::app_config::OAuthProvider::KomaRun {
+        crate::service::catalogue_overlay::premium_dynamic::spawn_refresh(conn_token);
+    }
     // Pre-compute the outcome (drafts on success) BEFORE the mode borrow so the fold
     // below doesn't need to re-borrow `rest.config` while holding `&mut ...mode`.
     let outcome = rest

--- a/src-agent/src/app/runtime/event_loop/daemon/hub/requests_read.rs
+++ b/src-agent/src/app/runtime/event_loop/daemon/hub/requests_read.rs
@@ -237,8 +237,18 @@ impl DaemonHub {
             .iter()
             .find(|c| c.uuid == provider)
         {
-            // OAuth-conn provider: no live fetch — resolve straight to the curated
+            // OAuth-conn provider: resolve straight to the curated
             // catalogue overlay for this provider's chat endpoint(s).
+            // For KomaRun, also trigger a TTL-gated refresh of the dynamic
+            // premium catalogue so the picker picks up new models.
+            if conn.provider == crate::model::app_config::OAuthProvider::KomaRun
+                && !conn.access_token.is_empty()
+            {
+                crate::service::catalogue_overlay::premium_dynamic::maybe_refresh(
+                    &conn.access_token,
+                    false,
+                );
+            }
             let models = crate::service::catalogue_overlay::models_for_provider(conn.provider)
                 .into_iter()
                 .map(|m| m.id)

--- a/src-agent/src/app/runtime/event_loop/global/drains.rs
+++ b/src-agent/src/app/runtime/event_loop/global/drains.rs
@@ -256,6 +256,13 @@ pub(super) fn drain_oauth(state: &mut AppState, handle: &tokio::runtime::Handle)
                         crate::service::oauth::registry::meta(conn_provider).catalogue_endpoint;
                     state.rest.request_catalogue(ep, &conn_token, &conn_uuid);
                 }
+                // Fire a background refresh of the dynamic premium model catalogue
+                // for KomaRun (force=true so the freshly-logged-in token is used).
+                if conn_provider == crate::model::app_config::OAuthProvider::KomaRun {
+                    crate::service::catalogue_overlay::premium_dynamic::spawn_refresh(
+                        conn_token.clone(),
+                    );
+                }
                 state.rest.oauth_task = None;
                 // GUI side-channel: terminal `success` push (conns are rebuilt hub-side
                 // from the now-updated `config.oauth_conns`). Terminal → disarm the client.

--- a/src-agent/src/service/catalogue_overlay/mod.rs
+++ b/src-agent/src/service/catalogue_overlay/mod.rs
@@ -19,6 +19,7 @@
 
 mod fetch;
 mod model;
+pub(crate) mod premium_dynamic;
 
 // dead_code: infra-only for now — no consumer wired yet (W2/W3 will read this).
 #[allow(unused_imports)]
@@ -53,6 +54,7 @@ pub fn init() {
     let table = load_initial();
     let _ = OVERLAY.set(RwLock::new(table));
     fetch::spawn_refresh();
+    premium_dynamic::init_from_disk();
 }
 
 /// Load the starting table: on-disk cache if it parses, else the bundled
@@ -75,7 +77,7 @@ fn load_initial() -> OverlayTable {
         Err(e) => {
             crate::model::store::append_global_error_log(
                 "catalogue overlay",
-                &format!("bundled default failed to parse ({e}) — starting empty"),
+                &format!("bundled default failed to parse ({e}) - starting empty"),
             );
             HashMap::new()
         }
@@ -185,7 +187,25 @@ pub fn models_for_provider(provider: OAuthProvider) -> Vec<ModelInfo> {
             models.push(m);
         }
     }
+    // Merge dynamic premium catalogue (live-fetched from KomaRun /models).
+    premium_dynamic::merge_into(&mut models);
     models
+}
+
+/// Fast membership check: is `model_id` a premium-tier KomaRun model?
+/// Returns true if the id is in the static premium overlay OR the dynamic
+/// premium store. Used by `resolve.rs` to route requests to the premium
+/// endpoint instead of the base endpoint.
+pub fn is_premium_model(model_id: &str) -> bool {
+    // Check static overlay first.
+    if models_for(crate::service::oauth::registry::KOMA_PREMIUM_CHAT_ENDPOINT)
+        .iter()
+        .any(|m| m.id == model_id)
+    {
+        return true;
+    }
+    // Then the dynamic store.
+    premium_dynamic::contains(model_id)
 }
 
 #[cfg(test)]

--- a/src-agent/src/service/catalogue_overlay/premium_dynamic.rs
+++ b/src-agent/src/service/catalogue_overlay/premium_dynamic.rs
@@ -1,0 +1,406 @@
+//! Dynamic premium model catalogue for KomaRun.
+//!
+//! Fetches the live allowlisted premium model list from
+//! `GET {KOMA_PREMIUM_CHAT_ENDPOINT}/models` (requires a KomaRun OAuth bearer),
+//! caches it on disk (`~/.koma/koma-premium-models.json`) and in memory, and
+//! merges it into the picker / routing paths so premium models beyond the
+//! bundled `koma/peach` seed appear automatically.
+//!
+//! This module is intentionally separate from the GitHub-refreshed overlay
+//! table (`super::fetch`) — GitHub overlay swaps must never wipe dynamic
+//! premium entries.
+
+use std::sync::{OnceLock, RwLock, atomic::{AtomicBool, Ordering}};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::dto::openrouter::ModelInfo;
+use crate::model::app_config::OAuthProvider;
+use super::model::OverlayModel;
+
+// ---------------------------------------------------------------------------
+// In-memory store
+// ---------------------------------------------------------------------------
+
+/// TTL before a network refresh is attempted again (1 hour).
+const REFRESH_TTL: Duration = Duration::from_secs(3600);
+
+/// HTTP timeout for the premium catalogue fetch.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The on-disk cache filename (sibling to `models.json`).
+const CACHE_FILENAME: &str = "koma-premium-models.json";
+
+static STORE: OnceLock<RwLock<PremiumDynamic>> = OnceLock::new();
+
+/// Single-flight guard: only one fetch task runs at a time.
+static IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Clone, Default)]
+struct PremiumDynamic {
+    models: Vec<OverlayModel>,
+    fetched_at: Option<u64>,
+}
+
+/// On-disk JSON shape.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct DiskCache {
+    fetched_at_unix: Option<u64>,
+    models: Vec<OverlayModel>,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Call once at startup (after `catalogue_overlay::init`). Loads the on-disk
+/// cache if present. Best-effort — never panics.
+pub fn init_from_disk() {
+    let data = load_disk().unwrap_or_default();
+    let _ = STORE.set(RwLock::new(data));
+}
+
+/// Snapshot of currently known premium models (cloned, cheap).
+#[allow(dead_code)]
+pub fn models() -> Vec<OverlayModel> {
+    let Some(lock) = STORE.get() else {
+        return Vec::new();
+    };
+    let Ok(guard) = lock.read() else {
+        return Vec::new();
+    };
+    guard.models.clone()
+}
+
+/// `true` if `model_id` is in the dynamic premium list.
+pub fn contains(model_id: &str) -> bool {
+    let Some(lock) = STORE.get() else {
+        return false;
+    };
+    let Ok(guard) = lock.read() else {
+        return false;
+    };
+    guard.models.iter().any(|m| m.id == model_id)
+}
+
+/// Append dynamic premium models into `models`, deduplicating by id.
+/// Used by `models_for_provider` so the picker includes live premium entries.
+pub fn merge_into(models: &mut Vec<ModelInfo>) {
+    let Some(lock) = STORE.get() else {
+        return;
+    };
+    let Ok(guard) = lock.read() else {
+        return;
+    };
+    let seen: std::collections::HashSet<&str> = models.iter().map(|m| m.id.as_str()).collect();
+    let new: Vec<ModelInfo> = guard
+        .models
+        .iter()
+        .filter(|m| !seen.contains(m.id.as_str()))
+        .map(|m| m.to_model_info())
+        .collect();
+    models.extend(new);
+}
+
+/// Spawn a non-blocking background refresh of the premium model list.
+/// `access_token` is the current KomaRun JWT. Uses the existing tokio handle
+/// (safe because this is only called from the event loop or after OAuth
+/// success, when a runtime is guaranteed).
+pub fn spawn_refresh(access_token: String) {
+    if IN_FLIGHT.swap(true, Ordering::AcqRel) {
+        return; // already running
+    }
+    tokio::spawn(async move {
+        let result = fetch_and_swap(&access_token).await;
+        IN_FLIGHT.store(false, Ordering::Release);
+        if let Err(e) = result {
+            crate::model::store::append_global_error_log(
+                "premium dynamic catalogue",
+                &format!("refresh failed: {e}"),
+            );
+        }
+    });
+}
+
+/// TTL-gated refresh: only fetches if the cache is older than [`REFRESH_TTL`]
+/// or `force` is true. Does nothing if no KomaRun token is available.
+pub fn maybe_refresh(access_token: &str, force: bool) {
+    if !force {
+        let Some(lock) = STORE.get() else {
+            return;
+        };
+        let Ok(guard) = lock.read() else {
+            return;
+        };
+        if let Some(ts) = guard.fetched_at {
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            if now.saturating_sub(ts) < REFRESH_TTL.as_secs() {
+                return; // cache is fresh
+            }
+        }
+    }
+    spawn_refresh(access_token.to_string());
+}
+
+// ---------------------------------------------------------------------------
+// Fetch + parse + swap
+// ---------------------------------------------------------------------------
+
+async fn fetch_and_swap(access_token: &str) -> anyhow::Result<()> {
+    use crate::service::oauth::registry::KOMA_PREMIUM_CHAT_ENDPOINT;
+
+    let url = format!("{KOMA_PREMIUM_CHAT_ENDPOINT}/models");
+    let client = reqwest::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .user_agent(concat!("koma/", env!("CARGO_PKG_VERSION")))
+        .build()?;
+
+    let mut resp = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {access_token}"))
+        .send()
+        .await?;
+
+    // On 401: try one fresh_key retry, then bail.
+    if resp.status().as_u16() == 401 {
+        let config = crate::model::app_config::AppConfig::load();
+        if let Some(conn) = config.oauth_conns.iter().find(|c| {
+            c.provider == OAuthProvider::KomaRun && c.access_token == access_token
+        }) {
+            let (fresh, _) =
+                crate::service::oauth::manager::fresh_key(&conn.uuid, &conn.access_token).await;
+            if !fresh.is_empty() && fresh != access_token {
+                resp = client
+                    .get(&url)
+                    .header("Authorization", format!("Bearer {fresh}"))
+                    .send()
+                    .await?;
+            }
+        }
+    }
+
+    if !resp.status().is_success() {
+        anyhow::bail!("HTTP {}", resp.status().as_u16());
+    }
+
+    let body = resp.text().await?;
+    let parsed: ServerModelList = serde_json::from_str(&body)?;
+
+    let fetched_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let models: Vec<OverlayModel> = parsed
+        .data
+        .into_iter()
+        .filter_map(|item| {
+            if item.id.is_empty() {
+                return None;
+            }
+            Some(OverlayModel {
+                id: item.id,
+                supported_parameters: item.supported_parameters.unwrap_or_default(),
+                reasoning: None, // server doesn't send reasoning metadata yet
+                context_length: item.context_length,
+                pricing: None, // server-metered credits, not per-token USD
+            })
+        })
+        .collect();
+
+    if models.is_empty() {
+        anyhow::bail!("server returned empty model list");
+    }
+
+    // Ensure the static `koma/peach` seed is always present.
+    let mut models = models;
+    if !models.iter().any(|m| m.id == "koma/peach") {
+        models.push(OverlayModel {
+            id: "koma/peach".to_string(),
+            supported_parameters: vec![],
+            reasoning: None,
+            context_length: Some(200_000),
+            pricing: None,
+        });
+    }
+
+    // Swap in-memory store.
+    if let Some(lock) = STORE.get() {
+        if let Ok(mut guard) = lock.write() {
+            guard.models = models.clone();
+            guard.fetched_at = Some(fetched_at);
+        }
+    }
+
+    // Atomic disk write.
+    let cache = DiskCache {
+        fetched_at_unix: Some(fetched_at),
+        models,
+    };
+    if let Ok(bytes) = serde_json::to_vec_pretty(&cache) {
+        if let Ok(base) = crate::model::store::base_dir() {
+            let path = base.join(CACHE_FILENAME);
+            let parent = path.parent().unwrap_or(std::path::Path::new("."));
+            let file_name = path
+                .file_name()
+                .ok_or_else(|| anyhow::anyhow!("no file name"))?;
+            let mut tmp_name = file_name.to_owned();
+            tmp_name.push(format!(".{}$", std::process::id()));
+            let tmp_path = parent.join(&tmp_name);
+            if let Err(e) = std::fs::write(&tmp_path, &bytes) {
+                crate::model::store::append_global_error_log(
+                    "premium dynamic catalogue",
+                    &format!("disk write failed: {e}"),
+                );
+            } else {
+                let _ = std::fs::rename(&tmp_path, &path);
+            }
+        }
+    }
+
+    crate::model::store::append_global_error_log(
+        "premium dynamic catalogue",
+        &format!("refreshed {} models", models_len_from_store()),
+    );
+
+    Ok(())
+}
+
+/// Helper to log the current store size after a refresh.
+fn models_len_from_store() -> usize {
+    STORE
+        .get()
+        .and_then(|lock| lock.read().ok())
+        .map(|g| g.models.len())
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// Server response types
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize)]
+struct ServerModelList {
+    data: Vec<ServerModelItem>,
+}
+
+#[derive(serde::Deserialize)]
+struct ServerModelItem {
+    id: String,
+    #[serde(default)]
+    supported_parameters: Option<Vec<String>>,
+    #[serde(default)]
+    context_length: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// Disk I/O
+// ---------------------------------------------------------------------------
+
+fn load_disk() -> Option<PremiumDynamic> {
+    let base = crate::model::store::base_dir().ok()?;
+    let path = base.join(CACHE_FILENAME);
+    let bytes = std::fs::read_to_string(&path).ok()?;
+    let cache: DiskCache = serde_json::from_str(&bytes).ok()?;
+    Some(PremiumDynamic {
+        models: cache.models,
+        fetched_at: cache.fetched_at_unix,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_server_response() {
+        let json = r#"{
+            "object": "list",
+            "data": [
+                { "id": "openai/gpt-4o", "context_length": 128000, "supported_parameters": ["tools"] },
+                { "id": "anthropic/claude-sonnet-4" }
+            ]
+        }"#;
+        let parsed: ServerModelList = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.data.len(), 2);
+        assert_eq!(parsed.data[0].id, "openai/gpt-4o");
+        assert_eq!(parsed.data[0].context_length, Some(128000));
+        assert_eq!(
+            parsed.data[0].supported_parameters,
+            Some(vec!["tools".to_string()])
+        );
+        assert_eq!(parsed.data[1].id, "anthropic/claude-sonnet-4");
+        assert!(parsed.data[1].context_length.is_none());
+    }
+
+    #[test]
+    fn parse_disk_cache_roundtrip() {
+        let cache = DiskCache {
+            fetched_at_unix: Some(1710000000),
+            models: vec![OverlayModel {
+                id: "openai/gpt-4o".to_string(),
+                supported_parameters: vec!["tools".to_string()],
+                reasoning: None,
+                context_length: Some(128000),
+                pricing: None,
+            }],
+        };
+        let json = serde_json::to_string(&cache).unwrap();
+        let parsed: DiskCache = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.fetched_at_unix, Some(1710000000));
+        assert_eq!(parsed.models.len(), 1);
+        assert_eq!(parsed.models[0].id, "openai/gpt-4o");
+    }
+
+    #[test]
+    fn contains_respects_store() {
+        // Without init_from_disk, store is unset — contains returns false.
+        assert!(!contains("koma/peach"));
+    }
+
+    #[test]
+    fn merge_into_dedupes() {
+        // Directly set up a store for test.
+        let store = PremiumDynamic {
+            models: vec![
+                OverlayModel {
+                    id: "koma/peach".to_string(),
+                    supported_parameters: vec![],
+                    reasoning: None,
+                    context_length: Some(200_000),
+                    pricing: None,
+                },
+                OverlayModel {
+                    id: "openai/gpt-4o".to_string(),
+                    supported_parameters: vec!["tools".to_string()],
+                    reasoning: None,
+                    context_length: Some(128_000),
+                    pricing: None,
+                },
+            ],
+            fetched_at: None,
+        };
+        let _ = STORE.set(RwLock::new(store));
+
+        let mut existing = vec![ModelInfo {
+            id: "koma/peach".to_string(),
+            name: None,
+            supported_parameters: vec![],
+            reasoning: None,
+            context_length: Some(200_000),
+            top_provider: None,
+            pricing: None,
+            architecture: None,
+        }];
+        merge_into(&mut existing);
+        // koma/peach deduped, gpt-4o added
+        assert_eq!(existing.len(), 2);
+        assert!(existing.iter().any(|m| m.id == "openai/gpt-4o"));
+    }
+}


### PR DESCRIPTION
New premium_dynamic module fetches the live allowlisted premium model list from GET {KOMA_PREMIUM_CHAT_ENDPOINT}/models, caches it on disk (~/.koma/koma-premium-models.json) and in memory, and merges it into the picker and routing paths so models beyond the static koma/peach seed appear automatically after KomaRun OAuth login.

- Separate OnceLock<RwLock> store survives GitHub overlay refresh swaps
- Single-flight async fetch with 401 fresh_key retry
- TTL-gated maybe_refresh (1h) on ListModels / model picker
- is_premium_model() helper replaces inline overlay scan in resolve.rs
- spawn_refresh on OAuth success (both async drain and paste path)
- 4 unit tests, 679/679 pass, clippy clean