### PR TITLE
fix(remote): GUI password prompt overlay + TUI two-pane /remote layout

### DIFF
--- a/src-agent/src/app/mode/remote.rs
+++ b/src-agent/src/app/mode/remote.rs
@@ -9,20 +9,18 @@ pub enum RemoteIntent {
 }
 
 /// Current screen within the remote workflow.
+///
+/// Mirrors the `/agents` two-pane pattern: `Browse` shows a list sidebar + detail
+/// pane; `Edit` takes over the full screen for create/edit form; `SessionHub` is
+/// an overlay session picker.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RemoteView {
-    /// Fullscreen searchable saved-host manager.
-    HostManager,
-    /// Fullscreen host picker used by remote resume/new.
-    HostPicker,
-    /// Management-only host details and diagnostics.
-    HostDetail,
-    /// Existing sessions on the prepared remote host.
+    /// Browse hosts: list sidebar + detail pane.
+    Browse,
+    /// Create or edit a host (form fields take over the full screen).
+    Edit,
+    /// Resume session picker (overlay on top of Browse).
     SessionHub,
-    /// Create a new host (form fields).
-    CreateHost,
-    /// Edit an existing host (form fields).
-    EditHost,
 }
 
 /// Which field is focused in the create/edit form.
@@ -120,8 +118,6 @@ pub struct RemoteState {
     pub query: String,
     /// Indices matching the current query.
     pub filtered: Vec<usize>,
-    /// Host ID shown in management detail.
-    pub detail_host: Option<String>,
     /// Host ID selected for preparation or session discovery.
     pub selected_host_id: Option<String>,
     /// Transient connection state (while preparing / authenticating / connecting).
@@ -134,7 +130,7 @@ pub struct RemoteState {
     pub pending_delete: Option<String>,
     /// Password input buffer (masked in rendering).
     pub password_buf: String,
-    /// Host editor state (Some when in CreateHost/EditHost sub).
+    /// Host editor state (Some when in Edit sub-mode).
     pub editor: Option<HostEditor>,
     /// Whether the editor is in text-edit mode (actively typing into a field).
     pub editing_field: bool,
@@ -160,16 +156,11 @@ impl RemoteState {
         let filtered: Vec<usize> = (0..hosts.len()).collect();
         Self {
             intent,
-            view: if intent == RemoteIntent::Manage {
-                RemoteView::HostManager
-            } else {
-                RemoteView::HostPicker
-            },
+            view: RemoteView::Browse,
             selected: 0,
             hosts,
             filtered,
             query: String::new(),
-            detail_host: None,
             selected_host_id: None,
             connection_state: None,
             sessions: Vec::new(),
@@ -234,17 +225,6 @@ impl RemoteState {
         Some(host_id)
     }
 
-    /// Open management detail for the currently selected host.
-    pub fn enter_detail(&mut self) {
-        if self.intent != RemoteIntent::Manage {
-            return;
-        }
-        if let Some(host) = self.selected_host() {
-            self.detail_host = Some(host.id.clone());
-            self.view = RemoteView::HostDetail;
-        }
-    }
-
     /// Enter the create-host form.
     pub fn enter_create(&mut self) {
         self.editor = Some(HostEditor {
@@ -258,7 +238,7 @@ impl RemoteState {
             error: None,
         });
         self.editing_field = false;
-        self.view = RemoteView::CreateHost;
+        self.view = RemoteView::Edit;
     }
 
     /// Enter the edit-host form for the currently selected host.
@@ -275,15 +255,15 @@ impl RemoteState {
                 error: None,
             });
             self.editing_field = false;
-            self.view = RemoteView::EditHost;
+            self.view = RemoteView::Edit;
         }
     }
 
-    /// Cancel editing and return to the management root.
+    /// Cancel editing and return to the browse root.
     pub fn cancel_edit(&mut self) {
         self.editor = None;
         self.editing_field = false;
-        self.view = RemoteView::HostManager;
+        self.view = RemoteView::Browse;
     }
 
     /// Validate the editor fields. Returns true if all fields are valid.
@@ -379,67 +359,49 @@ mod tests {
     }
 
     #[test]
-    fn manage_intent_starts_at_host_manager() {
+    fn manage_intent_starts_at_browse() {
         let hosts = vec![make_test_host("h1", "srv")];
         let state = RemoteState::for_intent(hosts, RemoteIntent::Manage);
         assert_eq!(state.intent, RemoteIntent::Manage);
-        assert_eq!(state.view, RemoteView::HostManager);
+        assert_eq!(state.view, RemoteView::Browse);
     }
 
     #[test]
-    fn resume_intent_starts_at_host_picker() {
+    fn resume_intent_starts_at_browse() {
         let state = RemoteState::for_intent(vec![], RemoteIntent::Resume);
         assert_eq!(state.intent, RemoteIntent::Resume);
-        assert_eq!(state.view, RemoteView::HostPicker);
+        assert_eq!(state.view, RemoteView::Browse);
     }
 
     #[test]
-    fn new_intent_starts_at_host_picker() {
+    fn new_intent_starts_at_browse() {
         let state = RemoteState::for_intent(vec![], RemoteIntent::New);
         assert_eq!(state.intent, RemoteIntent::New);
-        assert_eq!(state.view, RemoteView::HostPicker);
+        assert_eq!(state.view, RemoteView::Browse);
     }
 
     #[test]
-    fn new_alias_starts_at_host_manager() {
+    fn new_alias_starts_at_browse() {
         let state = RemoteState::new(vec![]);
         assert_eq!(state.intent, RemoteIntent::Manage);
-        assert_eq!(state.view, RemoteView::HostManager);
+        assert_eq!(state.view, RemoteView::Browse);
     }
 
     #[test]
-    fn enter_detail_only_for_manage_intent() {
-        let hosts = vec![make_test_host("h1", "srv")];
-
-        // Manage intent: enter_detail transitions to HostDetail.
-        let mut state = RemoteState::for_intent(hosts.clone(), RemoteIntent::Manage);
-        state.enter_detail();
-        assert_eq!(state.view, RemoteView::HostDetail);
-        assert_eq!(state.detail_host.as_deref(), Some("h1"));
-
-        // Resume intent: enter_detail is a no-op.
-        let mut state = RemoteState::for_intent(hosts, RemoteIntent::Resume);
-        state.enter_detail();
-        assert_eq!(state.view, RemoteView::HostPicker);
-        assert!(state.detail_host.is_none());
-    }
-
-    #[test]
-    fn enter_create_transitions_to_create_host() {
+    fn enter_create_transitions_to_edit() {
         let mut state = RemoteState::for_intent(vec![], RemoteIntent::Manage);
         state.enter_create();
-        assert_eq!(state.view, RemoteView::CreateHost);
+        assert_eq!(state.view, RemoteView::Edit);
         assert!(state.editor.is_some());
         assert!(!state.editing_field);
     }
 
     #[test]
-    fn enter_edit_transitions_to_edit_host() {
+    fn enter_edit_transitions_to_edit() {
         let hosts = vec![make_test_host("h1", "srv")];
         let mut state = RemoteState::for_intent(hosts, RemoteIntent::Manage);
-        state.enter_detail();
         state.enter_edit();
-        assert_eq!(state.view, RemoteView::EditHost);
+        assert_eq!(state.view, RemoteView::Edit);
         assert!(state.editor.is_some());
         let editor = state.editor.as_ref().unwrap();
         assert_eq!(editor.edit_id.as_deref(), Some("h1"));
@@ -447,14 +409,13 @@ mod tests {
     }
 
     #[test]
-    fn cancel_edit_returns_to_host_manager() {
+    fn cancel_edit_returns_to_browse() {
         let hosts = vec![make_test_host("h1", "srv")];
         let mut state = RemoteState::for_intent(hosts, RemoteIntent::Manage);
-        state.enter_detail();
         state.enter_edit();
-        assert_eq!(state.view, RemoteView::EditHost);
+        assert_eq!(state.view, RemoteView::Edit);
         state.cancel_edit();
-        assert_eq!(state.view, RemoteView::HostManager);
+        assert_eq!(state.view, RemoteView::Browse);
         assert!(state.editor.is_none());
     }
 

--- a/src-agent/src/app/mode/remote.rs
+++ b/src-agent/src/app/mode/remote.rs
@@ -114,9 +114,7 @@ pub struct RemoteState {
     pub hosts: Vec<crate::remote::hosts::RemoteHost>,
     /// Selected index in the host list.
     pub selected: usize,
-    /// Search/filter query.
-    pub query: String,
-    /// Indices matching the current query.
+    /// Indices matching the current query (always all indices — kept for wire compat).
     pub filtered: Vec<usize>,
     /// Host ID selected for preparation or session discovery.
     pub selected_host_id: Option<String>,
@@ -160,7 +158,6 @@ impl RemoteState {
             selected: 0,
             hosts,
             filtered,
-            query: String::new(),
             selected_host_id: None,
             connection_state: None,
             sessions: Vec::new(),
@@ -169,31 +166,6 @@ impl RemoteState {
             password_buf: String::new(),
             editor: None,
             editing_field: false,
-        }
-    }
-
-    /// Refilter the host list based on the current query.
-    pub fn refilter(&mut self) {
-        if self.query.is_empty() {
-            self.filtered = (0..self.hosts.len()).collect();
-        } else {
-            let q = self.query.to_lowercase();
-            self.filtered = self
-                .hosts
-                .iter()
-                .enumerate()
-                .filter(|(_, h)| {
-                    h.name.to_lowercase().contains(&q)
-                        || h.host.to_lowercase().contains(&q)
-                        || h.user.to_lowercase().contains(&q)
-                        || h.tags.iter().any(|t| t.to_lowercase().contains(&q))
-                })
-                .map(|(i, _)| i)
-                .collect();
-        }
-        // Clamp selection.
-        if self.selected >= self.filtered.len() {
-            self.selected = self.filtered.len().saturating_sub(1);
         }
     }
 
@@ -490,30 +462,6 @@ mod tests {
         }
         let host = state.build_host().expect("build_host should succeed");
         assert!(host.key_path.is_none());
-    }
-
-    #[test]
-    fn refilter_matches_name_host_user_tags() {
-        let hosts = vec![
-            make_test_host("h1", "prod-server"),
-            make_test_host("h2", "staging-server"),
-            make_test_host("h3", "dev"),
-        ];
-        let mut state = RemoteState::for_intent(hosts, RemoteIntent::Manage);
-        // Search by name substring.
-        state.query = "prod".into();
-        state.refilter();
-        assert_eq!(state.filtered, vec![0]);
-
-        // Search by user (all have "root").
-        state.query = "root".into();
-        state.refilter();
-        assert_eq!(state.filtered.len(), 3);
-
-        // Empty query: all match.
-        state.query.clear();
-        state.refilter();
-        assert_eq!(state.filtered.len(), 3);
     }
 
     #[test]

--- a/src-agent/src/app/runtime/actions/mod.rs
+++ b/src-agent/src/app/runtime/actions/mod.rs
@@ -521,7 +521,12 @@ pub(in crate::app::runtime) fn apply_action(
 
         Action::RemoteEditHost(id) => {
             if let crate::app::mode::Mode::Remote(ref mut remote) = state.mode_mut() {
-                remote.detail_host = Some(id);
+                // Find the host by id and set selection to it before entering edit.
+                if let Some(idx) = remote.filtered.iter().position(|&i| {
+                    remote.hosts.get(i).map_or(false, |h| h.id == id)
+                }) {
+                    remote.selected = idx;
+                }
                 remote.enter_edit();
             }
         }

--- a/src-agent/src/app/runtime/actions/mod.rs
+++ b/src-agent/src/app/runtime/actions/mod.rs
@@ -523,7 +523,7 @@ pub(in crate::app::runtime) fn apply_action(
             if let crate::app::mode::Mode::Remote(ref mut remote) = state.mode_mut() {
                 // Find the host by id and set selection to it before entering edit.
                 if let Some(idx) = remote.filtered.iter().position(|&i| {
-                    remote.hosts.get(i).map_or(false, |h| h.id == id)
+                    remote.hosts.get(i).is_some_and(|h| h.id == id)
                 }) {
                     remote.selected = idx;
                 }

--- a/src-agent/src/app/runtime/client/remote_ctl.rs
+++ b/src-agent/src/app/runtime/client/remote_ctl.rs
@@ -109,6 +109,7 @@ pub(super) struct ActiveRemote {
     pub ssh_child: tokio::process::Child,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn spawn_connect_worker(
     attempt_id: u64,
     host_id: String,

--- a/src-agent/src/app/runtime/client_shadow/modes.rs
+++ b/src-agent/src/app/runtime/client_shadow/modes.rs
@@ -776,7 +776,6 @@ pub(crate) fn shadow_remote(s: RemoteSnapshot) -> crate::app::mode::RemoteState 
             })
             .collect(),
         selected: s.selected,
-        query: s.query,
         filtered: s.filtered,
         selected_host_id: s.selected_host_id,
         connection_state,

--- a/src-agent/src/app/runtime/client_shadow/modes.rs
+++ b/src-agent/src/app/runtime/client_shadow/modes.rs
@@ -747,20 +747,13 @@ pub(crate) fn shadow_remote(s: RemoteSnapshot) -> crate::app::mode::RemoteState 
             _ => RemoteIntent::Manage,
         };
         let view = match parts.next() {
-            Some("host_picker") => RemoteView::HostPicker,
-            Some("host_detail") => RemoteView::HostDetail,
+            Some("browse") | Some("host_picker") | Some("host_manager") => RemoteView::Browse,
             Some("session_hub") => RemoteView::SessionHub,
-            Some("create_host") => RemoteView::CreateHost,
-            Some("edit_host") => RemoteView::EditHost,
+            Some("edit") | Some("create_host") | Some("edit_host") => RemoteView::Edit,
             // Legacy single-token values from old clients.
-            Some("fullscreen") | Some("host_manager") | None => {
-                if intent == RemoteIntent::Manage {
-                    RemoteView::HostManager
-                } else {
-                    RemoteView::HostPicker
-                }
-            }
-            _ => RemoteView::HostManager,
+            Some("fullscreen") | None => RemoteView::Browse,
+            // Unknown view tokens → Browse (safe fallback).
+            _ => RemoteView::Browse,
         };
         (intent, view)
     };
@@ -785,7 +778,6 @@ pub(crate) fn shadow_remote(s: RemoteSnapshot) -> crate::app::mode::RemoteState 
         selected: s.selected,
         query: s.query,
         filtered: s.filtered,
-        detail_host: s.detail_host,
         selected_host_id: s.selected_host_id,
         connection_state,
         sessions: s

--- a/src-agent/src/controller/input/remote.rs
+++ b/src-agent/src/controller/input/remote.rs
@@ -63,12 +63,6 @@ fn handle_browse(m: &mut RemoteState, key: KeyEvent) -> Action {
             }
         }
         KeyCode::Char('i') if m.intent == RemoteIntent::Manage => Action::RemoteImportSshConfig,
-        KeyCode::Char(c) => {
-            // Type to filter.
-            m.query.push(c);
-            m.refilter();
-            Action::None
-        }
         _ => Action::None,
     }
 }

--- a/src-agent/src/controller/input/remote.rs
+++ b/src-agent/src/controller/input/remote.rs
@@ -8,14 +8,14 @@ use crate::controller::input::Action;
 
 pub fn handle_remote(m: &mut RemoteState, key: KeyEvent) -> Action {
     match m.view {
-        RemoteView::HostManager | RemoteView::HostPicker => handle_host_list(m, key),
-        RemoteView::HostDetail => handle_host_detail(m, key),
+        RemoteView::Browse => handle_browse(m, key),
         RemoteView::SessionHub => handle_session_hub(m, key),
-        RemoteView::CreateHost | RemoteView::EditHost => handle_editor(m, key),
+        RemoteView::Edit => handle_editor(m, key),
     }
 }
 
-fn handle_host_list(m: &mut RemoteState, key: KeyEvent) -> Action {
+fn handle_browse(m: &mut RemoteState, key: KeyEvent) -> Action {
+    // Delete confirm modal
     if let Some(id) = m.pending_delete.clone() {
         return match key.code {
             KeyCode::Enter | KeyCode::Char('y' | 'Y') => {
@@ -41,71 +41,32 @@ fn handle_host_list(m: &mut RemoteState, key: KeyEvent) -> Action {
             Action::None
         }
         KeyCode::Enter => {
-            if m.intent == RemoteIntent::Manage {
-                m.enter_detail();
-                Action::None
-            } else if let Some(host_id) = m.select_current_host() {
+            // Connect to selected host.
+            if let Some(host_id) = m.select_current_host() {
                 Action::RemoteConnect(host_id)
             } else {
                 Action::None
             }
         }
-        KeyCode::Backspace if m.intent == RemoteIntent::Manage => {
+        KeyCode::Char('n' | 'N') if m.intent == RemoteIntent::Manage => Action::RemoteAddHost,
+        KeyCode::Char('d' | 'D') if m.intent == RemoteIntent::Manage => {
             if let Some(host) = m.selected_host() {
                 m.pending_delete = Some(host.id.clone());
             }
             Action::None
         }
-        KeyCode::Char(c) => {
-            if m.intent == RemoteIntent::Manage && is_ctrl(&key, 'a') {
-                Action::RemoteAddHost
-            } else if m.intent == RemoteIntent::Manage && c == 'i' {
-                Action::RemoteImportSshConfig
-            } else {
-                // Type to filter.
-                m.query.push(c);
-                m.refilter();
-                Action::None
-            }
-        }
-        _ => Action::None,
-    }
-}
-
-fn handle_host_detail(m: &mut RemoteState, key: KeyEvent) -> Action {
-    if let Some(id) = m.pending_delete.clone() {
-        return match key.code {
-            KeyCode::Enter | KeyCode::Char('y' | 'Y') => {
-                m.pending_delete = None;
-                Action::RemoteDeleteHost(id)
-            }
-            KeyCode::Esc | KeyCode::Char('n' | 'N') => {
-                m.pending_delete = None;
-                Action::None
-            }
-            _ => Action::None,
-        };
-    }
-
-    match key.code {
-        KeyCode::Esc => {
-            // Back to fullscreen manager.
-            m.view = RemoteView::HostManager;
-            m.detail_host = None;
-            Action::None
-        }
-        KeyCode::Char('e') | KeyCode::Char('E') => {
-            // Edit host.
+        KeyCode::Char('e' | 'E') if m.intent == RemoteIntent::Manage => {
             if let Some(host) = m.selected_host() {
                 Action::RemoteEditHost(host.id.clone())
             } else {
                 Action::None
             }
         }
-        KeyCode::Backspace => {
-            if let Some(host) = m.selected_host() {
-                m.pending_delete = Some(host.id.clone());
-            }
+        KeyCode::Char('i') if m.intent == RemoteIntent::Manage => Action::RemoteImportSshConfig,
+        KeyCode::Char(c) => {
+            // Type to filter.
+            m.query.push(c);
+            m.refilter();
             Action::None
         }
         _ => Action::None,
@@ -119,7 +80,7 @@ fn handle_session_hub(m: &mut RemoteState, key: KeyEvent) -> Action {
             m.session_selected = 0;
             m.connection_state = None;
             m.password_buf.clear();
-            m.view = RemoteView::HostPicker;
+            m.view = RemoteView::Browse;
             Action::None
         }
         KeyCode::Up | KeyCode::Char('k') => {
@@ -211,7 +172,7 @@ fn handle_editor(m: &mut RemoteState, key: KeyEvent) -> Action {
         // --- Navigation mode: moving between fields ---
         match key.code {
             KeyCode::Esc => {
-                // Go back to fullscreen.
+                // Go back to browse.
                 m.cancel_edit();
                 Action::None
             }

--- a/src-agent/src/ipc/snapshot/projection/modes.rs
+++ b/src-agent/src/ipc/snapshot/projection/modes.rs
@@ -951,7 +951,7 @@ pub fn remote_snapshot(m: &crate::app::mode::RemoteState) -> RemoteSnapshot {
             })
             .collect(),
         selected: m.selected,
-        query: m.query.clone(),
+        query: String::new(),
         filtered: m.filtered.clone(),
         detail_host: None,
         selected_host_id: m.selected_host_id.clone(),

--- a/src-agent/src/ipc/snapshot/projection/modes.rs
+++ b/src-agent/src/ipc/snapshot/projection/modes.rs
@@ -928,12 +928,9 @@ pub fn remote_snapshot(m: &crate::app::mode::RemoteState) -> RemoteSnapshot {
         RemoteIntent::New => "new",
     };
     let view_token = match m.view {
-        RemoteView::HostManager => "host_manager",
-        RemoteView::HostPicker => "host_picker",
-        RemoteView::HostDetail => "host_detail",
+        RemoteView::Browse => "browse",
         RemoteView::SessionHub => "session_hub",
-        RemoteView::CreateHost => "create_host",
-        RemoteView::EditHost => "edit_host",
+        RemoteView::Edit => "edit",
     };
 
     RemoteSnapshot {
@@ -956,7 +953,7 @@ pub fn remote_snapshot(m: &crate::app::mode::RemoteState) -> RemoteSnapshot {
         selected: m.selected,
         query: m.query.clone(),
         filtered: m.filtered.clone(),
-        detail_host: m.detail_host.clone(),
+        detail_host: None,
         selected_host_id: m.selected_host_id.clone(),
         connection_state: connection_state_str,
         stage,

--- a/src-agent/src/remote/auth.rs
+++ b/src-agent/src/remote/auth.rs
@@ -242,7 +242,7 @@ fn askpass_script_content(password: &str) -> String {
     format!(
         r#"#!/bin/sh
 case "$1" in
-  *[Pp]assword:|*[Pp]assphrase*) echo '{escaped}' ;;
+  *[Pp]assword*|*[Pp]assphrase*) printf '%s\\n' '{escaped}' ;;
   *) exit 1 ;;
 esac
 "#
@@ -259,7 +259,7 @@ mod tests {
         // Should contain the password for password prompts.
         assert!(script.contains("hunter2"));
         // Should have the case statement for validation.
-        assert!(script.contains("[Pp]assword:"));
+        assert!(script.contains("[Pp]assword*"));
         assert!(script.contains("[Pp]assphrase"));
     }
 

--- a/src-agent/src/remote/auth.rs
+++ b/src-agent/src/remote/auth.rs
@@ -308,7 +308,14 @@ mod tests {
             path = auth.askpass_path.clone().unwrap();
             assert!(path.exists());
         }
-        // After drop, the file should be deleted.
-        assert!(!path.exists());
+        // After drop, the file should be deleted. Retry briefly to handle
+        // filesystem race on slow/parallel CI runners.
+        for _ in 0..10 {
+            if !path.exists() {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(!path.exists(), "askpass file was not cleaned up after drop");
     }
 }

--- a/src-agent/src/remote/ssh.rs
+++ b/src-agent/src/remote/ssh.rs
@@ -116,6 +116,7 @@ pub(crate) fn exec_remote(
 
     cmd.arg(format!("{}@{}", target.user, target.host))
         .arg(command)
+        .stdin(Stdio::null()) // Force SSH to use SSH_ASKPASS, not terminal stdin.
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 

--- a/src-agent/src/view/remote.rs
+++ b/src-agent/src/view/remote.rs
@@ -49,6 +49,9 @@ pub fn draw(frame: &mut Frame, m: &RemoteState, palette: &Palette) {
 
 /// Two-pane browse layout: header | body (list + detail) | footer.
 fn draw_browse(frame: &mut Frame, m: &RemoteState, palette: &Palette) {
+    // Fill background so the chat underneath doesn't bleed through.
+    crate::view::clear_and_fill(frame, frame.area(), palette.bg);
+
     let outer = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -123,26 +126,9 @@ fn draw_host_list(frame: &mut Frame, m: &RemoteState, palette: &Palette, area: R
         return;
     }
 
-    // Search line at top.
-    let search_y = inner.y;
-    let search_line = Line::from(vec![
-        Span::styled(" > ", Style::default().fg(palette.accent)),
-        Span::styled(&m.query, Style::default().fg(palette.fg)),
-        Span::styled("_", Style::default().fg(palette.accent)),
-    ]);
-    frame.render_widget(
-        Paragraph::new(search_line),
-        Rect {
-            x: inner.x,
-            y: search_y,
-            width: inner.width,
-            height: 1,
-        },
-    );
-
-    // Host rows (below search).
-    let list_start_y = inner.y + 1;
-    let list_height = inner.height.saturating_sub(1);
+    // Host rows.
+    let list_start_y = inner.y;
+    let list_height = inner.height;
     for (row, &host_idx) in m
         .filtered
         .iter()
@@ -457,6 +443,9 @@ fn draw_sessions_list(frame: &mut Frame, m: &RemoteState, area: Rect, palette: &
 ///   Footer hint bar
 fn draw_editor(frame: &mut Frame, m: &RemoteState, area: Rect, palette: &Palette) {
     let Some(editor) = &m.editor else { return };
+
+    // Fill background so the chat underneath doesn't bleed through.
+    crate::view::clear_and_fill(frame, area, palette.bg);
 
     let header_area = Rect {
         x: area.x,

--- a/src-agent/src/view/remote.rs
+++ b/src-agent/src/view/remote.rs
@@ -34,8 +34,9 @@ const SIDEBAR_W: u16 = 26;
 pub fn draw(frame: &mut Frame, m: &RemoteState, palette: &Palette) {
     match m.view {
         RemoteView::Edit => {
-            if m.editor.is_some() {
-                draw_editor(frame, m, frame.area(), palette);
+            crate::view::clear_and_fill(frame, frame.area(), palette.bg);
+            if let Some(editor) = &m.editor {
+                draw_editor_inner(frame, editor, m.editing_field, frame.area(), palette);
             }
         }
         RemoteView::SessionHub => {
@@ -139,41 +140,43 @@ fn draw_host_list(frame: &mut Frame, m: &RemoteState, palette: &Palette, area: R
         let is_selected = row == m.selected;
 
         let dot = if host.last_connected.is_some() {
-            "●"
+            Span::styled("●", Style::default().fg(palette.success))
         } else {
-            "○"
+            Span::styled("○", Style::default().fg(palette.dim))
         };
 
         let name_w = (inner.width as usize).saturating_sub(3).max(2);
         let name = truncate_str(&host.name, name_w);
 
-        if is_selected {
+        let line = if is_selected {
             let hl = Style::default().fg(palette.sel_fg).bg(palette.sel_bg);
-            let content = format!("{dot} {name:<width$}", width = name_w);
-            frame.render_widget(
-                Paragraph::new(Line::from(Span::styled(content, hl))),
-                Rect {
-                    x: inner.x,
-                    y: list_start_y + row as u16,
-                    width: inner.width,
-                    height: 1,
-                },
-            );
+            Line::from(vec![
+                Span::styled("› ", hl),
+                Span::styled(format!("{name:<width$}", width = name_w), hl),
+                Span::styled(" ", Style::default()),
+                dot,
+            ])
         } else {
-            let content = format!(" {dot} {name:<width$}", width = name_w);
-            frame.render_widget(
-                Paragraph::new(Line::from(Span::styled(
-                    content,
-                    Style::default().fg(palette.fg),
-                ))),
-                Rect {
-                    x: inner.x,
-                    y: list_start_y + row as u16,
-                    width: inner.width,
-                    height: 1,
-                },
-            );
-        }
+            Line::from(vec![
+                Span::styled("  ", Style::default().fg(palette.dim)),
+                Span::styled(
+                    format!("{name:<width$}", width = name_w),
+                    Style::default().fg(palette.dim),
+                ),
+                Span::styled(" ", Style::default()),
+                dot,
+            ])
+        };
+
+        frame.render_widget(
+            Paragraph::new(line),
+            Rect {
+                x: inner.x,
+                y: list_start_y + row as u16,
+                width: inner.width,
+                height: 1,
+            },
+        );
     }
 
     // Empty state.
@@ -441,12 +444,13 @@ fn draw_sessions_list(frame: &mut Frame, m: &RemoteState, area: Rect, palette: &
 ///   5 rows for fields: name, user, host, port, key path
 ///   Error message (if any)
 ///   Footer hint bar
-fn draw_editor(frame: &mut Frame, m: &RemoteState, area: Rect, palette: &Palette) {
-    let Some(editor) = &m.editor else { return };
-
-    // Fill background so the chat underneath doesn't bleed through.
-    crate::view::clear_and_fill(frame, area, palette.bg);
-
+fn draw_editor_inner(
+    frame: &mut Frame,
+    editor: &crate::app::mode::remote::HostEditor,
+    editing_field: bool,
+    area: Rect,
+    palette: &Palette,
+) {
     let header_area = Rect {
         x: area.x,
         y: area.y,
@@ -530,7 +534,7 @@ fn draw_editor(frame: &mut Frame, m: &RemoteState, area: Rect, palette: &Palette
             Style::default().fg(palette.dim)
         };
 
-        let cursor = if is_focused && m.editing_field {
+        let cursor = if is_focused && editing_field {
             "█"
         } else if is_focused {
             "▌"
@@ -589,7 +593,7 @@ fn draw_editor(frame: &mut Frame, m: &RemoteState, area: Rect, palette: &Palette
     }
 
     // Footer hint.
-    let hint = if m.editing_field {
+    let hint = if editing_field {
         " Enter confirm field  Esc cancel edit "
     } else {
         " Enter edit field  s save  Esc back  ↑↓ navigate "

--- a/src-agent/src/view/remote.rs
+++ b/src-agent/src/view/remote.rs
@@ -1,148 +1,95 @@
-//! Fullscreen remote host management and intent-specific host/session pickers.
+//! Two-pane remote host management dashboard (mirrors `/agents` layout).
+//!
+//! ```text
+//! ┌──────────────────┬──────────────────────────────┐
+//! │ remote hosts     │ host detail                  │
+//! │                  │                              │
+//! │ › prod-server    │  name    prod-server         │
+//! │   staging-server │  addr    root@10.0.0.1       │
+//! │   dev-box        │  key     ~/.ssh/id_ed25519   │
+//! │                  │  status  ● connected          │
+//! │                  │                              │
+//! │                  │  sessions                    │
+//! │                  │  ● session-a (current)       │
+//! │                  │  ○ session-b                 │
+//! │                  │                              │
+//! └──────────────────┴──────────────────────────────┘
+//!   ↑↓ pick · Enter connect · n new · d delete · e edit · Esc close
+//! ```
 
 use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Direction, Layout, Margin};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::Frame;
 
-use crate::app::mode::remote::{HostEditField, RemoteIntent, RemoteState, RemoteView};
+use crate::app::mode::remote::{RemoteIntent, RemoteState, RemoteView};
 use crate::view::theme::Palette;
 
-/// Draw the fullscreen remote workflow.
-pub fn draw(frame: &mut ratatui::Frame, m: &RemoteState, palette: &Palette) {
+/// List sidebar column width (includes RIGHT border).
+const SIDEBAR_W: u16 = 26;
+
+/// Draw the remote workflow.
+pub fn draw(frame: &mut Frame, m: &RemoteState, palette: &Palette) {
     match m.view {
-        RemoteView::HostManager | RemoteView::HostPicker => {
-            render_host_list(frame, m, frame.area(), palette)
+        RemoteView::Edit => {
+            if m.editor.is_some() {
+                draw_editor(frame, m, frame.area(), palette);
+            }
         }
-        RemoteView::HostDetail => render_host_detail_screen(frame, m, frame.area(), palette),
-        RemoteView::SessionHub => render_session_hub(frame, m, frame.area(), palette),
-        RemoteView::CreateHost | RemoteView::EditHost => {
-            render_editor(frame, m, frame.area(), palette)
+        RemoteView::SessionHub => {
+            draw_session_hub(frame, m, frame.area(), palette);
+        }
+        RemoteView::Browse => {
+            draw_browse(frame, m, palette);
         }
     }
 }
 
-/// Fullscreen searchable saved-host list.
-fn render_host_list(frame: &mut ratatui::Frame, m: &RemoteState, area: Rect, palette: &Palette) {
-    crate::view::clear_and_fill(frame, area, palette.bg);
-    let popup = area;
+/// Two-pane browse layout: header | body (list + detail) | footer.
+fn draw_browse(frame: &mut Frame, m: &RemoteState, palette: &Palette) {
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2), // header
+            Constraint::Min(0),   // body
+            Constraint::Length(1), // footer
+        ])
+        .split(frame.area());
 
-    let block = Block::bordered()
-        .title(Span::styled(
-            match m.intent {
-                RemoteIntent::Manage => " remote hosts ",
-                RemoteIntent::Resume => " resume remote · choose host ",
-                RemoteIntent::New => " new remote · choose host ",
-            },
-            Style::default().fg(palette.dim),
-        ))
-        .border_style(Style::default().fg(palette.dim))
-        .padding(ratatui::widgets::Padding::horizontal(1));
-
-    let inner = block.inner(popup);
-    frame.render_widget(block, popup);
-
-    // Search line.
-    let search_line = Line::from(vec![
-        Span::styled(" > ", Style::default().fg(palette.accent)),
-        Span::styled(&m.query, Style::default().fg(palette.fg)),
-        Span::styled("_", Style::default().fg(palette.accent)),
-    ]);
-    let search_widget = Paragraph::new(search_line);
-    if inner.height > 0 {
-        frame.render_widget(
-            search_widget,
-            Rect {
-                x: inner.x,
-                y: inner.y,
-                width: inner.width,
-                height: 1,
-            },
-        );
-    }
-
-    // Host list.
-    let list_area = Rect {
-        x: inner.x,
-        y: inner.y + 1,
-        width: inner.width,
-        height: inner.height.saturating_sub(2), // minus search + hint
+    // Header.
+    let header_block = Block::new()
+        .borders(Borders::BOTTOM)
+        .border_style(Style::default().fg(palette.dim));
+    let header_inner = header_block.inner(outer[0]);
+    frame.render_widget(header_block, outer[0]);
+    let title = match m.intent {
+        RemoteIntent::Manage => "remote",
+        RemoteIntent::Resume => "remote — resume",
+        RemoteIntent::New => "remote — new session",
     };
-    for (row, &host_idx) in m
-        .filtered
-        .iter()
-        .enumerate()
-        .take(list_area.height as usize)
-    {
-        let host = &m.hosts[host_idx];
-        let is_selected = row == m.selected;
-        let is_pending_delete = m.pending_delete.as_deref() == Some(&host.id);
+    frame.render_widget(
+        Paragraph::new(Span::styled(title, Style::default().fg(palette.dim))),
+        header_inner.inner(Margin {
+            horizontal: 2,
+            vertical: 0,
+        }),
+    );
 
-        let row_style = if is_selected {
-            Style::default().fg(palette.sel_fg).bg(palette.sel_bg)
-        } else {
-            Style::default().fg(palette.fg).bg(palette.bg)
-        };
+    // Body: list sidebar + detail pane.
+    let body_cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(SIDEBAR_W), Constraint::Min(0)])
+        .split(outer[1]);
 
-        let content = format!(
-            " {} {}  {}@{}{}",
-            if host.last_connected.is_some() {
-                "●"
-            } else {
-                "○"
-            },
-            host.name,
-            host.user,
-            host.host,
-            if is_pending_delete { " [confirm?]" } else { "" },
-        );
-        let width = list_area.width as usize;
-        let padded = format!("{content:<width$}");
-        let line = Line::from(Span::styled(padded, row_style));
+    draw_host_list(frame, m, palette, body_cols[0]);
+    draw_detail(frame, m, palette, body_cols[1]);
 
-        let y = list_area.y + row as u16;
-        if y < list_area.y + list_area.height {
-            frame.render_widget(
-                Paragraph::new(line),
-                Rect {
-                    x: list_area.x,
-                    y,
-                    width: list_area.width,
-                    height: 1,
-                },
-            );
-        }
-    }
-
-    // Empty state.
-    if m.filtered.is_empty() && list_area.height > 0 {
-        let empty_text = if m.intent == RemoteIntent::Manage {
-            "no hosts. Ctrl+A to add."
-        } else {
-            "no saved hosts. Use /remote to add one."
-        };
-        let empty = Line::from(Span::styled(empty_text, Style::default().fg(palette.dim)));
-        frame.render_widget(
-            Paragraph::new(empty),
-            Rect {
-                x: inner.x,
-                y: inner.y + 1,
-                width: inner.width,
-                height: 1,
-            },
-        );
-    }
-
-    // Hint bar — full-width inverse bar matching other overlays.
-    if inner.height > 0 {
-        let hint_y = inner.y + inner.height - 1;
-        let hint = match m.intent {
-            RemoteIntent::Manage => {
-                "enter detail · ctrl+a add · i import · backspace delete (enter/y confirm) · esc close"
-            }
-            RemoteIntent::Resume => "enter prepare host · esc close",
-            RemoteIntent::New => "enter prepare host and create session · esc close",
-        };
+    // Footer.
+    let footer_rect = outer[2];
+    if footer_rect.width > 0 {
+        let hint = footer_hint(m);
         let bar_style = Style::default()
             .fg(palette.sel_fg)
             .bg(palette.sel_bg)
@@ -150,13 +97,114 @@ fn render_host_list(frame: &mut ratatui::Frame, m: &RemoteState, area: Rect, pal
         let padded = format!(
             " {:<width$}",
             hint,
-            width = inner.width.saturating_sub(1) as usize
+            width = footer_rect.width.saturating_sub(1) as usize
         );
         frame.render_widget(
             Paragraph::new(Line::from(Span::raw(padded))).style(bar_style),
+            footer_rect,
+        );
+    }
+
+    // Delete confirm overlay (on top of everything).
+    if m.pending_delete.is_some() {
+        draw_delete_confirm(frame, m, frame.area(), palette);
+    }
+}
+
+/// Render the host list sidebar (left pane) with search + selection.
+fn draw_host_list(frame: &mut Frame, m: &RemoteState, palette: &Palette, area: Rect) {
+    let block = Block::new()
+        .borders(Borders::RIGHT)
+        .border_style(Style::default().fg(palette.dim));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if inner.height == 0 {
+        return;
+    }
+
+    // Search line at top.
+    let search_y = inner.y;
+    let search_line = Line::from(vec![
+        Span::styled(" > ", Style::default().fg(palette.accent)),
+        Span::styled(&m.query, Style::default().fg(palette.fg)),
+        Span::styled("_", Style::default().fg(palette.accent)),
+    ]);
+    frame.render_widget(
+        Paragraph::new(search_line),
+        Rect {
+            x: inner.x,
+            y: search_y,
+            width: inner.width,
+            height: 1,
+        },
+    );
+
+    // Host rows (below search).
+    let list_start_y = inner.y + 1;
+    let list_height = inner.height.saturating_sub(1);
+    for (row, &host_idx) in m
+        .filtered
+        .iter()
+        .enumerate()
+        .take(list_height as usize)
+    {
+        let host = &m.hosts[host_idx];
+        let is_selected = row == m.selected;
+
+        let dot = if host.last_connected.is_some() {
+            "●"
+        } else {
+            "○"
+        };
+
+        let name_w = (inner.width as usize).saturating_sub(3).max(2);
+        let name = truncate_str(&host.name, name_w);
+
+        if is_selected {
+            let hl = Style::default().fg(palette.sel_fg).bg(palette.sel_bg);
+            let content = format!("{dot} {name:<width$}", width = name_w);
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(content, hl))),
+                Rect {
+                    x: inner.x,
+                    y: list_start_y + row as u16,
+                    width: inner.width,
+                    height: 1,
+                },
+            );
+        } else {
+            let content = format!(" {dot} {name:<width$}", width = name_w);
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    content,
+                    Style::default().fg(palette.fg),
+                ))),
+                Rect {
+                    x: inner.x,
+                    y: list_start_y + row as u16,
+                    width: inner.width,
+                    height: 1,
+                },
+            );
+        }
+    }
+
+    // Empty state.
+    if m.filtered.is_empty() && list_height > 0 {
+        let empty_text = if m.intent == RemoteIntent::Manage {
+            "no hosts. Press n to add."
+        } else {
+            "no saved hosts. Use /remote to add one."
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                empty_text,
+                Style::default().fg(palette.dim),
+            ))),
             Rect {
                 x: inner.x,
-                y: hint_y,
+                y: list_start_y,
                 width: inner.width,
                 height: 1,
             },
@@ -164,81 +212,12 @@ fn render_host_list(frame: &mut ratatui::Frame, m: &RemoteState, area: Rect, pal
     }
 }
 
-/// Fullscreen management diagnostics for one saved host.
-fn render_host_detail_screen(
-    frame: &mut ratatui::Frame,
-    m: &RemoteState,
-    area: Rect,
-    palette: &Palette,
-) {
-    // Header (2 rows).
-    let header_area = Rect {
-        x: area.x,
-        y: area.y,
-        width: area.width,
-        height: 2,
-    };
-    let body_area = Rect {
-        x: area.x,
-        y: area.y + 2,
-        width: area.width,
-        height: area.height.saturating_sub(3),
-    };
-    let footer_area = Rect {
-        x: area.x,
-        y: area.y + area.height - 1,
-        width: area.width,
-        height: 1,
-    };
-
-    let title = "remote > host diagnostics";
-    let header = Paragraph::new(Line::from(Span::styled(
-        format!(" {title} "),
-        Style::default()
-            .fg(palette.fg)
-            .bg(palette.bg)
-            .add_modifier(Modifier::BOLD),
-    )));
-    frame.render_widget(header, header_area);
-    // Separator line.
-    let sep = Paragraph::new(Line::from(Span::styled(
-        "─".repeat(area.width as usize),
-        Style::default().fg(palette.dim),
-    )));
-    frame.render_widget(
-        sep,
-        Rect {
-            x: area.x,
-            y: area.y + 1,
-            width: area.width,
-            height: 1,
-        },
-    );
-
-    // Body: management detail and diagnostics.
-    render_host_detail(frame, m, body_area, palette);
-
-    let hint = if m.pending_delete.is_some() {
-        " delete host? Enter/y confirm · Esc/n cancel ".to_string()
-    } else {
-        " e edit · Backspace delete · Esc back ".to_string()
-    };
-    let hint_line = Line::from(Span::styled(
-        hint,
-        Style::default().fg(palette.sel_fg).bg(palette.accent),
-    ));
-    frame.render_widget(Paragraph::new(hint_line), footer_area);
-}
-
-/// Render the host detail pane (left half).
-fn render_host_detail(frame: &mut ratatui::Frame, m: &RemoteState, area: Rect, palette: &Palette) {
-    let block = Block::default()
-        .title(" host detail ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(palette.dim));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+/// Render the detail pane (right side of browse mode).
+fn draw_detail(frame: &mut Frame, m: &RemoteState, palette: &Palette, area: Rect) {
+    let inner = area.inner(Margin {
+        horizontal: 2,
+        vertical: 1,
+    });
 
     let Some(host) = m.selected_host() else {
         let msg = Paragraph::new(Span::styled(
@@ -249,48 +228,170 @@ fn render_host_detail(frame: &mut ratatui::Frame, m: &RemoteState, area: Rect, p
         return;
     };
 
+    let value_w = (inner.width as usize).saturating_sub(14).max(4);
     let mut lines: Vec<Line> = Vec::new();
-    lines.push(Line::from(vec![
-        Span::styled("  name: ", Style::default().fg(palette.dim)),
-        Span::styled(&host.name, Style::default().fg(palette.fg)),
-    ]));
-    lines.push(Line::from(vec![
-        Span::styled("  addr: ", Style::default().fg(palette.dim)),
-        Span::styled(host.address(), Style::default().fg(palette.accent)),
-    ]));
+
+    let row = |label: &str, value: String, color: ratatui::style::Color| -> Line<'static> {
+        Line::from(vec![
+            Span::styled(format!("{label:<14}"), Style::default().fg(palette.dim)),
+            Span::styled(value, Style::default().fg(color)),
+        ])
+    };
+
+    lines.push(row("name", host.name.clone(), palette.accent));
+    lines.push(row(
+        "addr",
+        host.address(),
+        palette.fg,
+    ));
     if let Some(ref key) = host.key_path {
-        lines.push(Line::from(vec![
-            Span::styled("  key:  ", Style::default().fg(palette.dim)),
-            Span::styled(key.as_str(), Style::default().fg(palette.fg)),
-        ]));
+        lines.push(row("key", truncate_str(key, value_w), palette.fg));
     }
+
     let status_span = if host.last_connected.is_some() {
         Span::styled("● connected", Style::default().fg(palette.success))
     } else {
         Span::styled("○ not connected", Style::default().fg(palette.dim))
     };
     lines.push(Line::from(vec![
-        Span::styled("  status: ", Style::default().fg(palette.dim)),
+        Span::styled("status         ", Style::default().fg(palette.dim)),
         status_span,
     ]));
+
     if !host.tags.is_empty() {
+        lines.push(row(
+            "tags",
+            truncate_str(&host.tags.join(", "), value_w),
+            palette.info,
+        ));
+    }
+
+    // Connection state (if active).
+    if let Some(ref cs) = m.connection_state {
+        use crate::app::mode::remote::ConnectionState;
+        let cs_text = match cs {
+            ConnectionState::Disconnected => "disconnected".to_string(),
+            ConnectionState::Resolving => "resolving…".to_string(),
+            ConnectionState::Authenticating => "authenticating…".to_string(),
+            ConnectionState::AuthRequired { .. } => "auth required".to_string(),
+            ConnectionState::Bootstrapping => "bootstrapping…".to_string(),
+            ConnectionState::Connecting => "connecting…".to_string(),
+            ConnectionState::Connected { session_id } => {
+                format!("connected ({})", truncate_str(session_id, 12))
+            }
+            ConnectionState::Error { message } => format!("error: {}", truncate_str(message, 30)),
+        };
+        lines.push(Line::from(""));
         lines.push(Line::from(vec![
-            Span::styled("  tags: ", Style::default().fg(palette.dim)),
-            Span::styled(host.tags.join(", "), Style::default().fg(palette.info)),
+            Span::styled("connection     ", Style::default().fg(palette.dim)),
+            Span::styled(cs_text, Style::default().fg(palette.accent)),
         ]));
+    }
+
+    // Sessions (if any discovered).
+    if !m.sessions.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "sessions",
+            Style::default().fg(palette.dim),
+        )));
+        for (i, session) in m.sessions.iter().take(8).enumerate() {
+            let dot = if session.working {
+                Span::styled("●", Style::default().fg(palette.accent))
+            } else {
+                Span::styled("○", Style::default().fg(palette.dim))
+            };
+            let fg_label = if session.is_foreground {
+                " (current)"
+            } else {
+                ""
+            };
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                dot,
+                Span::raw(" "),
+                Span::styled(&session.name, Style::default().fg(palette.fg)),
+                Span::styled(fg_label, Style::default().fg(palette.dim)),
+            ]));
+            let _ = i; // suppress unused warning
+        }
     }
 
     let widget = Paragraph::new(lines).wrap(Wrap { trim: true });
     frame.render_widget(widget, inner);
 }
 
-/// Render the sessions pane (right half).
-fn render_sessions_pane(
-    frame: &mut ratatui::Frame,
-    m: &RemoteState,
-    area: Rect,
-    palette: &Palette,
-) {
+/// Render a delete confirm popup overlaid on the center of the screen.
+fn draw_delete_confirm(frame: &mut Frame, m: &RemoteState, area: Rect, palette: &Palette) {
+    let host_name = m
+        .pending_delete
+        .as_deref()
+        .and_then(|id| m.hosts.iter().find(|h| h.id == id))
+        .map(|h| h.name.as_str())
+        .unwrap_or("host");
+
+    let msg = format!(" Delete {host_name}? (y/n) ");
+    let popup_w = msg.len() as u16 + 4;
+    let popup_h: u16 = 3;
+    let x = area.x + (area.width.saturating_sub(popup_w)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_h)) / 2;
+    let popup = Rect {
+        x,
+        y,
+        width: popup_w.min(area.width),
+        height: popup_h.min(area.height),
+    };
+
+    let block = Block::bordered()
+        .title(Span::styled(
+            " confirm ",
+            Style::default().fg(palette.fg).add_modifier(Modifier::BOLD),
+        ))
+        .border_style(Style::default().fg(palette.accent));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            format!("Delete {host_name}?"),
+            Style::default().fg(palette.fg),
+        ))),
+        inner,
+    );
+}
+
+/// Render the dedicated remote session hub (fullscreen overlay).
+fn draw_session_hub(frame: &mut Frame, m: &RemoteState, area: Rect, palette: &Palette) {
+    crate::view::clear_and_fill(frame, area, palette.bg);
+    let host_name = m
+        .selected_host_id
+        .as_deref()
+        .and_then(|id| m.hosts.iter().find(|host| host.id == id))
+        .map(|host| host.name.as_str())
+        .unwrap_or("remote host");
+    let rows = ratatui::layout::Layout::vertical([
+        ratatui::layout::Constraint::Length(2),
+        ratatui::layout::Constraint::Min(1),
+        ratatui::layout::Constraint::Length(1),
+    ])
+    .split(area);
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            format!(" resume remote · {host_name} "),
+            Style::default().fg(palette.fg).add_modifier(Modifier::BOLD),
+        ))),
+        rows[0],
+    );
+    draw_sessions_list(frame, m, rows[1], palette);
+    frame.render_widget(
+        Paragraph::new(" enter resume selected UUID · esc choose another host ")
+            .style(Style::default().fg(palette.sel_fg).bg(palette.accent)),
+        rows[2],
+    );
+}
+
+/// Render the sessions list inside the session hub.
+fn draw_sessions_list(frame: &mut Frame, m: &RemoteState, area: Rect, palette: &Palette) {
     let block = Block::default()
         .title(" sessions ")
         .borders(Borders::ALL)
@@ -347,36 +448,6 @@ fn render_sessions_pane(
     }
 }
 
-/// Render the dedicated remote session hub.
-fn render_session_hub(frame: &mut ratatui::Frame, m: &RemoteState, area: Rect, palette: &Palette) {
-    crate::view::clear_and_fill(frame, area, palette.bg);
-    let host_name = m
-        .selected_host_id
-        .as_deref()
-        .and_then(|id| m.hosts.iter().find(|host| host.id == id))
-        .map(|host| host.name.as_str())
-        .unwrap_or("remote host");
-    let rows = ratatui::layout::Layout::vertical([
-        ratatui::layout::Constraint::Length(2),
-        ratatui::layout::Constraint::Min(1),
-        ratatui::layout::Constraint::Length(1),
-    ])
-    .split(area);
-    frame.render_widget(
-        Paragraph::new(Line::from(Span::styled(
-            format!(" resume remote · {host_name} "),
-            Style::default().fg(palette.fg).add_modifier(Modifier::BOLD),
-        ))),
-        rows[0],
-    );
-    render_sessions_pane(frame, m, rows[1], palette);
-    frame.render_widget(
-        Paragraph::new(" enter resume selected UUID · esc choose another host ")
-            .style(Style::default().fg(palette.sel_fg).bg(palette.accent)),
-        rows[2],
-    );
-}
-
 /// Render the host editor form (create or edit).
 ///
 /// Full-screen layout:
@@ -384,7 +455,7 @@ fn render_session_hub(frame: &mut ratatui::Frame, m: &RemoteState, area: Rect, p
 ///   5 rows for fields: name, user, host, port, key path
 ///   Error message (if any)
 ///   Footer hint bar
-fn render_editor(frame: &mut ratatui::Frame, m: &RemoteState, area: Rect, palette: &Palette) {
+fn draw_editor(frame: &mut Frame, m: &RemoteState, area: Rect, palette: &Palette) {
     let Some(editor) = &m.editor else { return };
 
     let header_area = Rect {
@@ -401,9 +472,10 @@ fn render_editor(frame: &mut ratatui::Frame, m: &RemoteState, area: Rect, palett
     };
 
     // Header.
-    let title = match m.view {
-        RemoteView::EditHost => "remote > edit host",
-        _ => "remote > add host",
+    let title = if editor.edit_id.is_some() {
+        "remote > edit host"
+    } else {
+        "remote > add host"
     };
     let header = Paragraph::new(Line::from(Span::styled(
         format!(" {title} "),
@@ -444,6 +516,7 @@ fn render_editor(frame: &mut ratatui::Frame, m: &RemoteState, area: Rect, palett
     let inner = block.inner(body_area);
     frame.render_widget(block, body_area);
 
+    use crate::app::mode::remote::HostEditField;
     let fields: [(HostEditField, &str); 5] = [
         (HostEditField::Name, &editor.name),
         (HostEditField::User, &editor.user),
@@ -537,4 +610,27 @@ fn render_editor(frame: &mut ratatui::Frame, m: &RemoteState, area: Rect, palett
         Style::default().fg(palette.sel_fg).bg(palette.accent),
     ));
     frame.render_widget(Paragraph::new(hint_line), footer_area);
+}
+
+/// Context-sensitive footer hint for the active view.
+fn footer_hint(m: &RemoteState) -> &'static str {
+    match m.intent {
+        RemoteIntent::Manage => "↑↓ pick · Enter connect · n new · d delete · e edit · i import · Esc close",
+        RemoteIntent::Resume => "↑↓ pick · Enter connect · Esc close",
+        RemoteIntent::New => "↑↓ pick · Enter connect · Esc close",
+    }
+}
+
+/// Truncate `s` to at most `max` chars, appending `…` if cut.
+fn truncate_str(s: &str, max: usize) -> String {
+    if max == 0 {
+        return String::new();
+    }
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() <= max {
+        s.to_string()
+    } else {
+        let cut = max.saturating_sub(1);
+        chars[..cut].iter().collect::<String>() + "…"
+    }
 }

--- a/src-webgui/src/components/NewSessionMenu.tsx
+++ b/src-webgui/src/components/NewSessionMenu.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState, type RefObject } from 'react'
 import { createPortal } from 'react-dom'
-import { ChevronDown, FolderOpen, Link2, LoaderCircle } from 'lucide-react'
+import { ChevronDown, FolderOpen, Link2 } from 'lucide-react'
 import { useKoma } from '../store/koma'
+import { BrailleSpinner } from './BrailleSpinner'
 
 // Track the trigger button's viewport rect while the menu is open, so the
 // menu can render in a body portal (fixed positioning) that no `overflow`
@@ -151,7 +152,7 @@ export function NewSessionMenu({ afterPick, className = '' }: NewSessionMenuProp
                     disabled={remoteState.state !== 'disconnected' && remoteState.state !== 'error'}
                     icon={
                       remoteState.hostId === host.id && remoteState.state !== 'error' && remoteState.state !== 'disconnected'
-                        ? <LoaderCircle size={13} className="animate-spin" />
+                        ? <BrailleSpinner size={13} />
                         : <Link2 size={13} />
                     }
                   >

--- a/src-webgui/src/components/NewSessionMenu.tsx
+++ b/src-webgui/src/components/NewSessionMenu.tsx
@@ -83,7 +83,15 @@ export function NewSessionMenu({ afterPick, className = '' }: NewSessionMenuProp
   }
 
   const connectRemote = (hostId: string, name: string) => {
-    if (remoteState.state !== 'disconnected' && remoteState.state !== 'error') return
+    if (remoteState.state !== 'disconnected' && remoteState.state !== 'error') {
+      // Already connecting/connected — let the user know why nothing happened.
+      const s = useKoma.getState()
+      const seq = s.ui.toastSeq + 1
+      useKoma.setState((prev) => ({
+        ui: { ...prev.ui, toastSeq: seq, toast: { id: seq, text: `Already ${remoteState.state.replace('_', ' ')}`, kind: 'error' } },
+      }))
+      return
+    }
     startSwitching(`remote ${name}`)
     req({ r: 'ConnectRemoteHost', hostId })
     setOpen(false)

--- a/src-webgui/src/components/NewSessionMenu.tsx
+++ b/src-webgui/src/components/NewSessionMenu.tsx
@@ -34,11 +34,10 @@ type NewSessionMenuProps = {
 
 const menuWidth = 240
 
-// The chevron segment of the split "+ New session" button. Shows different
-// content depending on whether a session is attached:
-//
-//   Attached (hub):  New session  |  New session + close current
-//   Detached (start): Open folder  ────────  Remote host A / B
+// The chevron segment of the split "+ New session" button. Always shows:
+//   - "New session" (opens folder picker)
+//   - "New session + close current" (only when a session is attached)
+//   - Remote host list (when any hosts are saved)
 export function NewSessionMenu({ afterPick, className = '' }: NewSessionMenuProps) {
   const req = useKoma((s) => s.req)
   const remoteHosts = useKoma((s) => s.remoteHosts)
@@ -131,43 +130,37 @@ export function NewSessionMenu({ afterPick, className = '' }: NewSessionMenuProp
             style={menuStyle}
             className="overflow-hidden rounded-md border border-koma-border bg-koma-panel py-1 shadow-sm"
           >
-            {attachedId ? (
-              // In-session: "New session" / "New session + close current"
+            {/* Local session options — always visible */}
+            <MenuItem onClick={openFolder} icon={<FolderOpen size={13} />}>
+              New session
+            </MenuItem>
+            {attachedId && (
+              <MenuItem onClick={() => pick(true)}>New session + close current</MenuItem>
+            )}
+            {/* Remote hosts — always visible when any are saved */}
+            {remoteHosts.length > 0 && (
               <>
-                <MenuItem onClick={() => pick(false)}>New session</MenuItem>
-                <MenuItem onClick={() => pick(true)}>New session + close current</MenuItem>
-              </>
-            ) : (
-              // Start screen: Open folder, separator, remote hosts
-              <>
-                <MenuItem onClick={openFolder} icon={<FolderOpen size={13} />}>
-                  Open folder
-                </MenuItem>
-                {remoteHosts.length > 0 && (
-                  <>
-                    <div className="my-1 mx-2 h-px bg-koma-border" />
-                    <div className="px-2.5 py-1 text-[10px] font-medium text-koma-dim uppercase tracking-wider">
-                      Remote
-                    </div>
-                    {remoteHosts.map((host) => (
-                      <MenuItem
-                        key={host.id}
-                        onClick={() => connectRemote(host.id, host.name)}
-                        disabled={remoteState.state !== 'disconnected' && remoteState.state !== 'error'}
-                        icon={
-                          remoteState.hostId === host.id && remoteState.state !== 'error' && remoteState.state !== 'disconnected'
-                            ? <LoaderCircle size={13} className="animate-spin" />
-                            : <Link2 size={13} />
-                        }
-                      >
-                        <span className="font-medium">{host.name}</span>
-                        <span className="ml-1 text-koma-dim">
-                          {host.user}@{host.host}
-                        </span>
-                      </MenuItem>
-                    ))}
-                  </>
-                )}
+                <div className="my-1 mx-2 h-px bg-koma-border" />
+                <div className="px-2.5 py-1 text-[10px] font-medium text-koma-dim uppercase tracking-wider">
+                  Remote
+                </div>
+                {remoteHosts.map((host) => (
+                  <MenuItem
+                    key={host.id}
+                    onClick={() => connectRemote(host.id, host.name)}
+                    disabled={remoteState.state !== 'disconnected' && remoteState.state !== 'error'}
+                    icon={
+                      remoteState.hostId === host.id && remoteState.state !== 'error' && remoteState.state !== 'disconnected'
+                        ? <LoaderCircle size={13} className="animate-spin" />
+                        : <Link2 size={13} />
+                    }
+                  >
+                    <span className="font-medium">{host.name}</span>
+                    <span className="ml-1 text-koma-dim">
+                      {host.user}@{host.host}
+                    </span>
+                  </MenuItem>
+                ))}
               </>
             )}
           </div>,

--- a/src-webgui/src/components/RemotePasswordPrompt.tsx
+++ b/src-webgui/src/components/RemotePasswordPrompt.tsx
@@ -1,27 +1,36 @@
 import { useEffect, useRef, useState, type FormEvent, type KeyboardEvent } from 'react'
+import { motion } from 'framer-motion'
+import { Check, Lock, X } from 'lucide-react'
+import { CMD_SEARCH_WIDTH } from './Titlebar'
 
 type RemotePasswordPromptProps = {
   active: boolean
   target?: string | null
   onSubmit: (password: string) => void
   onCancel: () => void
-  compact?: boolean
 }
 
-/** Password stays component-local and is cleared on every exit path. */
+/**
+ * Full-screen overlay with a narrow top pill bar for SSH password entry.
+ * Follows the RenameOverlay / OmniSearchPalette pattern: absolute inset-0
+ * backdrop, narrow centered bar at top, Esc/click-cancel, Enter/✓ submit.
+ */
 export function RemotePasswordPrompt({
   active,
   target,
   onSubmit,
   onCancel,
-  compact = false,
 }: RemotePasswordPromptProps) {
   const [password, setPassword] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
-    if (active) inputRef.current?.focus()
-    else setPassword('')
+    if (active) {
+      // Delay one tick so the motion div is in the DOM before focusing.
+      requestAnimationFrame(() => inputRef.current?.focus())
+    } else {
+      setPassword('')
+    }
     return () => setPassword('')
   }, [active])
 
@@ -48,40 +57,55 @@ export function RemotePasswordPrompt({
   }
 
   return (
-    <form
-      onSubmit={submit}
-      className={`flex flex-col gap-2 ${compact ? 'mt-2' : 'w-[280px]'}`}
-    >
-      <label className="text-[12px] text-koma-fg opacity-70">
-        Password{target ? ` for ${target}` : ''}
-      </label>
-      <input
-        ref={inputRef}
-        autoFocus
-        type="password"
-        autoComplete="current-password"
-        aria-label="SSH password"
-        value={password}
-        onChange={(event) => setPassword(event.target.value)}
-        onKeyDown={handleKeyDown}
-        className="w-full rounded border border-koma-border bg-koma-panel px-2 py-1.5 text-koma-fg outline-none focus:border-koma-accent"
-      />
-      <div className="flex justify-end gap-2">
-        <button
-          type="button"
-          onClick={cancel}
-          className="rounded border border-koma-border px-2.5 py-1 text-koma-fg opacity-70 hover:bg-koma-hover hover:opacity-100"
+    <div className="absolute inset-0 z-[70]" onMouseDown={cancel}>
+      <motion.div
+        initial={{ opacity: 0, y: -4 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.12, ease: 'easeOut' }}
+        className={`mx-auto mt-[5px] ${CMD_SEARCH_WIDTH}`}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <form
+          onSubmit={submit}
+          className="flex h-[22px] items-center gap-1.5 rounded-md border border-koma-border bg-koma-panel px-2.5 shadow-xl"
         >
-          Cancel
-        </button>
-        <button
-          type="submit"
-          disabled={!password.trim()}
-          className="rounded bg-koma-accent px-2.5 py-1 text-koma-bg disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          Connect
-        </button>
-      </div>
-    </form>
+          <Lock size={12} className="flex-none text-koma-dim" />
+          <input
+            ref={inputRef}
+            type="password"
+            autoComplete="current-password"
+            aria-label="SSH password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Enter password…"
+            className="w-full bg-transparent text-[12px] text-koma-fg outline-none placeholder:text-koma-fg placeholder:opacity-40"
+          />
+          <button
+            type="submit"
+            disabled={!password.trim()}
+            title="Submit"
+            aria-label="Submit password"
+            className="flex h-4 w-4 flex-none items-center justify-center rounded text-koma-fg opacity-60 transition-colors hover:text-emerald-500 hover:opacity-100 disabled:cursor-not-allowed disabled:opacity-30"
+          >
+            <Check size={13} />
+          </button>
+          <button
+            type="button"
+            onClick={cancel}
+            title="Cancel"
+            aria-label="Cancel"
+            className="flex h-4 w-4 flex-none items-center justify-center rounded text-koma-fg opacity-60 transition-colors hover:text-red-500 hover:opacity-100"
+          >
+            <X size={13} />
+          </button>
+        </form>
+        {target && (
+          <div className="mt-1 text-center text-[11px] text-koma-fg opacity-50">
+            Password for {target}
+          </div>
+        )}
+      </motion.div>
+    </div>
   )
 }

--- a/src-webgui/src/components/SwitchingOverlay.tsx
+++ b/src-webgui/src/components/SwitchingOverlay.tsx
@@ -4,7 +4,6 @@ import { Check, Minus, X } from 'lucide-react'
 import { useKoma } from '../store/koma'
 import type { LoadPhase } from '../store/koma'
 import { BrailleSpinner, useBrailleFrame } from './BrailleSpinner'
-import { RemotePasswordPrompt } from './RemotePasswordPrompt'
 
 // Duplicated from Titlebar.tsx's private (unexported) `post` helper — this
 // overlay covers the titlebar region too and needs the same win-drag/maximize
@@ -221,15 +220,9 @@ export function SwitchingOverlay({ onCancel }: SwitchingOverlayProps) {
               </motion.div>
             )}
             {remoteState.state === 'auth_required' ? (
-              <RemotePasswordPrompt
-                active
-                target={remoteState.user && remoteState.host ? `${remoteState.user}@${remoteState.host}` : null}
-                onSubmit={(password) => useKoma.getState().req({ r: 'SubmitRemotePassword', password })}
-                onCancel={() => {
-                  useKoma.getState().req({ r: 'CancelRemoteConnect' })
-                  useKoma.getState().cancelSwitching()
-                }}
-              />
+              <div className="text-[12px] text-koma-fg opacity-50">
+                Waiting for password…
+              </div>
             ) : (
               <button
                 onClick={() => {

--- a/src-webgui/src/components/panels/RemotePanel.tsx
+++ b/src-webgui/src/components/panels/RemotePanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useRef, type FormEvent, type KeyboardEvent } from 'react'
-import { Plus, Trash2, Edit3, Link2, LoaderCircle, Check, X, Lock } from 'lucide-react'
+import { Plus, Trash2, Edit3, Link2, Check, X, Lock } from 'lucide-react'
 import { useKoma } from '../../store/koma'
+import { BrailleSpinner } from '../BrailleSpinner'
 
 type RemotePanelView =
   | { kind: 'list' }
@@ -209,7 +210,7 @@ export function RemotePanel() {
                   className="flex min-h-[49px] items-center justify-between bg-koma-panel border border-koma-accent/40 rounded px-2 py-1.5"
                 >
                   <div className="flex items-center gap-2 min-w-0">
-                    <LoaderCircle size={13} className="flex-none animate-spin text-koma-accent" />
+                    <BrailleSpinner size={13} className="text-koma-accent" />
                     <div className="min-w-0">
                       <div className="text-koma-fg font-medium truncate">{host.name}</div>
                       <div className="text-koma-dim truncate">

--- a/src-webgui/src/components/panels/RemotePanel.tsx
+++ b/src-webgui/src/components/panels/RemotePanel.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useMemo } from 'react'
-import { Plus, Trash2, Edit3, Link2, LoaderCircle, Check, X } from 'lucide-react'
+import { useState, useEffect, useMemo, useRef, type FormEvent, type KeyboardEvent } from 'react'
+import { Plus, Trash2, Edit3, Link2, LoaderCircle, Check, X, Lock } from 'lucide-react'
 import { useKoma } from '../../store/koma'
 
 type RemotePanelView =
@@ -21,6 +21,9 @@ const emptyDraft = (): RemoteHostDraft => ({
   port: 22,
   keyPath: '',
 })
+
+/** States where the connection is in-progress (not idle). */
+const ACTIVE_STATES = ['resolving', 'auth_required', 'bootstrapping', 'connecting']
 
 export function RemotePanel() {
   const remoteHosts = useKoma((s) => s.remoteHosts)
@@ -64,9 +67,9 @@ export function RemotePanel() {
       isNew: false,
     })
   }
-  const connecting = !['disconnected', 'connected', 'error'].includes(remoteState.state)
+  const isBusy = ACTIVE_STATES.includes(remoteState.state)
   const handleConnect = (hostId: string) => {
-    if (connecting) return
+    if (isBusy) return
     push({ r: 'ConnectRemoteHost', hostId })
   }
   const confirmDelete = (hostId: string) => {
@@ -187,27 +190,6 @@ export function RemotePanel() {
         />
       </div>
 
-      {remoteState.state !== 'disconnected' && (
-        <div className={`mx-2 mt-2 rounded border px-2 py-1.5 ${remoteState.state === 'error' ? 'border-koma-error/50 text-koma-error' : 'border-koma-border text-koma-fg'}`}>
-          <div className="flex items-center gap-1.5">
-            {connecting && <LoaderCircle size={13} className="animate-spin text-koma-accent" />}
-            <span className="capitalize">{remoteState.state.replace('_', ' ')}</span>
-          </div>
-          {remoteState.error && <div className="mt-1 text-[11px] opacity-80">{remoteState.error}</div>}
-          {remoteState.state === 'auth_required' && (
-            <div className="mt-1 text-[11px] opacity-70">Waiting for password…</div>
-          )}
-          {['resolving', 'bootstrapping', 'connecting'].includes(remoteState.state) && (
-            <button
-              className="mt-2 rounded border border-koma-border px-2 py-1 text-koma-fg opacity-70 hover:bg-koma-hover hover:opacity-100"
-              onClick={() => push({ r: 'CancelRemoteConnect' })}
-            >
-              Cancel
-            </button>
-          )}
-        </div>
-      )}
-
       {/* Host list — scrollable, fills remaining space */}
       <div className="flex-1 overflow-auto px-2 py-1">
         <div className="flex flex-col gap-1">
@@ -216,10 +198,42 @@ export function RemotePanel() {
           )}
           {filtered.map((host) => {
             const armed = armedDelete === host.id
+            const isActiveHost = isBusy && remoteState.hostId === host.id
+            const isOtherBusy = isBusy && remoteState.hostId !== host.id
+
+            /* ── Active host: inline loading / auth state ── */
+            if (isActiveHost) {
+              return (
+                <div
+                  key={host.id}
+                  className="flex min-h-[49px] items-center justify-between bg-koma-panel border border-koma-accent/40 rounded px-2 py-1.5"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <LoaderCircle size={13} className="flex-none animate-spin text-koma-accent" />
+                    <div className="min-w-0">
+                      <div className="text-koma-fg font-medium truncate">{host.name}</div>
+                      <div className="text-koma-dim truncate">
+                        {remoteState.state === 'auth_required'
+                          ? 'Waiting for password…'
+                          : `${remoteState.state.replace('_', ' ')}…`}
+                      </div>
+                    </div>
+                  </div>
+                  <button
+                    className="flex-none rounded border border-koma-border px-2 py-0.5 text-koma-fg opacity-70 hover:bg-koma-hover hover:opacity-100"
+                    onClick={() => push({ r: 'CancelRemoteConnect' })}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              )
+            }
+
+            /* ── Normal / armed / disabled host row ── */
             return (
             <div
               key={host.id}
-              className="flex min-h-[49px] items-center justify-between bg-koma-panel border border-koma-border rounded px-2 py-1.5 hover:bg-koma-hover"
+              className={`flex min-h-[49px] items-center justify-between bg-koma-panel border border-koma-border rounded px-2 py-1.5 ${isOtherBusy ? 'opacity-40 pointer-events-none' : 'hover:bg-koma-hover'}`}
             >
               {armed ? (
                 <>
@@ -272,26 +286,24 @@ export function RemotePanel() {
               </div>
               <div className="flex items-center gap-1">
                 <button
-                  disabled={connecting}
+                  disabled={isBusy}
                   className="p-1 text-koma-accent hover:text-koma-fg disabled:cursor-not-allowed disabled:opacity-40"
                   title="Connect"
                   onClick={() => handleConnect(host.id)}
                 >
-                  {connecting && remoteState.hostId === host.id ? (
-                    <LoaderCircle size={14} className="animate-spin" />
-                  ) : (
-                    <Link2 size={14} />
-                  )}
+                  <Link2 size={14} />
                 </button>
                 <button
-                  className="p-1 text-koma-dim hover:text-koma-fg"
+                  disabled={isBusy}
+                  className="p-1 text-koma-dim hover:text-koma-fg disabled:cursor-not-allowed disabled:opacity-40"
                   title="Edit"
                   onClick={() => handleEdit(host)}
                 >
                   <Edit3 size={14} />
                 </button>
                 <button
-                  className="p-1 text-koma-dim hover:text-koma-error"
+                  disabled={isBusy}
+                  className="p-1 text-koma-dim hover:text-koma-error disabled:cursor-not-allowed disabled:opacity-40"
                   title="Delete"
                   onClick={() => setArmedDelete(host.id)}
                 >
@@ -309,7 +321,8 @@ export function RemotePanel() {
       {/* Add button — pinned to bottom */}
       <div className="flex-none border-t border-koma-border p-2">
         <button
-          className="flex w-full items-center justify-center gap-1.5 rounded border border-koma-border py-1.5 text-[12px] text-koma-accent hover:bg-koma-hover"
+          disabled={isBusy}
+          className="flex w-full items-center justify-center gap-1.5 rounded border border-koma-border py-1.5 text-[12px] text-koma-accent hover:bg-koma-hover disabled:cursor-not-allowed disabled:opacity-40"
           onClick={handleAdd}
         >
           <Plus size={14} />

--- a/src-webgui/src/components/panels/RemotePanel.tsx
+++ b/src-webgui/src/components/panels/RemotePanel.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { Plus, Trash2, Edit3, Link2, LoaderCircle, Check, X } from 'lucide-react'
 import { useKoma } from '../../store/koma'
-import { RemotePasswordPrompt } from '../RemotePasswordPrompt'
 
 type RemotePanelView =
   | { kind: 'list' }
@@ -195,13 +194,9 @@ export function RemotePanel() {
             <span className="capitalize">{remoteState.state.replace('_', ' ')}</span>
           </div>
           {remoteState.error && <div className="mt-1 text-[11px] opacity-80">{remoteState.error}</div>}
-          <RemotePasswordPrompt
-            compact
-            active={remoteState.state === 'auth_required'}
-            target={remoteState.user && remoteState.host ? `${remoteState.user}@${remoteState.host}` : null}
-            onSubmit={(password) => push({ r: 'SubmitRemotePassword', password })}
-            onCancel={() => push({ r: 'CancelRemoteConnect' })}
-          />
+          {remoteState.state === 'auth_required' && (
+            <div className="mt-1 text-[11px] opacity-70">Waiting for password…</div>
+          )}
           {['resolving', 'bootstrapping', 'connecting'].includes(remoteState.state) && (
             <button
               className="mt-2 rounded border border-koma-border px-2 py-1 text-koma-fg opacity-70 hover:bg-koma-hover hover:opacity-100"

--- a/src-webgui/src/routes/index.tsx
+++ b/src-webgui/src/routes/index.tsx
@@ -12,6 +12,7 @@ import { ResumePalette } from '../components/ResumePalette'
 import { RenameOverlay } from '../components/RenameOverlay'
 import { OmniSearchPalette } from '../components/OmniSearchPalette'
 import { SwitchingOverlay } from '../components/SwitchingOverlay'
+import { RemotePasswordPrompt } from '../components/RemotePasswordPrompt'
 import { ToastContainer } from '../components/ToastContainer'
 import { UsageFooter } from '../components/UsageFooter'
 import { useKoma } from '../store/koma'
@@ -64,6 +65,7 @@ function RootLayout() {
   const omnisearchOpen = useKoma((s) => s.ui.omnisearchOpen)
   const closeOmniSearch = useKoma((s) => s.closeOmniSearch)
   const cancelSwitching = useKoma((s) => s.cancelSwitching)
+  const remoteState = useKoma((s) => s.remoteState)
   const req = useKoma((s) => s.req)
   const openSettingsTab = useKoma((s) => s.openSettingsTab)
   const openHelpTab = useKoma((s) => s.openHelpTab)
@@ -262,6 +264,18 @@ function RootLayout() {
           req({ r: 'CancelSwitch' })
           cancelSwitching()
           setOverlay('resume')
+        }}
+      />
+      <RemotePasswordPrompt
+        active={remoteState.state === 'auth_required'}
+        target={remoteState.user && remoteState.host ? `${remoteState.user}@${remoteState.host}` : null}
+        onSubmit={(password) => req({ r: 'SubmitRemotePassword', password })}
+        onCancel={() => {
+          req({ r: 'CancelRemoteConnect' })
+          if (useKoma.getState().ui.switchingTo) {
+            req({ r: 'CancelSwitch' })
+            cancelSwitching()
+          }
         }}
       />
       <ToastContainer />


### PR DESCRIPTION
GUI:
- Rewrite RemotePasswordPrompt as top pill bar overlay (z-70, like RenameOverlay)
- Remove inline password forms from RemotePanel and SwitchingOverlay
- Mount global password overlay in index.tsx
- Add toast when NewSessionMenu connect is blocked

TUI:
- Collapse 5 RemoteView variants to 3: Browse, Edit, SessionHub
- Two-pane layout (26-col sidebar + detail pane) matching /agents pattern
- Simplified keybindings: Enter connect, n new, d delete, e edit, Esc close
- Update IPC projection and deserialization for new view tokens