### PR TITLE
fix(stream): error on soft EOF + main-chat stall nudge

### DIFF
--- a/src-agent/src/app/runtime/actions/chat.rs
+++ b/src-agent/src/app/runtime/actions/chat.rs
@@ -196,6 +196,7 @@ pub(super) fn handle_submit(
     // A new user turn starts fresh: no carried-over tool-call rounds or
     // a half-finished approval machine.
     state.rest.fg_mut().agent_steps = 0;
+    state.rest.fg_mut().main_stall_nudges = 0;
     state.rest.fg_mut().pending_tool_calls.clear();
     state.rest.fg_mut().awaiting_approval = false;
     state.rest.fg_mut().tool_idx = 0;

--- a/src-agent/src/app/runtime/event_loop/sessions/streaming.rs
+++ b/src-agent/src/app/runtime/event_loop/sessions/streaming.rs
@@ -83,6 +83,7 @@ pub(super) fn drain_stream(
                     // half-stashed tool calls / step count / approval machine).
                     finish_stream(&mut state.rest, idx, Some(e));
                     state.rest.sessions[idx].agent_steps = 0;
+                    state.rest.sessions[idx].main_stall_nudges = 0;
                     state.rest.sessions[idx].pending_tool_calls.clear();
                     state.rest.sessions[idx].awaiting_approval = false;
                     state.rest.sessions[idx].approval_reason = None;

--- a/src-agent/src/app/runtime/mod.rs
+++ b/src-agent/src/app/runtime/mod.rs
@@ -39,6 +39,9 @@ pub(crate) mod bg_persist;
 #[cfg(feature = "gui")]
 pub mod gui;
 
+// Shared stall detector (subagent engine; main-chat nudge reuses later).
+pub(crate) use stream::is_stall;
+
 // Re-export the sync-loop <-> per-client-task bridge message so the per-client
 // connection task in `crate::ipc::conn` (outside this module tree) can name it.
 pub(crate) use event_loop::daemon::HubInbound;

--- a/src-agent/src/app/runtime/stream/mod.rs
+++ b/src-agent/src/app/runtime/stream/mod.rs
@@ -2,8 +2,11 @@
 
 mod run;
 mod spawn;
+pub(crate) mod stall;
 mod tools;
 mod turn;
+
+pub(crate) use stall::is_stall;
 
 pub(super) use run::{abort_current, start_stream_task};
 pub(crate) use tools::resume_after_subagents;

--- a/src-agent/src/app/runtime/stream/stall.rs
+++ b/src-agent/src/app/runtime/stream/stall.rs
@@ -1,0 +1,91 @@
+//! Stall detection: interstitial narration vs a finished report.
+
+/// Returns `true` when `text` looks like interstitial narration rather than a
+/// finished report — e.g. "Let me read a few more files:" — so the engine can
+/// nudge the model to keep going instead of accepting the half-thought as done.
+///
+/// Altitude-aware: a substantial or structured response (long, multi-line, or
+/// containing markdown headings/tables/lists) is NEVER a stall. Only short,
+/// bodyless lead-ins or dangling colons qualify.
+///
+/// Criteria for NOT a stall (any one is enough to return false):
+/// - trimmed length >= 300 chars
+/// - contains a newline (multi-line = has a body)
+/// - contains "##" (markdown heading)
+/// - contains "| " (table row)
+/// - contains "- " (list item)
+///
+/// A stall requires ALL of the following (after ruling out the above):
+/// - trimmed text is empty, OR
+/// - trimmed text ends with `:` (classic "Let me read…:" cliffhanger), OR
+/// - trimmed text starts with a known procrastination phrase (case-insensitive)
+pub(crate) fn is_stall(text: &str) -> bool {
+    let t = text.trim();
+    if t.is_empty() {
+        return true;
+    }
+    // Substantial -> long, multi-line, or structured (headings/tables/lists). Never a stall.
+    let substantial = t.len() >= 300
+        || t.contains('\n')
+        || t.contains("##")
+        || t.contains("| ")
+        || t.contains("- ");
+    if substantial {
+        return false;
+    }
+    // Short + bodyless: a "let me..."/"next I..." lead-in or a dangling colon.
+    let lower = t.to_lowercase();
+    let lead_in = [
+        "let me", "i'll", "i will", "let's", "now i", "next,", "next i", "first,",
+    ]
+    .iter()
+    .any(|p| lower.starts_with(p));
+    t.ends_with(':') || lead_in
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_stall;
+
+    #[test]
+    fn empty_is_stall() {
+        assert!(is_stall(""));
+        assert!(is_stall("   "));
+    }
+
+    #[test]
+    fn colon_cliffhanger_is_stall() {
+        assert!(is_stall("Let me read more:"));
+    }
+
+    #[test]
+    fn lead_in_phrase_is_stall() {
+        assert!(is_stall("I'll check"));
+    }
+
+    #[test]
+    fn substantial_multi_line_is_not_stall() {
+        assert!(!is_stall("Here is the answer.\nIt spans two lines."));
+    }
+
+    #[test]
+    fn substantial_long_is_not_stall() {
+        let long = "a".repeat(300);
+        assert!(!is_stall(&long));
+    }
+
+    #[test]
+    fn list_body_is_not_stall() {
+        assert!(!is_stall("Findings:\n- item one"));
+    }
+
+    #[test]
+    fn heading_body_is_not_stall() {
+        assert!(!is_stall("## Summary\nDone."));
+    }
+
+    #[test]
+    fn table_body_is_not_stall() {
+        assert!(!is_stall("| col | val |"));
+    }
+}

--- a/src-agent/src/app/runtime/stream/turn.rs
+++ b/src-agent/src/app/runtime/stream/turn.rs
@@ -8,6 +8,21 @@ use crate::service::openrouter::OpenRouterClient;
 
 use super::final_answer;
 
+/// Max consecutive main-chat stall nudges per user turn before accepting the
+/// no-tools answer as final (mirrors the sub-agent engine budget).
+const MAIN_STALL_NUDGE_BUDGET: u8 = 2;
+
+/// Synthetic user message injected when the model ends a no-tools round on a
+/// cliffhanger instead of calling tools or writing a complete answer.
+const MAIN_STALL_NUDGE_MSG: &str = "Continue now: call the tools you need to finish the task, \
+     then write your complete answer. Do not stop with a 'let me...' line.";
+
+/// Whether the main chat should auto-continue after a no-tools stall.
+/// Pure helper so the budget gate is unit-testable without driving a full turn.
+fn should_stall_nudge(content: &str, nudges: u8) -> bool {
+    nudges < MAIN_STALL_NUDGE_BUDGET && super::is_stall(content)
+}
+
 /// Post koma's friendly "this model can't read images" notice into the chat
 /// (assistant message + msglog + save). Shared by the submit-time capability
 /// guard and the stream-error interception so the wording lives in one place.
@@ -290,7 +305,12 @@ pub(crate) fn advance_turn(
     // 2. Commit the assistant message (and log + count it). The assistant text
     //    may be empty on a tool-call turn — we still record the row so usage
     //    accounting stays correct across rounds.
+    //
+    // `answer_content` holds the cleaned no-tools final-answer text (same string
+    // committed to history) so the stall-nudge gate below judges the deliverable
+    // content, not raw stream markup. Empty when tools were requested.
     let mut save_err = None;
+    let mut answer_content = String::new();
     {
         // Bind session `sess_idx`'s runtime directly (not via `fg_mut()`, a
         // `&mut self` method that would lock all of `rest`) so the per-session
@@ -325,6 +345,7 @@ pub(crate) fn advance_turn(
             } else {
                 let (content, msg_reasoning, promoted) =
                     final_answer(buf.clone().unwrap_or_default(), reasoning);
+                answer_content = content.clone();
                 if !content.is_empty() {
                     let _ = crate::model::msglog::append(
                         &sess.path,
@@ -334,7 +355,7 @@ pub(crate) fn advance_turn(
                         usage,
                     );
                     sess.conversation
-                        .push_assistant(content.clone(), msg_reasoning, promoted);
+                        .push_assistant(content, msg_reasoning, promoted);
                     if let Err(e) = sess.save() {
                         save_err = Some(e.to_string());
                     }
@@ -391,11 +412,59 @@ pub(crate) fn advance_turn(
         }
     }
 
-    // 3. No tool calls → the model produced its final answer; the turn is done.
+    // 3. No tool calls → either a genuine final answer, or a stall cliffhanger
+    //    that we auto-nudge (budget 2) so the model keeps going instead of
+    //    ending the turn on "Let me read…".
     if pending.is_empty() {
+        let nudges = state.rest.sessions[sess_idx].main_stall_nudges;
+        if should_stall_nudge(&answer_content, nudges) {
+            // Keep the turn alive: waiting stays true, agent_steps untouched,
+            // queued steers stay parked until a real end-of-turn.
+            state.rest.sessions[sess_idx].main_stall_nudges = nudges.saturating_add(1);
+            if let Some(sess) = state.rest.sessions[sess_idx].session.as_mut() {
+                let _ = crate::model::msglog::append(
+                    &sess.path,
+                    Role::User,
+                    MAIN_STALL_NUDGE_MSG,
+                    None,
+                    None,
+                );
+                sess.conversation
+                    .push_user(MAIN_STALL_NUDGE_MSG.to_string());
+                if let Err(e) = sess.save() {
+                    save_err = Some(e.to_string());
+                }
+            }
+            if let Some(e) = save_err {
+                state.rest.sessions[sess_idx].set_toast(e);
+            }
+            if client.is_some() && state.rest.sessions[sess_idx].session.is_some() {
+                let history = state.rest.sessions[sess_idx]
+                    .session
+                    .as_ref()
+                    .map(|s| s.conversation.history())
+                    .unwrap_or_default();
+                state.rest.sessions[sess_idx].begin_stream();
+                state.rest.sessions[sess_idx].waiting = true;
+                state.rest.sessions[sess_idx].pending_tool_calls.clear();
+                state.rest.sessions[sess_idx].status = "thinking".into();
+                super::run::start_stream_task(history, state, sess_idx, client, handle);
+            } else {
+                // No client/session to continue with — fall through to end-turn
+                // so we don't leave waiting stuck true forever.
+                state.rest.sessions[sess_idx].waiting = false;
+                state.rest.sessions[sess_idx].current_task = None;
+                state.rest.sessions[sess_idx].agent_steps = 0;
+                state.rest.sessions[sess_idx].main_stall_nudges = 0;
+                state.rest.sessions[sess_idx].status = "ready".into();
+            }
+            return;
+        }
+
         state.rest.sessions[sess_idx].waiting = false;
         state.rest.sessions[sess_idx].current_task = None;
         state.rest.sessions[sess_idx].agent_steps = 0;
+        state.rest.sessions[sess_idx].main_stall_nudges = 0;
         // Status + toast are per-session (C6); this runs per-session unbracketed, so
         // write them on `sessions[sess_idx]` — the projection shows them only to the
         // client(s) viewing this session.
@@ -491,4 +560,25 @@ pub(crate) fn advance_turn(
     state.rest.sessions[sess_idx].tool_idx = 0;
     state.rest.sessions[sess_idx].tool_results.clear();
     super::tools::process_tools(state, sess_idx, client, handle);
+}
+
+#[cfg(test)]
+mod stall_nudge_tests {
+    use super::should_stall_nudge;
+
+    #[test]
+    fn stall_under_budget_nudges() {
+        assert!(should_stall_nudge("Let me read more:", 0));
+        assert!(should_stall_nudge("Let me read more:", 1));
+    }
+
+    #[test]
+    fn stall_at_budget_stops() {
+        assert!(!should_stall_nudge("Let me read more:", 2));
+    }
+
+    #[test]
+    fn complete_answer_does_not_nudge() {
+        assert!(!should_stall_nudge("Here is the answer.\nDone.", 0));
+    }
 }

--- a/src-agent/src/app/state/runtime/mod.rs
+++ b/src-agent/src/app/state/runtime/mod.rs
@@ -204,6 +204,10 @@ pub struct SessionRuntime {
     /// new user turn starts / the turn ends; bounded so a runaway model can't
     /// loop forever.
     pub agent_steps: usize,
+    /// Consecutive main-chat stall nudges in the current turn (budget 2). Bumped
+    /// when the model returns no tools but text looks like a cliffhanger
+    /// ("Let me…"); reset on real end-of-turn, user submit, or stream error.
+    pub main_stall_nudges: u8,
     // --- tool-approval state machine (within a single agentic turn) ---
     /// Index of the next call in `pending_tool_calls` to process this round.
     pub tool_idx: usize,
@@ -630,6 +634,7 @@ impl SessionRuntime {
             tokens_cached: 0,
             pending_tool_calls: Vec::new(),
             agent_steps: 0,
+            main_stall_nudges: 0,
             tool_idx: 0,
             tool_results: Vec::new(),
             awaiting_approval: false,

--- a/src-agent/src/app/subagent/engine.rs
+++ b/src-agent/src/app/subagent/engine.rs
@@ -58,49 +58,6 @@ fn tool_is_risky(name: &str) -> bool {
     crate::tool::tool_is_risky(name)
 }
 
-/// Returns `true` when `text` looks like interstitial narration rather than a
-/// finished report — e.g. "Let me read a few more files:" — so the engine can
-/// nudge the model to keep going instead of accepting the half-thought as done.
-///
-/// Altitude-aware: a substantial or structured response (long, multi-line, or
-/// containing markdown headings/tables/lists) is NEVER a stall. Only short,
-/// bodyless lead-ins or dangling colons qualify.
-///
-/// Criteria for NOT a stall (any one is enough to return false):
-/// - trimmed length >= 300 chars
-/// - contains a newline (multi-line = has a body)
-/// - contains "##" (markdown heading)
-/// - contains "| " (table row)
-/// - contains "- " (list item)
-///
-/// A stall requires ALL of the following (after ruling out the above):
-/// - trimmed text is empty, OR
-/// - trimmed text ends with `:` (classic "Let me read…:" cliffhanger), OR
-/// - trimmed text starts with a known procrastination phrase (case-insensitive)
-fn is_stall(text: &str) -> bool {
-    let t = text.trim();
-    if t.is_empty() {
-        return true;
-    }
-    // Substantial -> long, multi-line, or structured (headings/tables/lists). Never a stall.
-    let substantial = t.len() >= 300
-        || t.contains('\n')
-        || t.contains("##")
-        || t.contains("| ")
-        || t.contains("- ");
-    if substantial {
-        return false;
-    }
-    // Short + bodyless: a "let me..."/"next I..." lead-in or a dangling colon.
-    let lower = t.to_lowercase();
-    let lead_in = [
-        "let me", "i'll", "i will", "let's", "now i", "next,", "next i", "first,",
-    ]
-    .iter()
-    .any(|p| lower.starts_with(p));
-    t.ends_with(':') || lead_in
-}
-
 /// One drained stream result: the assistant text, any requested tool calls,
 /// a fatal error if the stream failed, and the optional usage tuple from the
 /// final `StreamEvent::Usage` chunk (prompt_tokens, completion_tokens,
@@ -391,7 +348,7 @@ pub async fn run_agent_loop(
             //    instead of accepting the half-thought as a report. The gate runs
             //    on the cleaned report; commit the RAW text into history so the
             //    transcript still shows what the model literally said.
-            if nudges < 2 && is_stall(&report) {
+            if nudges < 2 && crate::app::runtime::is_stall(&report) {
                 convo.push_assistant(assistant_text, reasoning.clone(), false);
                 convo.push_user(
                     "Continue now: call the tools you need to finish the task, \

--- a/src-agent/src/service/openrouter/anthropic/stream.rs
+++ b/src-agent/src/service/openrouter/anthropic/stream.rs
@@ -233,6 +233,9 @@ impl OpenRouterClient {
         let mut prompt_tokens: u64 = 0;
         let mut cached_tokens: u64 = 0;
         let mut completion_tokens: u64 = 0;
+        // Protocol terminal success marker (`message_stop`). Soft EOF without
+        // this is incomplete; tracked for a later leaf — emission still Done.
+        let mut saw_terminal = false;
         while let Some(chunk) = stream.next().await {
             let bytes = match chunk {
                 Ok(b) => b,
@@ -355,6 +358,7 @@ impl OpenRouterClient {
                         }
                     }
                     AnthropicEvent::MessageStop => {
+                        saw_terminal = true;
                         // Terminal emission order: Usage, then the replay
                         // ReasoningDetails, then any ToolCalls, then Done (ToolCalls
                         // must land just before Done, MATCHING codex).
@@ -377,6 +381,10 @@ impl OpenRouterClient {
                             sanitize_tool_acc(&mut tools);
                             emit(&tx, StreamEvent::ToolCalls(tools));
                         }
+                        // Terminal marker seen; keep emission Done (next leaf may branch).
+                        debug_assert!(!super::super::stream::stream_ended_incompletely(
+                            saw_terminal
+                        ));
                         emit(&tx, StreamEvent::Done);
                         return Ok(());
                     }
@@ -401,8 +409,9 @@ impl OpenRouterClient {
             }
         }
         // Stream ended without an explicit `message_stop` (mirrors the codex EOF
-        // path): flush any accumulated thinking + tool calls, then Done. No Usage
-        // here — a clean run always delivers it at message_stop above.
+        // path): flush thinking, then tools+Done if tools assembled (lenient),
+        // else Error on incomplete soft EOF. No Usage here — a clean run always
+        // delivers it at message_stop above.
         let details = finalize_thinking(&thinking_blocks);
         if !details.is_empty() {
             emit(&tx, StreamEvent::ReasoningDetails(details));
@@ -410,9 +419,21 @@ impl OpenRouterClient {
         let mut tools = finalize_tools(&tool_blocks);
         if !tools.is_empty() {
             sanitize_tool_acc(&mut tools);
-            emit(&tx, StreamEvent::ToolCalls(tools));
         }
-        emit(&tx, StreamEvent::Done);
+        let has_tools = !tools.is_empty();
+        if super::super::stream::soft_eof_is_complete(saw_terminal, has_tools) {
+            if has_tools {
+                emit(&tx, StreamEvent::ToolCalls(tools));
+            }
+            emit(&tx, StreamEvent::Done);
+        } else {
+            emit(
+                &tx,
+                StreamEvent::Error(
+                    "stream ended incompletely (connection closed before terminal marker)".into(),
+                ),
+            );
+        }
         Ok(())
     }
 }

--- a/src-agent/src/service/openrouter/codex/stream.rs
+++ b/src-agent/src/service/openrouter/codex/stream.rs
@@ -165,6 +165,9 @@ impl OpenRouterClient {
         // Function calls arrive COMPLETE on their `output_item.done` event, so no
         // index-merge is needed — each is pushed whole.
         let mut tool_acc: Vec<ToolCall> = Vec::new();
+        // Protocol terminal success marker (`response.completed`). Soft EOF
+        // without this is incomplete; tracked for a later leaf — emission still Done.
+        let mut saw_terminal = false;
         while let Some(chunk) = stream.next().await {
             let bytes = match chunk {
                 Ok(b) => b,
@@ -254,6 +257,7 @@ impl OpenRouterClient {
                         OutputItem::Reasoning { .. } | OutputItem::Other => {}
                     },
                     ResponsesEvent::Completed { response } => {
+                        saw_terminal = true;
                         let (prompt_tokens, completion_tokens, cached_tokens) = response
                             .usage
                             .map(|u| {
@@ -276,6 +280,10 @@ impl OpenRouterClient {
                             sanitize_tool_acc(&mut tool_acc);
                             emit(&tx, StreamEvent::ToolCalls(tool_acc.clone()));
                         }
+                        // Terminal marker seen; keep emission Done (next leaf may branch).
+                        debug_assert!(!super::super::stream::stream_ended_incompletely(
+                            saw_terminal
+                        ));
                         emit(&tx, StreamEvent::Done);
                         return Ok(());
                     }
@@ -308,12 +316,25 @@ impl OpenRouterClient {
             }
         }
         // Stream ended without an explicit `response.completed` (mirrors the
-        // chat-completions EOF path): flush any accumulated tool calls, then Done.
+        // chat-completions EOF path): tools+Done if tools assembled (lenient),
+        // else Error on incomplete soft EOF.
         if !tool_acc.is_empty() {
             sanitize_tool_acc(&mut tool_acc);
-            emit(&tx, StreamEvent::ToolCalls(tool_acc.clone()));
         }
-        emit(&tx, StreamEvent::Done);
+        let has_tools = !tool_acc.is_empty();
+        if super::super::stream::soft_eof_is_complete(saw_terminal, has_tools) {
+            if has_tools {
+                emit(&tx, StreamEvent::ToolCalls(tool_acc.clone()));
+            }
+            emit(&tx, StreamEvent::Done);
+        } else {
+            emit(
+                &tx,
+                StreamEvent::Error(
+                    "stream ended incompletely (connection closed before terminal marker)".into(),
+                ),
+            );
+        }
         Ok(())
     }
 }

--- a/src-agent/src/service/openrouter/commandcode/stream.rs
+++ b/src-agent/src/service/openrouter/commandcode/stream.rs
@@ -147,6 +147,9 @@ impl OpenRouterClient {
         let mut stream = resp.bytes_stream();
         let mut buf: Vec<u8> = Vec::new();
         let mut tool_acc: Vec<ToolCall> = Vec::new();
+        // Protocol terminal success marker (`finish`). Soft EOF without this is
+        // incomplete; tracked for a later leaf — emission still Done.
+        // (Reuses the existing `finished` name as `saw_terminal`.)
         let mut finished = false;
 
         while let Some(chunk) = stream.next().await {
@@ -216,7 +219,7 @@ impl OpenRouterClient {
                                 },
                             );
                         }
-                        finished = true;
+                        finished = true; // saw_terminal
                     }
                     CcEvent::Error { error } => {
                         let msg = error
@@ -236,12 +239,26 @@ impl OpenRouterClient {
                 break;
             }
         }
-        // Finalize: emit accumulated tool calls, then Done.
+        // Finalize: tools+Done when we saw `finish` or assembled tool calls
+        // (lenient for providers that omit the terminal marker after tools).
+        // Incomplete soft EOF (no finish, no tools) emits Error, not Done.
         if !tool_acc.is_empty() {
             sanitize_tool_acc(&mut tool_acc);
-            emit(&tx, StreamEvent::ToolCalls(tool_acc));
         }
-        emit(&tx, StreamEvent::Done);
+        let has_tools = !tool_acc.is_empty();
+        if super::super::stream::soft_eof_is_complete(finished, has_tools) {
+            if has_tools {
+                emit(&tx, StreamEvent::ToolCalls(tool_acc));
+            }
+            emit(&tx, StreamEvent::Done);
+        } else {
+            emit(
+                &tx,
+                StreamEvent::Error(
+                    "stream ended incompletely (connection closed before terminal marker)".into(),
+                ),
+            );
+        }
         Ok(())
     }
 }

--- a/src-agent/src/service/openrouter/stream.rs
+++ b/src-agent/src/service/openrouter/stream.rs
@@ -367,6 +367,9 @@ impl OpenRouterClient {
         // it to `"tool_calls"` on the frame that closes a tool-calling turn; we
         // record it so finalisation can confirm the model wants tools run.
         let mut finished_tool_calls = false;
+        // Protocol terminal success marker (`data: [DONE]`). Soft EOF without
+        // this is incomplete unless tool calls were assembled.
+        let mut saw_terminal = false;
         while let Some(chunk) = stream.next().await {
             let bytes = match chunk {
                 Ok(b) => b,
@@ -398,6 +401,7 @@ impl OpenRouterClient {
                     None => continue, // comments/keepalive
                 };
                 if data == "[DONE]" {
+                    saw_terminal = true;
                     // Flush any buffered think-tag tail (e.g. reasoning text
                     // held back waiting for a partial closer, or a partial
                     // opener that never completed).
@@ -426,6 +430,8 @@ impl OpenRouterClient {
                         sanitize_tool_acc(&mut tool_acc);
                         emit(&tx, StreamEvent::ToolCalls(tool_acc.clone()));
                     }
+                    // Terminal marker seen; keep emission Done (next leaf may branch).
+                    debug_assert!(!stream_ended_incompletely(saw_terminal));
                     emit(&tx, StreamEvent::Done);
                     return Ok(());
                 }
@@ -508,7 +514,8 @@ impl OpenRouterClient {
             }
         }
         // Stream ended without an explicit [DONE]: flush the think-tag buffer
-        // first (same as the [DONE] path), then tool calls, then Done.
+        // first (same as the [DONE] path), then either tools+Done (lenient when
+        // the provider omitted [DONE] but delivered tool calls) or Error.
         for e in think.finish() {
             match e {
                 ThinkEmit::Content(s) if !s.is_empty() => {
@@ -524,9 +531,65 @@ impl OpenRouterClient {
         // never sends [DONE] is also covered.
         if !tool_acc.is_empty() || finished_tool_calls {
             sanitize_tool_acc(&mut tool_acc);
-            emit(&tx, StreamEvent::ToolCalls(tool_acc.clone()));
         }
-        emit(&tx, StreamEvent::Done);
+        let has_tools = !tool_acc.is_empty() || finished_tool_calls;
+        if soft_eof_is_complete(saw_terminal, has_tools) {
+            if has_tools {
+                emit(&tx, StreamEvent::ToolCalls(tool_acc.clone()));
+            }
+            emit(&tx, StreamEvent::Done);
+        } else {
+            emit(
+                &tx,
+                StreamEvent::Error(
+                    "stream ended incompletely (connection closed before terminal marker)".into(),
+                ),
+            );
+        }
         Ok(())
+    }
+}
+
+/// Whether a stream soft-EOF lacked its protocol terminal success marker.
+///
+/// Each transport sets `saw_terminal` when it processes its clean close signal:
+/// chat-completions `[DONE]`, Codex `response.completed`, Anthropic
+/// `message_stop`, Command Code `finish`. Soft EOF with `!saw_terminal` is an
+/// incomplete end unless tool calls were assembled (lenient for providers that
+/// omit the terminal marker after a tool-calling turn).
+pub(in crate::service::openrouter) fn stream_ended_incompletely(saw_terminal: bool) -> bool {
+    !saw_terminal
+}
+
+/// Whether soft-EOF finalization should emit tools+Done rather than Error.
+///
+/// Complete when the transport saw its terminal success marker, or when tool
+/// calls were assembled (providers sometimes drop `[DONE]`/`message_stop`/
+/// `response.completed`/`finish` after a tool turn). Text-only soft EOF without
+/// a terminal marker is incomplete.
+pub(in crate::service::openrouter) fn soft_eof_is_complete(
+    saw_terminal: bool,
+    has_tools: bool,
+) -> bool {
+    saw_terminal || has_tools
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::{soft_eof_is_complete, stream_ended_incompletely};
+
+    #[test]
+    fn stream_ended_incompletely_tracks_terminal_marker() {
+        assert!(stream_ended_incompletely(false));
+        assert!(!stream_ended_incompletely(true));
+    }
+
+    #[test]
+    fn soft_eof_is_complete_terminal_or_tools() {
+        assert!(soft_eof_is_complete(true, false));
+        assert!(soft_eof_is_complete(true, true));
+        assert!(soft_eof_is_complete(false, true));
+        assert!(!soft_eof_is_complete(false, false));
     }
 }


### PR DESCRIPTION
Soft body end without a protocol terminal marker no longer emits success Done (unless tools were assembled); all four stream drivers surface an incomplete-stream error instead of silent ready.

Main chat now mirrors subagent stall recovery: cliffhanger no-tool replies get up to two Continue-now nudges before ending the turn. is_stall is shared under runtime/stream/stall.rs.