### PR TITLE
feat: customizable subagent turn limit (default 500)

### DIFF
--- a/src-agent/src/app/mode/settings/field_types.rs
+++ b/src-agent/src/app/mode/settings/field_types.rs
@@ -31,6 +31,8 @@ pub enum SettingField {
     InternetMode,
     /// Toggle: mouse-capture mode — `auto` (touch detection) / `on` / `off`.
     MouseCapture,
+    /// Numeric: max agentic turns per sub-agent (when agent def has no `steps`).
+    SubagentMaxTurns,
 }
 
 impl SettingField {
@@ -52,6 +54,7 @@ impl SettingField {
             SettingField::CodingAutosave => "Coding autosave",
             SettingField::InternetMode => "Internet mode",
             SettingField::MouseCapture => "Mouse capture",
+            SettingField::SubagentMaxTurns => "Max turns",
         }
     }
 }
@@ -69,4 +72,5 @@ pub const GENERAL_FIELDS: &[SettingField] = &[
     SettingField::CodingAutosave,
     SettingField::InternetMode,
     SettingField::MouseCapture,
+    SettingField::SubagentMaxTurns,
 ];

--- a/src-agent/src/app/mode/settings/state/mod.rs
+++ b/src-agent/src/app/mode/settings/state/mod.rs
@@ -86,6 +86,8 @@ pub struct SettingsState {
     pub internet_mode: InternetMode,
     /// Draft: mouse-capture mode toggle.
     pub mouse_capture: MouseCapture,
+    /// Draft: max agentic turns per sub-agent (numeric, string for editing).
+    pub subagent_max_turns: String,
     /// The session's effective working directory, captured at construction. Used
     /// as the base for resolving workspace-relative paths in the FS picker.
     pub cwd: PathBuf,
@@ -264,6 +266,7 @@ impl SettingsState {
             coding_autosave: session.settings.coding_autosave,
             internet_mode: session.settings.internet_mode,
             mouse_capture: session.settings.mouse_capture,
+            subagent_max_turns: session.settings.subagent_max_turns.to_string(),
             cwd: effective_cwd,
             list_editing: false,
             list_sel: 0,
@@ -344,6 +347,9 @@ impl SettingsState {
                 self.list_editing = true;
                 self.list_sel = 0;
             }
+            SettingField::SubagentMaxTurns => {
+                self.editing = true;
+            }
             _ => {
                 self.editing = true;
             }
@@ -351,8 +357,12 @@ impl SettingsState {
     }
 
     /// Append `c` to the draft of the current text field.
+    /// For numeric fields, only digits are accepted.
     pub fn push_char(&mut self, c: char) {
         let f = self.current_field();
+        if f == SettingField::SubagentMaxTurns && !c.is_ascii_digit() {
+            return;
+        }
         if let Some(s) = self.text_draft_mut(f) {
             s.push(c);
         }

--- a/src-agent/src/app/mode/settings/state/path_ops.rs
+++ b/src-agent/src/app/mode/settings/state/path_ops.rs
@@ -15,6 +15,7 @@ impl SettingsState {
             SettingField::ApiKey => Some(&mut self.api_key),
             SettingField::Provider => Some(&mut self.provider),
             SettingField::Name => Some(&mut self.name),
+            SettingField::SubagentMaxTurns => Some(&mut self.subagent_max_turns),
             SettingField::Workdir
             | SettingField::AllowedFolders
             | SettingField::Accent

--- a/src-agent/src/app/runtime/actions/settings.rs
+++ b/src-agent/src/app/runtime/actions/settings.rs
@@ -35,6 +35,7 @@ pub(super) fn handle_save_settings(state: &mut AppState) -> Result<()> {
             s.coding_autosave,
             s.internet_mode,
             s.mouse_capture,
+            s.subagent_max_turns.clone(),
             s.providers.clone(),
             s.oauth_drafts.clone(),
             s.models.clone(),
@@ -59,6 +60,7 @@ pub(super) fn handle_save_settings(state: &mut AppState) -> Result<()> {
         coding_autosave,
         internet_mode,
         mouse_capture,
+        subagent_max_turns,
         provider_drafts,
         oauth_drafts,
         model_drafts,
@@ -327,6 +329,10 @@ pub(super) fn handle_save_settings(state: &mut AppState) -> Result<()> {
             // Mouse-capture toggle: apply immediately so touch/desktop
             // mode switches live. No client rebuild needed.
             sess.settings.mouse_capture = mouse_capture;
+            // Subagent max turns: parse as u32, clamp ≥ 1, default to 500 on
+            // empty/invalid input so the user can never disable the safety cap.
+            let parsed_turns: u32 = subagent_max_turns.parse().unwrap_or(0);
+            sess.settings.subagent_max_turns = parsed_turns.max(1);
             // But DO refresh the system-prompt roster so any mode-gated agents
             // stay in sync on a mid-session mode change (rebuild reads in-memory
             // settings; nothing else here rebuilds).

--- a/src-agent/src/app/runtime/client/host.rs
+++ b/src-agent/src/app/runtime/client/host.rs
@@ -683,6 +683,7 @@ fn host_swapper<P: Fn(String) + Clone + Send + 'static>(
                     d.internet_mode.as_str().to_string(),
                     cfg.palette,
                     String::new(),
+                    d.subagent_max_turns,
                 );
             }
             // GUI /agents dashboard opened while detached (StartScreen / swapper): there is

--- a/src-agent/src/app/runtime/client/push_intercept.rs
+++ b/src-agent/src/app/runtime/client/push_intercept.rs
@@ -84,6 +84,7 @@ pub(super) fn repush_before_fold(frame: &crate::ipc::proto::DaemonFrame, push: &
         internet_mode,
         palette,
         effort,
+        subagent_max_turns,
     } = &frame.event
     {
         let env = PushEnvelope::SettingsValues {
@@ -96,6 +97,7 @@ pub(super) fn repush_before_fold(frame: &crate::ipc::proto::DaemonFrame, push: &
             internet_mode: internet_mode.clone(),
             palette: palette.clone(),
             effort: effort.clone(),
+            subagent_max_turns: *subagent_max_turns,
         };
         if let Ok(json) = serde_json::to_string(&env) {
             push(json);

--- a/src-agent/src/app/runtime/client/push_proto.rs
+++ b/src-agent/src/app/runtime/client/push_proto.rs
@@ -402,6 +402,8 @@ pub(super) enum PushEnvelope {
         /// The foreground session's stored `/effort` value (`""` = model
         /// default), for the composer's effort-picker trigger-pill label.
         effort: String,
+        /// Max agentic turns per sub-agent (user-editable, ≥ 1).
+        subagent_max_turns: u32,
     },
     /// One-shot reply to a `GetAgents` (and the re-push after a `SetAgent` / `DeleteAgent`):
     /// the merged sub-agent registry + model / provider catalogue for the GUI /agents
@@ -854,6 +856,7 @@ pub(super) fn push_settings_values(
     internet_mode: String,
     palette: String,
     effort: String,
+    subagent_max_turns: u32,
 ) {
     super::render::emit(
         push,
@@ -867,6 +870,7 @@ pub(super) fn push_settings_values(
             internet_mode,
             palette,
             effort,
+            subagent_max_turns,
         },
     );
 }

--- a/src-agent/src/app/runtime/client_shadow/settings.rs
+++ b/src-agent/src/app/runtime/client_shadow/settings.rs
@@ -46,6 +46,7 @@ pub(crate) fn shadow_settings(s: SettingsSnapshot) -> SettingsState {
         coding_autosave: s.coding_autosave,
         internet_mode: shadow_internet_mode(&s.internet_mode),
         mouse_capture: shadow_mouse_capture(&s.mouse_capture),
+        subagent_max_turns: s.subagent_max_turns.to_string(),
         cwd: std::path::PathBuf::from(s.cwd),
         list_editing: s.list_editing,
         list_sel: s.list_sel,

--- a/src-agent/src/app/runtime/event_loop/daemon/hub/requests.rs
+++ b/src-agent/src/app/runtime/event_loop/daemon/hub/requests.rs
@@ -491,6 +491,7 @@ impl DaemonHub {
                 coding_autosave,
                 internet_mode,
                 workdir,
+                subagent_max_turns,
             } => {
                 self.set_session_prefs(
                     idx,
@@ -501,6 +502,7 @@ impl DaemonHub {
                     coding_autosave,
                     internet_mode,
                     workdir,
+                    subagent_max_turns,
                 );
             }
 
@@ -768,6 +770,7 @@ impl DaemonHub {
             internet_mode: s.internet_mode.as_str().to_string(),
             palette: state.rest.config.palette.clone(),
             effort: s.effort.clone(),
+            subagent_max_turns: s.subagent_max_turns,
         };
         self.send_to(idx, event);
     }

--- a/src-agent/src/app/runtime/event_loop/daemon/hub/requests_config.rs
+++ b/src-agent/src/app/runtime/event_loop/daemon/hub/requests_config.rs
@@ -335,6 +335,7 @@ impl DaemonHub {
         coding_autosave: Option<bool>,
         internet_mode: Option<String>,
         workdir: Option<Vec<String>>,
+        subagent_max_turns: Option<u32>,
     ) {
         use crate::model::settings::InternetMode;
         // Capture the old internet mode BEFORE the set, for the shared change-gated
@@ -393,6 +394,9 @@ impl DaemonHub {
             }
             if let Some(v) = workdir_vec {
                 sess.settings.workdir = v;
+            }
+            if let Some(v) = subagent_max_turns {
+                sess.settings.subagent_max_turns = v.max(1);
             }
             // Refresh the mode-gated system-prompt roster, then persist — mirrors
             // handle_save_settings (:198 rebuild + :216 save). A save error just

--- a/src-agent/src/app/runtime/gui/dispatch.rs
+++ b/src-agent/src/app/runtime/gui/dispatch.rs
@@ -554,6 +554,7 @@ pub(super) fn handle_gui_req(req: GuiReq, ctx: &GuiReqCtx) {
             coding_autosave,
             internet_mode,
             workdir,
+            subagent_max_turns,
         } => {
             if let Ok(g) = ctx.req.lock() {
                 if let Some(tx) = g.as_ref() {
@@ -564,6 +565,7 @@ pub(super) fn handle_gui_req(req: GuiReq, ctx: &GuiReqCtx) {
                         coding_autosave,
                         internet_mode,
                         workdir,
+                        subagent_max_turns,
                     });
                 }
             }

--- a/src-agent/src/app/runtime/gui/proto.rs
+++ b/src-agent/src/app/runtime/gui/proto.rs
@@ -637,6 +637,8 @@ pub(super) enum GuiReq {
         internet_mode: Option<String>,
         #[serde(default)]
         workdir: Option<Vec<String>>,
+        #[serde(default, rename = "subagentMaxTurns")]
+        subagent_max_turns: Option<u32>,
     },
 
     // ─── GUI composer EFFORT picker (TUI `/effort` parity) ───────────────────────

--- a/src-agent/src/app/subagent/spawn.rs
+++ b/src-agent/src/app/subagent/spawn.rs
@@ -165,8 +165,12 @@ pub fn spawn_subagent(
         task,
     );
     // None = unbounded (natural termination when model returns no tool calls).
-    // Some(n) = explicit per-agent cap from the agent-def `steps` field.
-    let max_steps: Option<usize> = agent.steps.map(|s| s as usize);
+    // Some(n) = per-agent cap from agent-def `steps`, falling back to the
+    // session-level `subagent_max_turns` (default 500).
+    let max_steps: Option<usize> = agent
+        .steps
+        .map(|s| s as usize)
+        .or(Some(settings.subagent_max_turns.max(1) as usize));
 
     // Owned clones moved into the task so it borrows nothing from the caller.
     let client_arc = Arc::clone(client);

--- a/src-agent/src/ipc/proto/mod.rs
+++ b/src-agent/src/ipc/proto/mod.rs
@@ -390,6 +390,7 @@ pub enum ClientRequest {
         coding_autosave: Option<bool>,
         internet_mode: Option<String>,
         workdir: Option<Vec<String>>,
+        subagent_max_turns: Option<u32>,
     },
 
     /// GUI composer EFFORT picker opened: derive the `/effort` menu for the
@@ -701,6 +702,8 @@ pub enum DaemonEvent {
         /// default), for the GUI composer's effort-picker label. Mirrors the
         /// TUI's `sess.settings.effort` field verbatim.
         effort: String,
+        /// Max agentic turns per sub-agent (user-editable, ≥ 1).
+        subagent_max_turns: u32,
     },
     /// One-shot reply to a [`ClientRequest::GetEffortOptions`]: the derived
     /// `/effort` menu for the foreground session's current model, from

--- a/src-agent/src/ipc/proto/snapshot/settings.rs
+++ b/src-agent/src/ipc/proto/snapshot/settings.rs
@@ -88,6 +88,14 @@ pub struct SettingsSnapshot {
     /// `#[serde(default)]` for older-client compatibility.
     #[serde(default)]
     pub menu_sel: usize,
+    /// Max agentic turns per sub-agent. `#[serde(default)]` for older-client
+    /// snapshot compatibility.
+    #[serde(default = "default_u32_500")]
+    pub subagent_max_turns: u32,
+}
+
+fn default_u32_500() -> u32 {
+    500
 }
 
 // -- mode payload projections (stage 3: secondary full-screen views) -----------

--- a/src-agent/src/ipc/snapshot/projection/modes.rs
+++ b/src-agent/src/ipc/snapshot/projection/modes.rs
@@ -262,6 +262,7 @@ pub fn settings_snapshot(st: &SettingsState) -> SettingsSnapshot {
         .to_string(),
         palette_sel: st.palette_sel,
         menu_sel: st.menu_sel,
+        subagent_max_turns: st.subagent_max_turns.parse().unwrap_or(500),
     }
 }
 

--- a/src-agent/src/model/settings.rs
+++ b/src-agent/src/model/settings.rs
@@ -335,6 +335,11 @@ pub struct Settings {
     /// (Firefox subprocess, higher token usage); `web_search` is unchanged.
     #[serde(default = "default_internet_mode")]
     pub internet_mode: InternetMode,
+    /// Maximum agentic turns (iterations) per sub-agent when the agent def
+    /// doesn't specify its own `steps` cap. User-editable (≥ 1). A value of
+    /// `0` is treated as `1` at runtime to prevent unbounded loops.
+    #[serde(default = "default_subagent_max_turns")]
+    pub subagent_max_turns: u32,
     /// Preferred search-engine URL template for browser-backed searches.
     /// Must contain `{query}` as a placeholder. The model builds a search URL
     /// from this template and passes it to `web_search_full` via `--url`.
@@ -435,6 +440,12 @@ fn default_internet_mode() -> InternetMode {
     InternetMode::Simple
 }
 
+const DEFAULT_SUBAGENT_MAX_TURNS: u32 = 500;
+
+fn default_subagent_max_turns() -> u32 {
+    DEFAULT_SUBAGENT_MAX_TURNS
+}
+
 /// Default preferred search-engine URL template.
 pub const DEFAULT_SEARCH_ENGINE: &str = "https://html.duckduckgo.com/html/?q={query}";
 
@@ -493,6 +504,7 @@ impl Default for Settings {
             coding_autosave: default_coding_autosave(),
             internet_mode: InternetMode::Simple,
             search_engine: default_search_engine(),
+            subagent_max_turns: default_subagent_max_turns(),
             session_models: Vec::new(),
             git_ssh_key: None,
             mouse_capture: MouseCapture::default(),

--- a/src-agent/src/view/settings/pages/general.rs
+++ b/src-agent/src/view/settings/pages/general.rs
@@ -140,6 +140,7 @@ pub(crate) fn draw_general(
                         }
                     }
                     SettingField::Name => st.name.as_str(),
+                    SettingField::SubagentMaxTurns => st.subagent_max_turns.as_str(),
                     _ => "",
                 };
                 let editing_here = st.editing && is_selected;

--- a/src-webgui/src/components/SettingsTab.tsx
+++ b/src-webgui/src/components/SettingsTab.tsx
@@ -421,6 +421,7 @@ function SessionSettings() {
   const [bashSaving, setBashSaving] = useState(true)
   const [codingAutosave, setCodingAutosave] = useState(false)
   const [internet, setInternet] = useState<'simple' | 'full'>('simple')
+  const [maxTurns, setMaxTurns] = useState('500')
 
   useEffect(() => {
     if (!values) return
@@ -431,6 +432,7 @@ function SessionSettings() {
     setBashSaving(values.bashSaving)
     setCodingAutosave(values.codingAutosave)
     setInternet(values.internetMode === 'full' ? 'full' : 'simple')
+    setMaxTurns(String(values.subagentMaxTurns ?? 500))
   }, [values])
 
   if (!values) {
@@ -478,6 +480,15 @@ function SessionSettings() {
   const setNet = (v: 'simple' | 'full') => {
     setInternet(v)
     req({ r: 'SetPrefs', internetMode: v })
+  }
+  // Max turns: commit on blur; clamp ≥ 1, fall back to 500 on invalid input.
+  const commitMaxTurns = () => {
+    const n = parseInt(maxTurns, 10)
+    const safe = isNaN(n) || n < 1 ? 500 : n
+    setMaxTurns(String(safe))
+    if (safe !== (values.subagentMaxTurns ?? 500)) {
+      req({ r: 'SetPrefs', subagentMaxTurns: safe })
+    }
   }
 
   return (
@@ -541,6 +552,20 @@ function SessionSettings() {
             onChange={setNet}
           />
         </div>
+      </SettingRow>
+
+      <SettingRow label="Max turns" desc="Max agentic turns per sub-agent (when agent has no step cap). Default: 500.">
+        <input
+          type="number"
+          min={1}
+          value={maxTurns}
+          onChange={(e) => setMaxTurns(e.target.value.replace(/[^0-9]/g, ''))}
+          onBlur={commitMaxTurns}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+          }}
+          className="w-24 rounded border border-koma-border bg-koma-bg px-2 py-1.5 font-mono text-[12px] text-koma-fg outline-none focus:border-koma-grip"
+        />
       </SettingRow>
     </div>
   )

--- a/src-webgui/src/koma.d.ts
+++ b/src-webgui/src/koma.d.ts
@@ -213,6 +213,7 @@ declare global {
         codingAutosave?: boolean
         internetMode?: string
         workdir?: string[]
+        subagentMaxTurns?: number
       }
     // Composer EFFORT pill opened: fetch the derived `/effort` menu (TUI
     // parity) for the foreground session's current model. Attached-only (like

--- a/src-webgui/src/store/coding.test.ts
+++ b/src-webgui/src/store/coding.test.ts
@@ -208,6 +208,7 @@ assert.equal(useKoma.getState().ui.activeTabId, 'chat')
     internetMode: 'simple',
     palette: 'dark',
     effort: '',
+    subagentMaxTurns: 500,
   })
   assert.equal(useKoma.getState().settingsValues?.codingAutosave, true)
   useKoma.getState().push({
@@ -221,6 +222,7 @@ assert.equal(useKoma.getState().ui.activeTabId, 'chat')
     internetMode: 'simple',
     palette: 'dark',
     effort: '',
+    subagentMaxTurns: 500,
   })
   assert.equal(useKoma.getState().settingsValues?.codingAutosave, false)
 }

--- a/src-webgui/src/store/importGraphScoping.test.ts
+++ b/src-webgui/src/store/importGraphScoping.test.ts
@@ -44,6 +44,7 @@ function resetStore() {
     settingsValues: {
       name: 'test', workdir: WORKDIRS, shortSend: false, slidingCache: false,
       bashSaving: false, codingAutosave: false, internetMode: 'simple', palette: 'dark', effort: '',
+      subagentMaxTurns: 500,
     },
     session: { ...s.session, id: 'test-session' },
   }))
@@ -243,7 +244,7 @@ function igPush(p: Record<string, unknown>) {
     { path: '/ws/a/a.rs', language: 'Rust', outDegree: 0, inDegree: 0, role: 'Overview' as const, depthFromFocus: null, workspaceRoot: '/ws/a' },
     { path: '/ws/b/b.py', language: 'Python', outDegree: 0, inDegree: 0, role: 'Overview' as const, depthFromFocus: null, workspaceRoot: '/ws/b' },
   ] } }))
-  useKoma.getState().push({ k: 'SettingsValues', name: 'test', workdir: ['/ws/a'], shortSend: false, slidingCache: false, bashSaving: false, codingAutosave: false, internetMode: 'simple', palette: 'dark', effort: '' })
+  useKoma.getState().push({ k: 'SettingsValues', name: 'test', workdir: ['/ws/a'], shortSend: false, slidingCache: false, bashSaving: false, codingAutosave: false, internetMode: 'simple', palette: 'dark', effort: '', subagentMaxTurns: 500 })
   const s = useKoma.getState().importGraph
   assert.deepEqual(s.filterRoots, ['/ws/a'])
   assert.deepEqual(s.filterLanguages, ['Rust'])

--- a/src-webgui/src/store/koma.ts
+++ b/src-webgui/src/store/koma.ts
@@ -107,6 +107,8 @@ export type SettingsValues = {
   // The foreground session's stored `/effort` value ("" = model default), for
   // the composer EffortPicker's trigger-pill label.
   effort: string
+  // Max agentic turns per sub-agent (≥ 1, default 500).
+  subagentMaxTurns: number
 }
 
 // The composer EffortPicker's latest GetEffortOptions reply (host
@@ -1002,6 +1004,7 @@ export type PushEnvelope =
       internetMode: string
       palette: string
       effort: string
+      subagentMaxTurns: number
     }
   // Reply to GuiReq GetEffortOptions — the composer EffortPicker's derived
   // `/effort` menu for the foreground session's current model. ALWAYS a reply
@@ -2976,6 +2979,7 @@ export const useKoma = create<KomaState>((set, get) => ({
             internetMode: env.internetMode,
             palette: env.palette,
             effort: env.effort ?? '',
+            subagentMaxTurns: env.subagentMaxTurns ?? 500,
           },
         }))
         // Prune importGraph state when the workdir list changes (same session).


### PR DESCRIPTION
Add subagent_max_turns to Settings (per-session, user-editable) with a fallback chain: agent def steps > session setting > 500 default.

TUI: new "Max turns" text-editable field in General settings page with digit-only input validation.

GUI: new "Max turns" numeric input in Settings tab with blur-to-commit validation (clamped to >= 1, fallback 500 on invalid input).

IPC: field threaded through DaemonEvent::SettingsValues, ClientRequest::SetSessionPrefs, PushEnvelope, and the GUI host intercept/projection layers.