### PR TITLE
fix: cache known_file_set in ProjectIndex to eliminate O(N²) allocati…

### DIFF
--- a/src-agent/src/linker/project.rs
+++ b/src-agent/src/linker/project.rs
@@ -70,6 +70,8 @@ pub struct ProjectIndex {
     root_configs: HashMap<String, RootConfig>,
     /// Monotonically increasing generation counter for cache identity.
     generation: u64,
+    /// Cached set of all file names (keys of `files`). Rebuilt on add/remove.
+    file_names: HashSet<String>,
 }
 
 impl ProjectIndex {
@@ -132,6 +134,7 @@ impl ProjectIndex {
         };
         self.by_dir.entry(dir).or_default().push(path.clone());
         self.by_lang.entry(lang).or_default().push(path.clone());
+        self.file_names.insert(path.clone());
         self.files.insert(path, entry);
         Ok(())
     }
@@ -142,6 +145,7 @@ impl ProjectIndex {
         let Some(old) = self.files.remove(&path) else {
             return false;
         };
+        self.file_names.remove(&path);
         remove_group_entry(&mut self.by_dir, &old.dir, &path);
         remove_group_entry(&mut self.by_lang, &old.lang, &path);
         true
@@ -168,8 +172,8 @@ impl ProjectIndex {
     pub fn known_files(&self) -> &HashMap<String, KnownFileEntry> {
         &self.files
     }
-    pub fn known_file_set(&self) -> HashSet<String> {
-        self.files.keys().cloned().collect()
+    pub fn known_file_set(&self) -> &HashSet<String> {
+        &self.file_names
     }
     #[allow(dead_code)]
     pub fn file_count(&self) -> usize {

--- a/src-agent/src/linker/resolve/go.rs
+++ b/src-agent/src/linker/resolve/go.rs
@@ -102,7 +102,7 @@ pub fn resolve_go_import(
                             normalize_lexical(&format!("{mod_dir}/{sub}"))
                         };
                         let known = ctx.project.known_file_set();
-                        let targets = resolve_go_package(&local_path, &known);
+                        let targets = resolve_go_package(&local_path, known);
                         if !targets.is_empty() {
                             return Resolution::Resolved(targets);
                         }
@@ -151,7 +151,7 @@ fn resolve_relative_import(
 
     // Try as directory with Go files.
     let known = ctx.project.known_file_set();
-    let targets = resolve_go_package(&resolved, &known);
+    let targets = resolve_go_package(&resolved, known);
     if !targets.is_empty() {
         let _ = conditions; // conditions preserved via meta at scan level
         return Resolution::Resolved(targets);
@@ -202,7 +202,7 @@ fn resolve_local_replace(
     };
 
     let known = ctx.project.known_file_set();
-    let targets = resolve_go_package(&target_dir, &known);
+    let targets = resolve_go_package(&target_dir, known);
     if !targets.is_empty() {
         return Resolution::Resolved(targets);
     }
@@ -279,7 +279,7 @@ fn resolve_in_vendor(
 
     let vendor_dir = format!("{mod_dir}/vendor/{specifier}");
     let known = project.known_file_set();
-    let targets = resolve_go_package(&vendor_dir, &known);
+    let targets = resolve_go_package(&vendor_dir, known);
     if targets.is_empty() {
         None
     } else {

--- a/src-agent/src/linker/resolve/python.rs
+++ b/src-agent/src/linker/resolve/python.rs
@@ -93,13 +93,13 @@ fn resolve_relative_import(py_meta: &PythonMeta, ctx: &ResolveContext<'_>) -> Re
                 };
             }
             let known = ctx.project.known_file_set();
-            let targets = resolve_module_targets(&full_path, &known);
+            let targets = resolve_module_targets(&full_path, known);
             if !targets.is_empty() {
                 let mut all = targets;
                 if !py_meta.names.is_empty() && py_meta.names[0] != "*" {
                     for name in &py_meta.names {
                         let sub = normalize_lexical(&format!("{full_path}/{name}"));
-                        for t in resolve_module_targets(&sub, &known) {
+                        for t in resolve_module_targets(&sub, known) {
                             if !all.contains(&t) {
                                 all.push(t);
                             }
@@ -122,7 +122,7 @@ fn resolve_relative_import(py_meta: &PythonMeta, ctx: &ResolveContext<'_>) -> Re
                 };
             }
             let sub = normalize_lexical(&format!("{current}/{name}"));
-            let targets = resolve_module_targets(&sub, &known);
+            let targets = resolve_module_targets(&sub, known);
             if !targets.is_empty() {
                 let mut all = targets;
                 let sub_init = normalize_lexical(&format!("{sub}/__init__.py"));
@@ -162,7 +162,7 @@ fn resolve_absolute_import_fallback(
     let known = ctx.project.known_file_set();
     for root in &roots {
         let base = normalize_lexical(&format!("{root}/{path}"));
-        let targets = resolve_module_targets(&base, &known);
+        let targets = resolve_module_targets(&base, known);
         if !targets.is_empty() {
             return Resolution::Resolved(targets);
         }
@@ -189,13 +189,13 @@ fn resolve_module_in_roots(
 
     for root in &roots {
         let base = normalize_lexical(&format!("{root}/{module_path}"));
-        let targets = resolve_module_targets(&base, &known);
+        let targets = resolve_module_targets(&base, known);
         if !targets.is_empty() {
             let mut all = targets;
             if !py_meta.names.is_empty() && py_meta.names[0] != "*" {
                 for name in &py_meta.names {
                     let sub = normalize_lexical(&format!("{base}/{name}"));
-                    for t in resolve_module_targets(&sub, &known) {
+                    for t in resolve_module_targets(&sub, known) {
                         if !all.contains(&t) {
                             all.push(t);
                         }

--- a/src-agent/src/linker/scan.rs
+++ b/src-agent/src/linker/scan.rs
@@ -171,7 +171,8 @@ pub fn scan_roots(roots: &[PathBuf]) -> (ImportGraph, ProjectIndex) {
     }
 
     // Build the known_files set from the ProjectIndex for resolution.
-    let known_files: HashSet<String> = index.known_file_set();
+    // NOTE: deferred until after reclassification block to avoid borrow conflict.
+    // The reclassification block mutates `index`, so we cannot hold a borrow.
 
     // Phase 3: reclassify .h files using compile DB header language detection.
     // Without this, .h files are always Lang::C.  When compile DB owns a .h
@@ -209,6 +210,8 @@ pub fn scan_roots(roots: &[PathBuf]) -> (ImportGraph, ProjectIndex) {
         }
     }
 
+    let known_files = index.known_file_set();
+
     for sf in &source_files {
         let lang = detect_lang(&sf.rel_path);
         if lang == Lang::Unknown {
@@ -232,7 +235,7 @@ pub fn scan_roots(roots: &[PathBuf]) -> (ImportGraph, ProjectIndex) {
 
         if lang == Lang::Rust {
             let structured = extract_rust_imports(&content);
-            let ctx = compute_module_context(&sf.abs_path, owner_path, &known_files);
+            let ctx = compute_module_context(&sf.abs_path, owner_path, known_files);
             for ri in &structured {
                 let is_mod = ri.kind == RustImportKind::Mod;
                 let edge_kind = if is_mod {
@@ -252,10 +255,10 @@ pub fn scan_roots(roots: &[PathBuf]) -> (ImportGraph, ProjectIndex) {
                         ri.path_attr.as_deref(),
                         &sf.abs_path,
                         &ctx,
-                        &known_files,
+                        known_files,
                     )
                 } else {
-                    resolve_rust_use(&ri.raw, &sf.abs_path, &ctx, &known_files)
+                    resolve_rust_use(&ri.raw, &sf.abs_path, &ctx, known_files)
                 };
 
                 // mod declarations are always local (inherently module-scoped).
@@ -357,7 +360,7 @@ pub fn scan_roots(roots: &[PathBuf]) -> (ImportGraph, ProjectIndex) {
                     let ctx = CFamilyResolveContext {
                         importer_path: &sf.abs_path,
                         compile_flags: entry_flags_ref,
-                        known_files: &known_files,
+                        known_files,
                         owner_root: owner,
                     };
                     c_family::resolve_c_include(import_ref, &ctx)
@@ -366,7 +369,7 @@ pub fn scan_roots(roots: &[PathBuf]) -> (ImportGraph, ProjectIndex) {
                         importer_path: &sf.abs_path,
                         ts_config,
                         package_json: package_json_info,
-                        known_files: &known_files,
+                        known_files,
                         owner_root: owner,
                     };
                     js_ts::resolve_js_ts_import(import_ref, &ctx)
@@ -433,7 +436,7 @@ pub fn scan_roots(roots: &[PathBuf]) -> (ImportGraph, ProjectIndex) {
         } else {
             let raw_imports = extract_imports_for_file(lang, &sf.abs_path, &content);
             for raw in &raw_imports {
-                let resolved = resolve_import(lang, raw, &sf.abs_path, owner_path, &known_files);
+                let resolved = resolve_import(lang, raw, &sf.abs_path, owner_path, known_files);
 
                 let local = is_local_looking_import(lang, raw);
                 match resolved {
@@ -524,7 +527,7 @@ pub fn scan_file(
 
     if lang == Lang::Rust {
         let structured = extract_rust_imports(&content);
-        let ctx = compute_module_context(&path_str, owner_path, &known_files);
+        let ctx = compute_module_context(&path_str, owner_path, known_files);
         for ri in &structured {
             let is_mod = ri.kind == RustImportKind::Mod;
             let edge_kind = if is_mod {
@@ -544,10 +547,10 @@ pub fn scan_file(
                     ri.path_attr.as_deref(),
                     &path_str,
                     &ctx,
-                    &known_files,
+                    known_files,
                 )
             } else {
-                resolve_rust_use(&ri.raw, &path_str, &ctx, &known_files)
+                resolve_rust_use(&ri.raw, &path_str, &ctx, known_files)
             };
 
             // mod declarations are always local (inherently module-scoped).
@@ -647,7 +650,7 @@ pub fn scan_file(
                 let ctx = CFamilyResolveContext {
                     importer_path: &path_str,
                     compile_flags: entry_flags_ref,
-                    known_files: &known_files,
+                    known_files,
                     owner_root: &owner,
                 };
                 c_family::resolve_c_include(import_ref, &ctx)
@@ -656,7 +659,7 @@ pub fn scan_file(
                     importer_path: &path_str,
                     ts_config,
                     package_json: package_json_info,
-                    known_files: &known_files,
+                    known_files,
                     owner_root: &owner,
                 };
                 js_ts::resolve_js_ts_import(import_ref, &ctx)
@@ -718,7 +721,7 @@ pub fn scan_file(
     } else {
         let raw_imports = extract_imports_for_file(lang, &path_str, &content);
         for raw in &raw_imports {
-            let resolved = resolve_import(lang, raw, &path_str, owner_path, &known_files);
+            let resolved = resolve_import(lang, raw, &path_str, owner_path, known_files);
 
             let local = is_local_looking_import(lang, raw);
             match resolved {


### PR DESCRIPTION
…on churn

known_file_set() previously cloned all file keys into a new HashSet on every call. With N files and M total imports, this caused O(N² + M×N) string allocations per scan cycle. The allocator retains freed pages, causing monotonic RSS growth (observed: 9+ GB in linker daemon).

Fix: cache the HashSet as a field in ProjectIndex, rebuilt only on add_file/remove_file. Return &HashSet instead of owned HashSet. All 12 call sites updated to use the borrowed reference.

Files changed: project.rs, scan.rs, resolve/go.rs, resolve/python.rs