### PR TITLE
fix: sidebar Overview link no longer active on every section page

### DIFF
--- a/src-docs/src/components/Sidebar.tsx
+++ b/src-docs/src/components/Sidebar.tsx
@@ -191,7 +191,7 @@ function detectProduct(pathname: string): ProductDef {
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function isActive(pathname: string, to: string): boolean {
-  return pathname === to || pathname.startsWith(to + '/')
+  return pathname === to
 }
 
 function filterItem(item: SidebarItem, q: string): boolean {


### PR DESCRIPTION
The isActive helper used a prefix match (startsWith) which made Overview links highlight on all sibling pages. Changed to exact match since every nav link is a leaf node.