### PR TITLE
feat(msglog): persist reasoning + kill FTS COUNT(*) stall

### DIFF
--- a/src-agent/src/app/runtime/actions/chat.rs
+++ b/src-agent/src/app/runtime/actions/chat.rs
@@ -90,7 +90,7 @@ pub(super) fn handle_submit(
         );
         return Ok(());
     };
-    let _ = msglog::append(&sess.path, Role::User, &text, None);
+    let _ = msglog::append(&sess.path, Role::User, &text, None, None);
     sess.conversation
         .push_user_with_attachments(text, attachments);
     if let Err(e) = sess.save() {
@@ -469,11 +469,11 @@ pub(super) fn handle_deny_tool(state: &mut AppState) -> Result<()> {
         .collect();
     if let Some(sess) = state.rest.fg_mut().session.as_mut() {
         for (id, result) in &results {
-            let _ = msglog::append(&sess.path, Role::Tool, result, None);
+            let _ = msglog::append(&sess.path, Role::Tool, result, None, None);
             sess.conversation.push_tool(id.clone(), result.clone());
         }
         for id in &denied_ids {
-            let _ = msglog::append(&sess.path, Role::Tool, "denied by user", None);
+            let _ = msglog::append(&sess.path, Role::Tool, "denied by user", None, None);
             sess.conversation
                 .push_tool(id.clone(), "denied by user".to_string());
         }

--- a/src-agent/src/app/runtime/actions/plan_decision.rs
+++ b/src-agent/src/app/runtime/actions/plan_decision.rs
@@ -185,7 +185,7 @@ pub(super) fn handle_approve_plan_compact(
         let rt = &mut state.rest.sessions[fgi];
         if let Some(sess) = rt.session.as_mut() {
             for (id, result) in &staged {
-                let _ = msglog::append(&sess.path, Role::Tool, result, None);
+                let _ = msglog::append(&sess.path, Role::Tool, result, None, None);
                 sess.conversation.push_tool(id.clone(), result.clone());
             }
             for id in &trailing_ids {
@@ -193,6 +193,7 @@ pub(super) fn handle_approve_plan_compact(
                     &sess.path,
                     Role::Tool,
                     "skipped — plan approved, compacting context",
+                    None,
                     None,
                 );
                 sess.conversation.push_tool(

--- a/src-agent/src/app/runtime/event_loop/sessions/deferred.rs
+++ b/src-agent/src/app/runtime/event_loop/sessions/deferred.rs
@@ -89,6 +89,7 @@ pub(super) fn drain_deferred_and_resume(
                     crate::dto::chat::Role::User,
                     &content,
                     None,
+                    None,
                 );
                 sess.conversation.push_user(content);
                 let _ = sess.save();
@@ -263,7 +264,7 @@ pub(super) fn drain_deferred_and_resume(
             Some(s) => s,
             None => return dirty,
         };
-        let _ = crate::model::msglog::append(&sess.path, crate::dto::chat::Role::User, &body, None);
+        let _ = crate::model::msglog::append(&sess.path, crate::dto::chat::Role::User, &body, None, None);
         sess.conversation.push_user(body);
         let _ = sess.save();
         let history = sess.conversation.history();
@@ -338,7 +339,7 @@ pub(super) fn drain_deferred_and_resume(
             Some(s) => s,
             None => return dirty,
         };
-        let _ = crate::model::msglog::append(&sess.path, crate::dto::chat::Role::User, &body, None);
+        let _ = crate::model::msglog::append(&sess.path, crate::dto::chat::Role::User, &body, None, None);
         sess.conversation.push_user(body);
         let _ = sess.save();
         let history = sess.conversation.history();
@@ -431,7 +432,7 @@ pub(super) fn drain_deferred_and_resume(
             Some(s) => s,
             None => return dirty,
         };
-        let _ = crate::model::msglog::append(&sess.path, crate::dto::chat::Role::User, &body, None);
+        let _ = crate::model::msglog::append(&sess.path, crate::dto::chat::Role::User, &body, None, None);
         sess.conversation.push_user(body);
         let _ = sess.save();
         let history = sess.conversation.history();

--- a/src-agent/src/app/runtime/event_loop/sessions/subagents.rs
+++ b/src-agent/src/app/runtime/event_loop/sessions/subagents.rs
@@ -444,6 +444,7 @@ pub(super) fn drain_subagents(
                     crate::dto::chat::Role::User,
                     &note,
                     None,
+                    None,
                 );
                 sess.conversation.push_user(note);
                 let _ = sess.save();

--- a/src-agent/src/app/runtime/stream/tools/dispatch.rs
+++ b/src-agent/src/app/runtime/stream/tools/dispatch.rs
@@ -142,7 +142,7 @@ pub(super) fn finish_tool_round(
         let rt = &mut state.rest.sessions[sess_idx];
         if let Some(sess) = rt.session.as_mut() {
             for (id, result) in &cleaned_results {
-                let _ = crate::model::msglog::append(&sess.path, Role::Tool, result, None);
+                let _ = crate::model::msglog::append(&sess.path, Role::Tool, result, None, None);
                 sess.conversation.push_tool(id.clone(), result.clone());
             }
             let _ = sess.save();
@@ -188,7 +188,7 @@ pub(super) fn finish_tool_round(
     if !steers.is_empty() {
         let joined = steers.join("\n\n");
         if let Some(sess) = state.rest.sessions[sess_idx].session.as_mut() {
-            let _ = crate::model::msglog::append(&sess.path, Role::User, &joined, None);
+            let _ = crate::model::msglog::append(&sess.path, Role::User, &joined, None, None);
             sess.conversation.push_user(joined);
             let _ = sess.save();
         }
@@ -320,11 +320,11 @@ pub(crate) fn deny_all_pending(state: &mut AppState, sess_idx: usize, reason: &s
         .collect();
     if let Some(sess) = state.rest.sessions[sess_idx].session.as_mut() {
         for (id, result) in &results {
-            let _ = crate::model::msglog::append(&sess.path, Role::Tool, result, None);
+            let _ = crate::model::msglog::append(&sess.path, Role::Tool, result, None, None);
             sess.conversation.push_tool(id.clone(), result.clone());
         }
         for id in &pending_ids {
-            let _ = crate::model::msglog::append(&sess.path, Role::Tool, reason, None);
+            let _ = crate::model::msglog::append(&sess.path, Role::Tool, reason, None, None);
             sess.conversation.push_tool(id.clone(), reason.to_string());
         }
         let _ = sess.save();

--- a/src-agent/src/app/runtime/stream/turn.rs
+++ b/src-agent/src/app/runtime/stream/turn.rs
@@ -14,7 +14,7 @@ use super::final_answer;
 pub(crate) fn push_image_unsupported_notice(rest: &mut AppStateRest) {
     let notice = "Sorry, I can't see images on this model. Switch to a vision-capable model, or send your message without the image.".to_string();
     if let Some(sess) = rest.fg_mut().session.as_mut() {
-        let _ = crate::model::msglog::append(&sess.path, Role::Assistant, &notice, None);
+        let _ = crate::model::msglog::append(&sess.path, Role::Assistant, &notice, None, None);
         sess.conversation.push_assistant(notice, None, false);
         let _ = sess.save();
     }
@@ -87,6 +87,7 @@ pub(crate) fn finish_stream(rest: &mut AppStateRest, sess_idx: usize, error: Opt
                 &sess.path,
                 crate::dto::chat::Role::Assistant,
                 &content,
+                msg_reasoning.as_deref(),
                 usage,
             );
             sess.conversation
@@ -213,7 +214,7 @@ pub(crate) fn advance_turn(
     let usage = state.rest.sessions[sess_idx].pending_usage.take();
     // Display-only reasoning streamed this round. Taken unconditionally (so it
     // can never leak into the next round) and folded onto the committed message
-    // below; never logged to disk or sent to the API.
+    // below; persisted to messages.json for session resume but not sent on the wire.
     let reasoning = state.rest.sessions[sess_idx].take_reasoning();
     // Structured OpenRouter reasoning_details streamed this round. Drained
     // unconditionally (same as `reasoning`, so it can never leak into the next
@@ -305,7 +306,7 @@ pub(crate) fn advance_turn(
                 // so it decodes here; only decode — strip nothing else.
                 let raw = buf.clone().unwrap_or_default();
                 let content = crate::dto::chat::unescape_reasoning_tags(&raw).into_owned();
-                let _ = crate::model::msglog::append(&sess.path, Role::Assistant, &content, usage);
+                let _ = crate::model::msglog::append(&sess.path, Role::Assistant, &content, reasoning.as_deref(), usage);
                 sess.conversation.push_assistant_with_tools(
                     content,
                     pending.clone(),
@@ -320,7 +321,7 @@ pub(crate) fn advance_turn(
                     final_answer(buf.clone().unwrap_or_default(), reasoning);
                 if !content.is_empty() {
                     let _ =
-                        crate::model::msglog::append(&sess.path, Role::Assistant, &content, usage);
+                        crate::model::msglog::append(&sess.path, Role::Assistant, &content, msg_reasoning.as_deref(), usage);
                     sess.conversation
                         .push_assistant(content.clone(), msg_reasoning, promoted);
                     if let Err(e) = sess.save() {
@@ -408,7 +409,7 @@ pub(crate) fn advance_turn(
             // pub(super) in the actions module, so we inline the essentials here
             // rather than risk a module-visibility or borrow cycle.
             if let Some(sess) = state.rest.sessions[sess_idx].session.as_mut() {
-                let _ = crate::model::msglog::append(&sess.path, Role::User, &joined, None);
+                let _ = crate::model::msglog::append(&sess.path, Role::User, &joined, None, None);
                 sess.conversation.push_user(joined);
                 let _ = sess.save();
             }

--- a/src-agent/src/app/state/runtime/lifecycle.rs
+++ b/src-agent/src/app/state/runtime/lifecycle.rs
@@ -208,6 +208,7 @@ impl SessionRuntime {
                         &sess.path,
                         crate::dto::chat::Role::Assistant,
                         &content,
+                        reasoning.as_deref(),
                         usage,
                     );
                     sess.conversation.push_assistant(content, reasoning, false);

--- a/src-agent/src/dto/chat/message.rs
+++ b/src-agent/src/dto/chat/message.rs
@@ -108,12 +108,12 @@ pub struct ChatMessage {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub attachments: Vec<Attachment>,
     /// Display-only reasoning/thinking text accumulated from the model's
-    /// `delta.reasoning` channel during streaming. `#[serde(skip)]` means it is
-    /// NEVER serialised — not into a `ChatRequest` body nor `messages.json` — and
-    /// always defaults to `None` on deserialise. This keeps reasoning purely a
-    /// render-time concern: it shows above the answer but never re-enters the
-    /// conversation the model sees, and never touches disk.
-    #[serde(skip)]
+    /// `delta.reasoning` channel during streaming. Persisted to `messages.json`
+    /// for session resume / transcript rehydration, but NEVER sent on the wire
+    /// (`to_wire` builds request bodies from fields and omits this). Old
+    /// `messages.json` files without a `reasoning` key deserialize to `None`
+    /// via `#[serde(default)]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<String>,
     /// Display+replay-only OpenRouter reasoning_details for THIS assistant turn.
     /// `#[serde(skip)]` — never touches `messages.json` and never re-enters the

--- a/src-agent/src/model/conversation.rs
+++ b/src-agent/src/model/conversation.rs
@@ -70,9 +70,10 @@ impl Conversation {
     ///
     /// `reasoning` is the display-only thinking block streamed for this turn
     /// (`None` when the model didn't think). It is attached BEFORE the message
-    /// enters the list so the transcript cache captures it on first render, and
-    /// it is never serialised (the field is `#[serde(skip)]`) — it only ever
-    /// shows above the answer, never re-entering the conversation or disk.
+    /// enters the list so the transcript cache captures it on first render. It
+    /// is persisted to `messages.json` (for session resume / transcript rehydrate)
+    /// but never sent on the wire (`to_wire` builds request bodies from fields
+    /// and omits this).
     pub fn push_assistant(
         &mut self,
         content: impl Into<String>,
@@ -89,11 +90,11 @@ impl Conversation {
     /// Append an assistant turn that requested tool calls. `content` is the
     /// assistant text accompanying the calls (often empty). `reasoning` is the
     /// display-only thinking block (the model may think before emitting tool
-    /// calls); attached before the push and never serialised — see
-    /// [`Self::push_assistant`]. `reasoning_details` is the structured OpenRouter
-    /// chain-of-thought (typed + signed) for this turn, echoed back on the
-    /// tool-continuation request so the model keeps its reasoning across tool calls;
-    /// also never persisted to disk.
+    /// calls); attached before the push and persisted to `messages.json` for
+    /// session resume — see [`Self::push_assistant`]. `reasoning_details` is the
+    /// structured OpenRouter chain-of-thought (typed + signed) for this turn,
+    /// echoed back on the tool-continuation request so the model keeps its
+    /// reasoning across tool calls; never persisted to disk.
     pub fn push_assistant_with_tools(
         &mut self,
         content: String,

--- a/src-agent/src/model/msglog/mod.rs
+++ b/src-agent/src/model/msglog/mod.rs
@@ -8,12 +8,27 @@
 //! Writes are best-effort: callers ignore the error so a DB hiccup never
 //! interrupts the chat.
 //!
+//! ## Reasoning column
+//!
+//! The `messages` table carries an optional `reasoning TEXT` column that stores
+//! the display-only thinking trace from assistant turns. It is NOT indexed by
+//! FTS5 (search stays on user-visible content); reasoning is rehydrated from
+//! `messages.json` on session load and returned as a snippet by
+//! [`query::search_messages`] for display in `message_find` results.
+//!
 //! ## Full-text search (FTS5)
 //!
 //! The `messages_fts` virtual table indexes every message's `content` and `role`
 //! for full-text search via [`query::search_messages`]. It is populated on every
 //! `append()` and cleaned up on `truncate_after()`; existing DBs are backfilled
-//! once on first open. The `message_find` tool exposes this to the model.
+//! once on first open (gated by `schema_meta` to avoid expensive re-runs). The
+//! `message_find` tool exposes this to the model.
+//!
+//! ## Schema migration gate (`schema_meta`)
+//!
+//! A key/value table that tracks one-shot migrations (e.g. `fts_backfilled`).
+//! This replaces the old `COUNT(*)` probe on `messages_fts` which was O(n) on
+//! multi-million-row tables and caused multi-minute stalls on every `open()`.
 //!
 //! ## "Short-send" storage (Phase 1)
 //!

--- a/src-agent/src/model/msglog/query.rs
+++ b/src-agent/src/model/msglog/query.rs
@@ -9,30 +9,36 @@ use crate::dto::chat::Role;
 use super::blobs::classify_blob;
 use super::schema::{now_secs, open, role_str};
 
-/// One archived message row, role + content, as stored in `messages`.
-/// Used by [`fetch_messages_since`] for replaying history (P2/P3).
+/// One archived message row, role + content + optional reasoning, as stored in
+/// `messages`. Used by [`fetch_messages_since`] for replaying history (P2/P3).
 #[allow(dead_code)] // consumed by later phases (short-send summary/router)
 #[derive(Debug, Clone)]
 pub struct ArchivedMsg {
     pub id: i64,
     pub role: String,
     pub content: String,
+    pub reasoning: Option<String>,
 }
 
 /// A match from the FTS5 full-text search index (`messages_fts`).
 /// Returned by [`search_messages`]; the `snippet` field is the first 300
-/// characters of the matching message for coherent context.
+/// characters of the matching message for coherent context. `reasoning` holds
+/// the first 300 characters of the assistant's thinking trace when present,
+/// surfaced by the `message_find` tool for display.
 #[derive(Debug, Clone)]
 pub struct MessageMatch {
     pub id: i64,
     pub role: String,
     pub snippet: String,
     pub created_at: i64,
+    pub reasoning: Option<String>,
 }
 
 /// Append one message to the session's SQLite log, creating the DB + tables on
 /// first use, and return the inserted `messages.id`. `session_dir` is the
-/// session directory (where messages.json lives). `usage` is
+/// session directory (where messages.json lives). `reasoning` is the display-
+/// only thinking trace for assistant messages (stored as-is for later re-
+/// hydration; NOT indexed by FTS5). `usage` is
 /// `(prompt_tokens, completion_tokens, cost)` for assistant messages, or `None`
 /// (stored as zeros) for user messages. Best-effort — callers ignore the
 /// result.
@@ -46,18 +52,28 @@ pub fn append(
     session_dir: &Path,
     role: Role,
     content: &str,
+    reasoning: Option<&str>,
     usage: Option<(u64, u64, f64)>,
 ) -> Result<i64> {
     let mut conn = open(session_dir)?;
     let created_at = now_secs();
     let (pt, ct, cost) = usage.unwrap_or((0, 0, 0.0));
+    // Store reasoning only when non-empty; SQL NULL otherwise.
+    let reasoning = reasoning.and_then(|r| {
+        let trimmed = r.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    });
 
     let tx = conn.transaction()?;
     tx.execute(
         "INSERT INTO messages
-            (role, content, created_at, prompt_tokens, completion_tokens, cost)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        rusqlite::params![role_str(role), content, created_at, pt, ct, cost],
+            (role, content, reasoning, created_at, prompt_tokens, completion_tokens, cost)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        rusqlite::params![role_str(role), content, reasoning, created_at, pt, ct, cost],
     )?;
     let msg_id = tx.last_insert_rowid();
 
@@ -74,6 +90,8 @@ pub fn append(
     }
 
     // Keep the FTS5 index in sync: one row per message, keyed by rowid = msg_id.
+    // Only content + role are indexed (reasoning is NOT in FTS — keeps search
+    // focused on user-visible text; reasoning is rehydrated from messages.json).
     tx.execute(
         "INSERT INTO messages_fts(rowid, content, role) VALUES (?1, ?2, ?3)",
         rusqlite::params![msg_id, content, role_str(role)],
@@ -116,7 +134,7 @@ pub fn fetch_messages_since(session_dir: &Path, after_id: i64, limit: i64) -> Ve
     fn inner(session_dir: &Path, after_id: i64, limit: i64) -> Result<Vec<ArchivedMsg>> {
         let conn = open(session_dir)?;
         let mut stmt = conn.prepare(
-            "SELECT id, role, content FROM messages
+            "SELECT id, role, content, reasoning FROM messages
              WHERE id > ?1 ORDER BY id ASC LIMIT ?2",
         )?;
         let rows = stmt.query_map(rusqlite::params![after_id, limit], |r| {
@@ -124,6 +142,7 @@ pub fn fetch_messages_since(session_dir: &Path, after_id: i64, limit: i64) -> Ve
                 id: r.get(0)?,
                 role: r.get(1)?,
                 content: r.get(2)?,
+                reasoning: r.get(3)?,
             })
         })?;
         let mut out = Vec::new();
@@ -290,15 +309,19 @@ pub fn search_messages(
         let conn = open(session_dir)?;
         // Use substr() for the first 300 chars of the actual message content
         // instead of FTS5's snippet() — gives coherent, readable context.
+        // Reasoning is also returned as a first-300-chars snippet for display
+        // in `message_find` results; it is NOT in the FTS index.
         let sql = if role_filter.is_some() {
-            "SELECT m.id, m.role, substr(m.content, 1, 300) AS excerpt, m.created_at
+            "SELECT m.id, m.role, substr(m.content, 1, 300) AS excerpt, m.created_at,
+                    substr(m.reasoning, 1, 300)
              FROM messages_fts
              JOIN messages m ON m.id = messages_fts.rowid
              WHERE messages_fts MATCH ?1 AND m.role = ?2
              ORDER BY rank
              LIMIT ?3"
         } else {
-            "SELECT m.id, m.role, substr(m.content, 1, 300) AS excerpt, m.created_at
+            "SELECT m.id, m.role, substr(m.content, 1, 300) AS excerpt, m.created_at,
+                    substr(m.reasoning, 1, 300)
              FROM messages_fts
              JOIN messages m ON m.id = messages_fts.rowid
              WHERE messages_fts MATCH ?1
@@ -306,11 +329,13 @@ pub fn search_messages(
              LIMIT ?2"
         };
         fn map_row(r: &rusqlite::Row) -> rusqlite::Result<MessageMatch> {
+            let reasoning: Option<String> = r.get(4)?;
             Ok(MessageMatch {
                 id: r.get(0)?,
                 role: r.get(1)?,
                 snippet: r.get(2)?,
                 created_at: r.get(3)?,
+                reasoning: reasoning.filter(|s| !s.is_empty()),
             })
         }
         let mut stmt = conn.prepare(sql)?;

--- a/src-agent/src/model/msglog/query_test.rs
+++ b/src-agent/src/model/msglog/query_test.rs
@@ -39,9 +39,9 @@ fn message_count_none_when_no_sqlite_yet() {
 #[test]
 fn message_count_counts_appended_rows() {
     let dir = TempDir::new("counts");
-    append(dir.path(), Role::User, "hi", None).unwrap();
-    append(dir.path(), Role::Assistant, "hello", Some((10, 5, 0.001))).unwrap();
-    append(dir.path(), Role::Tool, "tool output", None).unwrap();
+    append(dir.path(), Role::User, "hi", None, None).unwrap();
+    append(dir.path(), Role::Assistant, "hello", None, Some((10, 5, 0.001))).unwrap();
+    append(dir.path(), Role::Tool, "tool output", None, None).unwrap();
 
     assert_eq!(message_count(dir.path()), Some(3));
 }
@@ -54,8 +54,8 @@ fn message_count_is_a_plain_row_count() {
     // documents that the query itself does not special-case any role — if a
     // System row were ever appended, it would be counted too.
     let dir = TempDir::new("plain-count");
-    append(dir.path(), Role::System, "system prompt", None).unwrap();
-    append(dir.path(), Role::User, "hi", None).unwrap();
+    append(dir.path(), Role::System, "system prompt", None, None).unwrap();
+    append(dir.path(), Role::User, "hi", None, None).unwrap();
 
     assert_eq!(message_count(dir.path()), Some(2));
 }
@@ -63,8 +63,8 @@ fn message_count_is_a_plain_row_count() {
 #[test]
 fn clear_rolling_summary_freezes_watermark_and_empties_text() {
     let dir = TempDir::new("clear-summary");
-    append(dir.path(), Role::User, "hi", None).unwrap();
-    append(dir.path(), Role::Assistant, "hello", Some((10, 5, 0.0))).unwrap();
+    append(dir.path(), Role::User, "hi", None, None).unwrap();
+    append(dir.path(), Role::Assistant, "hello", None, Some((10, 5, 0.0))).unwrap();
     let tip = max_message_id(dir.path());
     assert!(tip >= 2);
     // Seed a non-empty summary covering the archive.
@@ -92,8 +92,8 @@ fn clear_rolling_summary_on_empty_archive_deletes_row() {
 #[test]
 fn search_messages_single_term_finds_match() {
     let dir = TempDir::new("fts-single");
-    append(dir.path(), Role::User, "hello world", None).unwrap();
-    append(dir.path(), Role::Assistant, "goodbye", Some((10, 5, 0.0))).unwrap();
+    append(dir.path(), Role::User, "hello world", None, None).unwrap();
+    append(dir.path(), Role::Assistant, "goodbye", None, Some((10, 5, 0.0))).unwrap();
 
     let hits = search_messages(dir.path(), "hello", 10, None);
     assert_eq!(hits.len(), 1);
@@ -108,15 +108,16 @@ fn search_messages_single_term_finds_match() {
 #[test]
 fn search_messages_multi_term_or_finds_any_match() {
     let dir = TempDir::new("fts-multi");
-    append(dir.path(), Role::User, "the quick brown fox", None).unwrap();
+    append(dir.path(), Role::User, "the quick brown fox", None, None).unwrap();
     append(
         dir.path(),
         Role::Assistant,
         "lazy dog sleeps",
+        None,
         Some((10, 5, 0.0)),
     )
     .unwrap();
-    append(dir.path(), Role::User, "unrelated text here", None).unwrap();
+    append(dir.path(), Role::User, "unrelated text here", None, None).unwrap();
 
     // "fox zebra" -> fox* OR zebra* -> should match message 1 but not 2 or 3.
     let hits = search_messages(dir.path(), "fox zebra", 10, None);
@@ -132,16 +133,18 @@ fn search_messages_or_ranks_multiple_hits() {
         Role::User,
         "security vulnerability found in parser",
         None,
+        None,
     )
     .unwrap();
     append(
         dir.path(),
         Role::Assistant,
         "security is important always",
+        None,
         Some((10, 5, 0.0)),
     )
     .unwrap();
-    append(dir.path(), Role::User, "nothing to see here", None).unwrap();
+    append(dir.path(), Role::User, "nothing to see here", None, None).unwrap();
 
     let hits = search_messages(dir.path(), "security", 10, None);
     assert_eq!(hits.len(), 2);
@@ -156,7 +159,7 @@ fn search_messages_or_ranks_multiple_hits() {
 #[test]
 fn search_messages_no_match_returns_empty() {
     let dir = TempDir::new("fts-nomatch");
-    append(dir.path(), Role::User, "hello", None).unwrap();
+    append(dir.path(), Role::User, "hello", None, None).unwrap();
 
     let hits = search_messages(dir.path(), "zzznotexist", 10, None);
     assert!(hits.is_empty());
@@ -170,6 +173,7 @@ fn search_messages_strips_fts5_syntax_chars() {
         Role::User,
         "the FOO constant is defined in config.rs",
         None,
+        None,
     )
     .unwrap();
 
@@ -177,4 +181,119 @@ fn search_messages_strips_fts5_syntax_chars() {
     let hits = search_messages(dir.path(), "FOO*", 10, None);
     assert!(!hits.is_empty());
     assert!(hits[0].snippet.contains("FOO"));
+}
+
+#[test]
+fn append_stores_and_fetch_reasoning() {
+    let dir = TempDir::new("reasoning-store");
+    append(
+        dir.path(),
+        Role::Assistant,
+        "The answer is 42",
+        Some("I considered many possibilities before settling on this"),
+        Some((10, 5, 0.001)),
+    )
+    .unwrap();
+    append(dir.path(), Role::User, "thanks", None, None).unwrap();
+
+    // Reasoning is returned by fetch_messages_since.
+    let msgs = fetch_messages_since(dir.path(), 0, 10);
+    assert_eq!(msgs.len(), 2);
+    assert_eq!(
+        msgs[0].reasoning.as_deref(),
+        Some("I considered many possibilities before settling on this")
+    );
+    // User message has no reasoning.
+    assert!(msgs[1].reasoning.is_none());
+
+    // FTS search still matches on content (not reasoning).
+    let hits = search_messages(dir.path(), "answer", 10, None);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].role, "assistant");
+    // The reasoning snippet is populated in search results.
+    assert_eq!(
+        hits[0].reasoning.as_deref(),
+        Some("I considered many possibilities before settling on this")
+    );
+}
+
+#[test]
+fn append_empty_reasoning_stores_null() {
+    let dir = TempDir::new("reasoning-empty");
+    append(
+        dir.path(),
+        Role::Assistant,
+        "hello",
+        Some("   "),
+        Some((10, 5, 0.0)),
+    )
+    .unwrap();
+
+    let msgs = fetch_messages_since(dir.path(), 0, 10);
+    assert_eq!(msgs.len(), 1);
+    // Whitespace-only reasoning should be stored as NULL.
+    assert!(msgs[0].reasoning.is_none());
+}
+
+#[test]
+fn schema_meta_skips_fts_recount() {
+    let dir = TempDir::new("schema-meta");
+    // First append triggers ensure_schema + backfill.
+    append(dir.path(), Role::User, "first message", None, None).unwrap();
+
+    // Verify schema_meta has fts_backfilled=1.
+    let conn = crate::model::msglog::schema::open(dir.path()).unwrap();
+    let val: i64 = conn
+        .query_row(
+            "SELECT value FROM schema_meta WHERE key = 'fts_backfilled'",
+            [],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap_or(0);
+    assert_eq!(val, 1, "fts_backfilled should be set after first append");
+
+    // Second open should succeed without re-running backfill (schema ready).
+    let conn2 = crate::model::msglog::schema::open(dir.path()).unwrap();
+    let val2: i64 = conn2
+        .query_row(
+            "SELECT value FROM schema_meta WHERE key = 'fts_backfilled'",
+            [],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap_or(0);
+    assert_eq!(val2, 1, "meta unchanged after second open");
+}
+
+#[test]
+fn search_still_works_after_reasoning_column() {
+    let dir = TempDir::new("fts-after-reasoning");
+    append(
+        dir.path(),
+        Role::Assistant,
+        "we need to fix the parser bug",
+        Some("I analyzed the stack trace and found the root cause"),
+        Some((10, 5, 0.0)),
+    )
+    .unwrap();
+    append(
+        dir.path(),
+        Role::User,
+        "great, go ahead",
+        None,
+        None,
+    )
+    .unwrap();
+
+    // FTS matches on content, not reasoning.
+    let hits = search_messages(dir.path(), "parser", 10, None);
+    assert_eq!(hits.len(), 1);
+    assert!(hits[0].snippet.contains("parser"));
+    assert_eq!(
+        hits[0].reasoning.as_deref(),
+        Some("I analyzed the stack trace and found the root cause")
+    );
+
+    // Reasoning-only terms don't match via FTS.
+    let hits = search_messages(dir.path(), "stack trace", 10, None);
+    assert!(hits.is_empty(), "FTS should not index reasoning");
 }

--- a/src-agent/src/model/msglog/schema.rs
+++ b/src-agent/src/model/msglog/schema.rs
@@ -1,6 +1,17 @@
 //! DB connection helpers, schema migrations, and small utility functions.
+//!
+//! The `reasoning` column on `messages` stores display-only thinking traces
+//! from assistant turns. It is NOT indexed by FTS5 (search stays on user-
+//! visible content); reasoning is rehydrated from `messages.json` on load
+//! and returned as a snippet by `search_messages` for display in
+//! `message_find` results.
+//!
+//! `schema_meta` is a key/value table that gates one-shot migrations (e.g.
+//! FTS backfill) so `open()` never re-runs expensive init work.
 
-use std::path::Path;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
@@ -28,12 +39,48 @@ pub(super) fn role_str(role: Role) -> &'static str {
     }
 }
 
+/// Per-process set of paths whose schema has already been run. Prevents the
+/// expensive `ensure_schema` (especially FTS backfill) from executing more
+/// than once per `messages.sqlite` file across all `open()` calls in this
+/// process — the primary fix for the multi-minute stall on large sessions.
+static SCHEMA_READY: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+
 /// Open the session's SQLite archive and run migrations. Centralises the path
 /// join so every entry point hits the same file + schema.
+///
+/// Sets WAL mode + performance PRAGMAs on every connection, then runs
+/// `ensure_schema` at most once per file path (guarded by [`SCHEMA_READY`]).
 pub fn open(session_dir: &Path) -> Result<Connection> {
-    let conn = Connection::open(session_dir.join("messages.sqlite"))?;
-    ensure_schema(&conn)?;
+    let path = session_dir.join("messages.sqlite");
+    let conn = Connection::open(&path)?;
+    // WAL + performance PRAGMAs. WAL mode is persistent in the file; the rest
+    // are per-connection but harmless to repeat.
+    let _ = conn.execute_batch(
+        "PRAGMA journal_mode=WAL;
+         PRAGMA synchronous=NORMAL;
+         PRAGMA busy_timeout=5000;
+         PRAGMA cache_size=-65536;
+         PRAGMA mmap_size=268435456;
+         PRAGMA temp_store=MEMORY;",
+    );
+    ensure_schema_once(&path, &conn)?;
     Ok(conn)
+}
+
+/// Run [`ensure_schema`] exactly once per file path. The `OnceLock` + `HashSet`
+/// avoids repeated schema checks (and especially the FTS backfill probe) on
+/// every `open()` call within a process — the primary fix for the multi-minute
+/// stall caused by `COUNT(*)` on large FTS tables.
+fn ensure_schema_once(path: &Path, conn: &Connection) -> Result<()> {
+    let set = SCHEMA_READY.get_or_init(|| Mutex::new(HashSet::new()));
+    let mut guard = set.lock().unwrap_or_else(|e| e.into_inner());
+    let key = path.to_path_buf();
+    if guard.contains(&key) {
+        return Ok(());
+    }
+    ensure_schema(conn)?;
+    guard.insert(key);
+    Ok(())
 }
 
 /// Unix-seconds timestamp, or 0 if the clock is before the epoch (won't happen
@@ -46,19 +93,27 @@ pub(super) fn now_secs() -> i64 {
 }
 
 /// Create the `messages` table if absent, then best-effort add the usage
-/// columns so pre-usage DBs migrate forward. The CREATE includes the usage
-/// columns for fresh DBs; the ALTERs cover existing DBs and intentionally
-/// ignore the "duplicate column" error they raise once the columns exist.
+/// and `reasoning` columns so pre-existing DBs migrate forward. The CREATE
+/// includes all columns for fresh DBs; the ALTERs cover existing DBs and
+/// intentionally ignore the "duplicate column" error they raise once the
+/// columns exist.
 ///
-/// Also creates the Phase-1 side tables (`blobs`, `summary`) and the FTS5
-/// full-text search index (`messages_fts`). All statements are `IF NOT EXISTS`,
-/// so running this against a DB that already has the tables is a no-op.
+/// Also creates the Phase-1 side tables (`blobs`, `summary`), the FTS5
+/// full-text search index (`messages_fts`), and the `schema_meta` migration-
+/// gate table. All statements are `IF NOT EXISTS`, so running this against a
+/// DB that already has the tables is a no-op.
+///
+/// FTS backfill is gated by `schema_meta.fts_backfilled`: once the flag is set,
+/// we never re-run the backfill (even if the FTS is somehow emptied). This
+/// replaces the old `COUNT(*)` probe which was O(n) on multi-million-row FTS
+/// tables and caused multi-minute stalls on every `open()`.
 fn ensure_schema(conn: &Connection) -> Result<()> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS messages (
             id                INTEGER PRIMARY KEY AUTOINCREMENT,
             role              TEXT NOT NULL,
             content           TEXT NOT NULL,
+            reasoning         TEXT,
             created_at        INTEGER NOT NULL,
             prompt_tokens     INTEGER NOT NULL DEFAULT 0,
             completion_tokens INTEGER NOT NULL DEFAULT 0,
@@ -112,10 +167,15 @@ fn ensure_schema(conn: &Connection) -> Result<()> {
 
         CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
             content, role, tokenize='unicode61'
+        );
+
+        CREATE TABLE IF NOT EXISTS schema_meta (
+            key   TEXT PRIMARY KEY,
+            value INTEGER NOT NULL
         );",
     )?;
-    // Migrate older DBs (created before the usage columns existed). Errors here
-    // are expected once the columns are present, so they're discarded.
+    // Migrate older DBs (created before the usage/reasoning columns existed).
+    // Errors here are expected once the columns are present, so they're discarded.
     let _ = conn.execute(
         "ALTER TABLE messages ADD COLUMN prompt_tokens INTEGER NOT NULL DEFAULT 0",
         [],
@@ -128,16 +188,39 @@ fn ensure_schema(conn: &Connection) -> Result<()> {
         "ALTER TABLE messages ADD COLUMN cost REAL NOT NULL DEFAULT 0",
         [],
     );
-    // Backfill FTS index for existing DBs that predate the virtual table.
-    // The count check is cheap and makes this a one-shot: once populated,
-    // new messages enter FTS via `append()` so this never runs again.
-    let fts_count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM messages_fts", [], |r| r.get(0))
+    let _ = conn.execute("ALTER TABLE messages ADD COLUMN reasoning TEXT", []);
+
+    // FTS backfill: gated by schema_meta to avoid the O(n) COUNT(*) that caused
+    // multi-minute stalls on large sessions. Once fts_backfilled=1, we never
+    // re-run (even if FTS is somehow emptied — better than silent full reindex;
+    // truncate_after already keeps FTS in sync).
+    let backfilled: i64 = conn
+        .query_row(
+            "SELECT value FROM schema_meta WHERE key = 'fts_backfilled'",
+            [],
+            |r| r.get(0),
+        )
         .unwrap_or(0);
-    if fts_count == 0 {
+    if backfilled == 0 {
+        // Only backfill if FTS is empty AND messages has rows — one-shot for
+        // old DBs that predate the FTS virtual table. EXISTS is O(1) / first
+        // page, not a full FTS count.
+        let fts_empty: bool = conn
+            .query_row(
+                "SELECT NOT EXISTS(SELECT 1 FROM messages_fts LIMIT 1)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(true);
+        if fts_empty {
+            let _ = conn.execute(
+                "INSERT INTO messages_fts(rowid, content, role)
+                 SELECT id, content, role FROM messages",
+                [],
+            );
+        }
         let _ = conn.execute(
-            "INSERT INTO messages_fts(rowid, content, role)
-             SELECT id, content, role FROM messages",
+            "INSERT OR REPLACE INTO schema_meta(key, value) VALUES ('fts_backfilled', 1)",
             [],
         );
     }

--- a/src-agent/src/tool/history.rs
+++ b/src-agent/src/tool/history.rs
@@ -67,7 +67,7 @@ impl Tool for MessageFind {
         let out = format_matches(
             matches
                 .iter()
-                .map(|m| (m.id, m.role.as_str(), m.snippet.as_str(), m.created_at)),
+                .map(|m| (m.id, m.role.as_str(), m.snippet.as_str(), m.created_at, m.reasoning.as_deref())),
         );
 
         if out.is_empty() {
@@ -77,9 +77,9 @@ impl Tool for MessageFind {
     }
 }
 
-fn format_matches<'a>(matches: impl Iterator<Item = (i64, &'a str, &'a str, i64)>) -> String {
+fn format_matches<'a>(matches: impl Iterator<Item = (i64, &'a str, &'a str, i64, Option<&'a str>)>) -> String {
     let mut out = String::new();
-    for (msg_id, role, content, _created_at) in matches {
+    for (msg_id, role, content, _created_at, reasoning) in matches {
         let role_prefix = match role {
             "user" => "[user]",
             "assistant" => "[assistant]",
@@ -95,6 +95,18 @@ fn format_matches<'a>(matches: impl Iterator<Item = (i64, &'a str, &'a str, i64)
             snippet
         };
         out.push_str(&format!("{} #{}: {}\n\n", role_prefix, msg_id, snippet));
+        // Append a thinking snippet for assistant messages that have reasoning.
+        if let Some(thinking) = reasoning {
+            let thinking = thinking.trim();
+            if !thinking.is_empty() {
+                let t = if thinking.len() > 300 {
+                    &thinking[..300]
+                } else {
+                    thinking
+                };
+                out.push_str(&format!("  thinking: {}\n\n", t));
+            }
+        }
     }
     out
 }


### PR DESCRIPTION
Reasoning persistence:
- ChatMessage.reasoning now serializes to messages.json (skip_serializing_if) so assistant thinking traces survive session resume and compact.
- New nullable reasoning TEXT column on messages table; not indexed by FTS5.
- search_messages returns reasoning snippet in MessageMatch for message_find.
- message_find tool formats thinking snippets below assistant hits.
- Wire safety: to_wire builds WireMessage from fields, never touches reasoning.

FTS performance fix:
- Replace O(n) COUNT(*) FTS backfill probe with schema_meta.fts_backfilled gate + EXISTS LIMIT 1 (O(1)).
- OnceLock<HashSet> ensures ensure_schema runs at most once per file path per process — eliminates repeated schema checks on every open() call.
- WAL + performance PRAGMAs on every connection.

4 new tests (14 total passing), clippy clean.

Files: schema.rs, query.rs, query_test.rs, mod.rs, message.rs, conversation.rs, turn.rs, lifecycle.rs, history.rs + 5 call-site files.