### PR TITLE
feat(composer): add Ctrl+Left/Right word-jump navigation

### DIFF
--- a/src-agent/src/app/state/input.rs
+++ b/src-agent/src/app/state/input.rs
@@ -50,6 +50,16 @@ impl AppStateRest {
         self.fg_mut().cursor_right();
     }
 
+    /// Jump the caret to the start of the previous word (Ctrl+Left).
+    pub fn cursor_word_left(&mut self) {
+        self.fg_mut().cursor_word_left();
+    }
+
+    /// Jump the caret to the start of the next word (Ctrl+Right).
+    pub fn cursor_word_right(&mut self) {
+        self.fg_mut().cursor_word_right();
+    }
+
     /// Jump the caret to the start of the input.
     pub fn cursor_home(&mut self) {
         self.fg_mut().cursor_home();

--- a/src-agent/src/app/state/runtime/composer.rs
+++ b/src-agent/src/app/state/runtime/composer.rs
@@ -100,6 +100,44 @@ impl SessionRuntime {
         self.cursor = (self.cursor + 1).min(self.char_len());
     }
 
+    /// Jump the caret to the start of the previous word (Ctrl+Left).
+    ///
+    /// Standard terminal word-jump: skip backward over separator (non-alphanumeric)
+    /// chars, then over the word (alphanumeric) chars. Stops at position 0.
+    pub fn cursor_word_left(&mut self) {
+        let chars: Vec<char> = self.input.chars().collect();
+        let mut pos = self.cursor;
+        // Skip backward over separators.
+        while pos > 0 && !chars[pos - 1].is_ascii_alphanumeric() {
+            pos -= 1;
+        }
+        // Skip backward over word chars.
+        while pos > 0 && chars[pos - 1].is_ascii_alphanumeric() {
+            pos -= 1;
+        }
+        self.cursor = pos;
+    }
+
+    /// Jump the caret to the start of the next word (Ctrl+Right).
+    ///
+    /// Standard terminal word-jump: skip forward over the current word
+    /// (alphanumeric) chars, then over separator (non-alphanumeric) chars.
+    /// Stops at the end of input.
+    pub fn cursor_word_right(&mut self) {
+        let chars: Vec<char> = self.input.chars().collect();
+        let len = chars.len();
+        let mut pos = self.cursor;
+        // Skip forward over word chars.
+        while pos < len && chars[pos].is_ascii_alphanumeric() {
+            pos += 1;
+        }
+        // Skip forward over separators.
+        while pos < len && !chars[pos].is_ascii_alphanumeric() {
+            pos += 1;
+        }
+        self.cursor = pos;
+    }
+
     /// Jump the caret to the start of the input.
     pub fn cursor_home(&mut self) {
         self.cursor = 0;

--- a/src-agent/src/controller/input/chat.rs
+++ b/src-agent/src/controller/input/chat.rs
@@ -459,14 +459,23 @@ pub fn handle_chat(rest: &mut AppStateRest, key: KeyEvent) -> Action {
             Action::None
         }
         // Caret movement within the input line (mid-text editing). Left/Right
-        // step one char; Home jumps to the start. End is handled below (it also
-        // doubles as "scroll to bottom" when the input is empty).
+        // step one char; Ctrl+Left/Right jump to word boundaries; Home jumps to
+        // the start. End is handled below (it also doubles as "scroll to bottom"
+        // when the input is empty).
         KeyCode::Left => {
-            rest.cursor_left();
+            if key.modifiers.contains(KeyModifiers::CONTROL) {
+                rest.cursor_word_left();
+            } else {
+                rest.cursor_left();
+            }
             Action::None
         }
         KeyCode::Right => {
-            rest.cursor_right();
+            if key.modifiers.contains(KeyModifiers::CONTROL) {
+                rest.cursor_word_right();
+            } else {
+                rest.cursor_right();
+            }
             Action::None
         }
         KeyCode::Home => {


### PR DESCRIPTION
Add cursor_word_left and cursor_word_right methods to SessionRuntime that jump the caret to word boundaries using standard terminal behavior: skip separators (non-alphanumeric) then word chars. Wired to Ctrl+Left and Ctrl+Right in the chat key handler.

Files changed:
- src-agent/src/app/state/runtime/composer.rs: add cursor_word_left/right
- src-agent/src/app/state/input.rs: add delegation wrappers
- src-agent/src/controller/input/chat.rs: Ctrl modifier check on Left/Right