### PR TITLE
fix(gui): stop remote connect at host-ready hub

### DIFF
--- a/src-agent/src/app/runtime/client/host.rs
+++ b/src-agent/src/app/runtime/client/host.rs
@@ -44,6 +44,11 @@ use super::{push_loop, render, HostCtl, StreamView};
 enum HostStep {
     /// Show the detached session swapper (the hub) and wait for a pick.
     Swapper,
+    /// Host is live (auth+bootstrap done); show remote hub and wait for session/folder pick.
+    /// No SSH `koma server` child yet — path listing and session attach use `ctx`.
+    RemoteHub {
+        ctx: Box<super::remote_ctl::RemoteCtx>,
+    },
     /// Attach to this session UUID and fold its frames into pushes. `workdir` is the
     /// folder a GUI `[+ new session]` native-picker chose (the new session's working
     /// dir); `None` for every other attach (existing pick, `--session` boot, daemon
@@ -52,6 +57,13 @@ enum HostStep {
         id: String,
         workdir: Option<std::path::PathBuf>,
     },
+    /// SSH-attach a remote session using a retained host context.
+    RemoteAttach {
+        ctx: Box<super::remote_ctl::RemoteCtx>,
+        session_id: String,
+        cwd: Option<String>,
+    },
+    /// Live SSH-bridged remote session.
     Remote {
         active: Box<super::remote_ctl::ActiveRemote>,
         session_id: String,
@@ -185,6 +197,35 @@ pub(in crate::app::runtime) fn run_host_relay(
                 &ctl_rx,
                 &mut push_state,
                 current_session_id.as_deref(),
+                &terminal_manager,
+            ),
+            HostStep::RemoteHub { ctx } => host_remote_hub(
+                &handle,
+                &push,
+                &ctl_tx,
+                &ctl_rx,
+                &mut push_state,
+                &mut current_session_id,
+                *ctx,
+                &terminal_manager,
+            ),
+            HostStep::RemoteAttach {
+                ctx,
+                session_id,
+                cwd,
+            } => host_remote_attach(
+                &handle,
+                &push,
+                &ctl_tx,
+                &ctl_rx,
+                &live_req,
+                &live_marks,
+                &live_view,
+                &mut push_state,
+                &mut current_session_id,
+                *ctx,
+                session_id,
+                cwd,
                 &terminal_manager,
             ),
             HostStep::Remote { active, session_id } => host_remote(
@@ -333,13 +374,13 @@ fn host_swapper<P: Fn(String) + Clone + Send + 'static>(
     let mut oauth_task: Option<tokio::task::AbortHandle> = None;
     let (remote_state_tx, remote_state_rx) =
         std::sync::mpsc::channel::<super::remote_ctl::RemoteStateUpdate>();
-    let (remote_connected_tx, remote_connected_rx) =
-        std::sync::mpsc::channel::<super::remote_ctl::ActiveRemote>();
+    let (remote_ready_tx, remote_ready_rx) =
+        std::sync::mpsc::channel::<super::remote_ctl::ReadyRemote>();
     let remote_shared = std::sync::Arc::new(super::remote_ctl::RemoteSessionShared::new());
 
     loop {
-        // Push worker state first so `connected` clears the GUI's connection
-        // overlay before the remote Snapshot starts rendering.
+        // Push worker state first so `ready` clears the GUI's connection
+        // overlay before the remote hub starts rendering.
         while let Ok(update) = remote_state_rx.try_recv() {
             if !remote_shared.is_current(update.attempt_id) {
                 continue;
@@ -355,18 +396,23 @@ fn host_swapper<P: Fn(String) + Clone + Send + 'static>(
                 &update.sessions,
             );
         }
-        while let Ok(mut active) = remote_connected_rx.try_recv() {
-            if !remote_shared.is_current(active.attempt_id) {
-                let _ = handle.block_on(async { active.ssh_child.kill().await });
+        while let Ok(ready) = remote_ready_rx.try_recv() {
+            if !remote_shared.is_current(ready.attempt_id) {
                 continue;
             }
-            let session_id = match &active.connection.transport {
-                super::connect::TransportKind::Remote { session_id, .. }
-                | super::connect::TransportKind::Local { session_id } => session_id.clone(),
-            };
-            return HostStep::Remote {
-                active: Box::new(active),
-                session_id,
+            // Re-push ready with sessions in case the last state update raced.
+            push_remote_state(
+                push,
+                "ready",
+                Some(&ready.ctx.host_id),
+                Some(&ready.ctx.target.user),
+                Some(&ready.ctx.target.host),
+                None,
+                None,
+                &ready.sessions,
+            );
+            return HostStep::RemoteHub {
+                ctx: Box::new(ready.ctx),
             };
         }
 
@@ -1070,10 +1116,11 @@ fn host_swapper<P: Fn(String) + Clone + Send + 'static>(
                     .hosts
                     .iter()
                     .map(|h| {
+                        // Live = current remoteState host; historical last_connected is separate.
                         serde_json::json!({
                             "id": h.id, "name": h.name, "user": h.user, "host": h.host,
                             "port": h.port, "keyPath": h.key_path,
-                            "connected": h.last_connected.is_some(),
+                            "connected": false,
                             "lastConnected": h.last_connected,
                             "tags": h.tags,
                         })
@@ -1102,7 +1149,7 @@ fn host_swapper<P: Fn(String) + Clone + Send + 'static>(
                     attempt_id,
                     host_id,
                     remote_state_tx.clone(),
-                    remote_connected_tx.clone(),
+                    remote_ready_tx.clone(),
                     pw_rx,
                     cancelled,
                     std::sync::Arc::clone(&remote_shared),
@@ -1249,6 +1296,16 @@ fn host_attached(
 fn transition_to_step(transition: push_loop::HostTransition) -> HostStep {
     match transition {
         push_loop::HostTransition::Attach { id, workdir } => HostStep::Attach { id, workdir },
+        push_loop::HostTransition::ToRemoteHub { ctx } => HostStep::RemoteHub { ctx },
+        push_loop::HostTransition::RemoteAttach {
+            ctx,
+            session_id,
+            cwd,
+        } => HostStep::RemoteAttach {
+            ctx,
+            session_id,
+            cwd,
+        },
         push_loop::HostTransition::Remote {
             connection,
             session_id,
@@ -1256,8 +1313,359 @@ fn transition_to_step(transition: push_loop::HostTransition) -> HostStep {
             active: connection,
             session_id,
         },
-        push_loop::HostTransition::ToSwapper => HostStep::Swapper,
+        push_loop::HostTransition::DisconnectRemote | push_loop::HostTransition::ToSwapper => {
+            HostStep::Swapper
+        }
         push_loop::HostTransition::Exit => HostStep::Done,
+    }
+}
+
+/// Wire `RemoteHosts` list. `live_host_id` marks the currently retained remote ctx
+/// (ready/connecting/connected) so the green dot means live, not historical.
+fn push_remote_hosts_list(push: &dyn Fn(String), live_host_id: Option<&str>) {
+    let hosts = crate::remote::hosts::load_hosts();
+    let wire_hosts: Vec<serde_json::Value> = hosts
+        .hosts
+        .iter()
+        .map(|h| {
+            let live = live_host_id.is_some_and(|id| id == h.id);
+            serde_json::json!({
+                "id": h.id, "name": h.name, "user": h.user, "host": h.host,
+                "port": h.port, "keyPath": h.key_path,
+                "connected": live,
+                "lastConnected": h.last_connected,
+                "tags": h.tags,
+            })
+        })
+        .collect();
+    let envelope = serde_json::json!({ "k": "RemoteHosts", "hosts": wire_hosts });
+    if let Ok(json) = serde_json::to_string(&envelope) {
+        push(json);
+    }
+}
+
+/// Detached remote hub: host is authenticated, no session SSH child yet.
+/// User picks an existing remote session or opens a folder (path picker — Phase 2).
+#[allow(clippy::too_many_arguments)]
+fn host_remote_hub<P: Fn(String) + Clone + Send + 'static>(
+    handle: &tokio::runtime::Handle,
+    push: &P,
+    ctl_tx: &std::sync::mpsc::Sender<HostCtl>,
+    ctl_rx: &std::sync::mpsc::Receiver<HostCtl>,
+    push_state: &mut push_loop::PushState,
+    current: &mut Option<String>,
+    ctx: super::remote_ctl::RemoteCtx,
+    terminal_manager: &std::sync::Arc<std::sync::Mutex<super::terminal_host::TerminalManager>>,
+) -> HostStep {
+    *current = None;
+    push_state.reset();
+
+    // Remote hub: cooking sessions on this host, empty local history.
+    let hub = super::swapper::build_remote_hub(&ctx.target, ctx.password(), None);
+    push_hub(&hub, push, push_state);
+    push_swapper_config(push, push_state);
+    push_remote_hosts_list(push, Some(&ctx.host_id));
+
+    let (remote_state_tx, remote_state_rx) =
+        std::sync::mpsc::channel::<super::remote_ctl::RemoteStateUpdate>();
+    // Session attach from hub is handled by returning RemoteAttach; no connected_rx here.
+    let remote_shared = std::sync::Arc::new(super::remote_ctl::RemoteSessionShared::new());
+    let oauth_task: Option<tokio::task::AbortHandle> = None;
+    let _ = (remote_state_tx, ctl_tx); // reserved for phase-2 path workers / parity
+
+    loop {
+        while let Ok(update) = remote_state_rx.try_recv() {
+            if !remote_shared.is_current(update.attempt_id) {
+                continue;
+            }
+            push_remote_state(
+                push,
+                &update.state,
+                update.host_id.as_deref(),
+                update.user.as_deref(),
+                update.host.as_deref(),
+                update.session_id.as_deref(),
+                update.error.as_deref(),
+                &update.sessions,
+            );
+        }
+
+        match ctl_rx.recv_timeout(std::time::Duration::from_millis(16)) {
+            Ok(HostCtl::Ready) | Ok(HostCtl::RefreshHub) | Ok(HostCtl::ToSwapper) => {
+                let hub = super::swapper::build_remote_hub(&ctx.target, ctx.password(), None);
+                push_state.reset();
+                push_hub(&hub, push, push_state);
+                push_swapper_config(push, push_state);
+                // Keep remoteState = ready so the GUI stays in remote mode.
+                push_remote_state(
+                    push,
+                    "ready",
+                    Some(&ctx.host_id),
+                    Some(&ctx.target.user),
+                    Some(&ctx.target.host),
+                    None,
+                    None,
+                    &[],
+                );
+                push_remote_hosts_list(push, Some(&ctx.host_id));
+            }
+            Ok(HostCtl::Select(id)) => {
+                // Existing remote cooking session — attach without minting cwd.
+                return HostStep::RemoteAttach {
+                    ctx: Box::new(ctx),
+                    session_id: id,
+                    cwd: None,
+                };
+            }
+            Ok(HostCtl::New { .. }) => {
+                // Phase 2 wires RequestRemotePath; for now surface the path-picker error
+                // path so the UI does not fall into a local new-session.
+                let envelope = serde_json::json!({
+                    "k": "RemotePathPicker",
+                    "state": "error",
+                    "error": "open a remote folder (path picker not yet wired)"
+                });
+                if let Ok(json) = serde_json::to_string(&envelope) {
+                    push(json);
+                }
+            }
+            Ok(HostCtl::DisconnectRemote) | Ok(HostCtl::CancelRemoteConnect) => {
+                remote_shared.cancel();
+                push_remote_state(push, "disconnected", None, None, None, None, None, &[]);
+                push_remote_hosts_list(push, None);
+                return HostStep::Swapper;
+            }
+            Ok(HostCtl::ConnectRemote { host_id }) => {
+                // Switch host: drop current ctx, let the local swapper start connect.
+                // (Phase 4 may disconnect-then-connect inline; Phase 1 returns to swapper
+                // after pushing disconnect so the user can reconnect.)
+                if host_id == ctx.host_id {
+                    // Already on this host — refresh hub.
+                    let hub = super::swapper::build_remote_hub(&ctx.target, ctx.password(), None);
+                    push_hub(&hub, push, push_state);
+                    continue;
+                }
+                push_remote_state(push, "disconnected", None, None, None, None, None, &[]);
+                push_remote_hosts_list(push, None);
+                // Re-queue the connect so host_swapper picks it up.
+                let _ = ctl_tx.send(HostCtl::ConnectRemote { host_id });
+                return HostStep::Swapper;
+            }
+            Ok(HostCtl::SubmitRemotePassword { .. }) => {
+                // No in-flight password wait on the hub.
+            }
+            Ok(HostCtl::RequestRemotePath)
+            | Ok(HostCtl::ListRemotePath { .. })
+            | Ok(HostCtl::ConfirmRemotePath { .. })
+            | Ok(HostCtl::CancelRemotePath) => {
+                // Phase 2 implements these against ctx.
+                let envelope = serde_json::json!({
+                    "k": "RemotePathPicker",
+                    "state": "error",
+                    "error": "path picker not yet wired"
+                });
+                if let Ok(json) = serde_json::to_string(&envelope) {
+                    push(json);
+                }
+            }
+            Ok(HostCtl::ConfigMutate(req)) => {
+                apply_swapper_config_mutation(&req, push, push_state);
+            }
+            Ok(HostCtl::ListModels { provider }) => {
+                let push2 = P::clone(push);
+                handle.spawn(async move {
+                    let models = fetch_models_for_provider(&provider).await;
+                    push_model_list(&push2, provider, models);
+                });
+            }
+            Ok(HostCtl::ListRoutes { provider, model_id }) => {
+                let push2 = P::clone(push);
+                handle.spawn(async move {
+                    let routes = fetch_routes_for_provider(&provider, &model_id).await;
+                    push_route_list(&push2, provider, model_id, routes);
+                });
+            }
+            Ok(HostCtl::GetRemoteHosts)
+            | Ok(HostCtl::AddRemoteHost { .. })
+            | Ok(HostCtl::EditRemoteHost { .. })
+            | Ok(HostCtl::DeleteRemoteHost { .. }) => {
+                // Re-emit hosts with live connected flag for this ctx.
+                // Mutations intentionally deferred — hub stays on current host.
+                push_remote_hosts_list(push, Some(&ctx.host_id));
+            }
+            Ok(HostCtl::TerminalCreate { id, cwd }) => {
+                if let Ok(mut mgr) = terminal_manager.lock() {
+                    if let Err(e) = mgr.create(id, cwd) {
+                        crate::model::store::append_global_error_log(
+                            "terminal",
+                            &format!("terminal create failed: {e}"),
+                        );
+                    }
+                }
+            }
+            Ok(HostCtl::TerminalInput { id, data }) => {
+                if let Ok(mut mgr) = terminal_manager.lock() {
+                    mgr.input(&id, &data);
+                }
+            }
+            Ok(HostCtl::TerminalResize { id, cols, rows }) => {
+                if let Ok(mut mgr) = terminal_manager.lock() {
+                    mgr.resize(&id, cols, rows);
+                }
+            }
+            Ok(HostCtl::TerminalKill { id }) => {
+                if let Ok(mut mgr) = terminal_manager.lock() {
+                    mgr.kill(&id);
+                }
+            }
+            // Everything else is no-op on the detached remote hub (local git/store/
+            // coding/oauth ctls don't apply until a session is attached).
+            Ok(_) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return HostStep::Done,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+        }
+        let _ = &oauth_task;
+    }
+}
+
+/// Spawn SSH `koma server` for a remote session and enter the attached remote fold.
+#[allow(clippy::too_many_arguments)]
+fn host_remote_attach(
+    handle: &tokio::runtime::Handle,
+    push: &dyn Fn(String),
+    ctl_tx: &std::sync::mpsc::Sender<HostCtl>,
+    ctl_rx: &std::sync::mpsc::Receiver<HostCtl>,
+    live_req: &std::sync::Arc<std::sync::Mutex<Option<std::sync::mpsc::Sender<ClientRequest>>>>,
+    live_marks: &std::sync::Arc<std::sync::Mutex<Vec<usize>>>,
+    live_view: &std::sync::Arc<std::sync::Mutex<StreamView>>,
+    push_state: &mut push_loop::PushState,
+    current: &mut Option<String>,
+    ctx: super::remote_ctl::RemoteCtx,
+    session_id: String,
+    cwd: Option<String>,
+    terminal_manager: &std::sync::Arc<std::sync::Mutex<super::terminal_host::TerminalManager>>,
+) -> HostStep {
+    let (remote_state_tx, remote_state_rx) =
+        std::sync::mpsc::channel::<super::remote_ctl::RemoteStateUpdate>();
+    let (remote_connected_tx, remote_connected_rx) =
+        std::sync::mpsc::channel::<super::remote_ctl::ActiveRemote>();
+    let remote_shared = std::sync::Arc::new(super::remote_ctl::RemoteSessionShared::new());
+
+    // begin() needs a password channel even when unused (key auth).
+    let (pw_tx, _pw_rx) = std::sync::mpsc::channel::<String>();
+    let (attempt_id, cancelled) = remote_shared.begin(pw_tx);
+
+    push_switching(push, &session_id);
+    push_remote_state(
+        push,
+        "connecting",
+        Some(&ctx.host_id),
+        Some(&ctx.target.user),
+        Some(&ctx.target.host),
+        Some(&session_id),
+        None,
+        &[],
+    );
+
+    // Keep a clone so attach failure can return to the remote hub.
+    let hub_ctx = ctx.clone();
+    super::remote_ctl::spawn_session_worker(
+        attempt_id,
+        ctx,
+        session_id.clone(),
+        cwd,
+        remote_state_tx,
+        remote_connected_tx,
+        cancelled,
+        std::sync::Arc::clone(&remote_shared),
+        handle.clone(),
+    );
+
+    // Wait for ActiveRemote or error/cancel. Drain ctl for cancel.
+    loop {
+        while let Ok(update) = remote_state_rx.try_recv() {
+            if !remote_shared.is_current(update.attempt_id) {
+                continue;
+            }
+            push_remote_state(
+                push,
+                &update.state,
+                update.host_id.as_deref(),
+                update.user.as_deref(),
+                update.host.as_deref(),
+                update.session_id.as_deref(),
+                update.error.as_deref(),
+                &update.sessions,
+            );
+            if update.state == "error" {
+                // Stay on the remote host — user can pick another session.
+                push_remote_state(
+                    push,
+                    "ready",
+                    Some(&hub_ctx.host_id),
+                    Some(&hub_ctx.target.user),
+                    Some(&hub_ctx.target.host),
+                    None,
+                    None,
+                    &[],
+                );
+                *current = None;
+                return HostStep::RemoteHub {
+                    ctx: Box::new(hub_ctx),
+                };
+            }
+        }
+        while let Ok(mut active) = remote_connected_rx.try_recv() {
+            if !remote_shared.is_current(active.attempt_id) {
+                let _ = handle.block_on(async { active.ssh_child.kill().await });
+                continue;
+            }
+            let sid = match &active.connection.transport {
+                super::connect::TransportKind::Remote { session_id, .. }
+                | super::connect::TransportKind::Local { session_id } => session_id.clone(),
+            };
+            return host_remote(
+                handle,
+                push,
+                ctl_tx,
+                ctl_rx,
+                live_req,
+                live_marks,
+                live_view,
+                push_state,
+                current,
+                active,
+                sid,
+                terminal_manager,
+            );
+        }
+
+        match ctl_rx.recv_timeout(std::time::Duration::from_millis(16)) {
+            Ok(HostCtl::DisconnectRemote) | Ok(HostCtl::CancelRemoteConnect) => {
+                remote_shared.cancel();
+                // Cancel mid-attach: keep host ctx, return to hub.
+                push_remote_state(
+                    push,
+                    "ready",
+                    Some(&hub_ctx.host_id),
+                    Some(&hub_ctx.target.user),
+                    Some(&hub_ctx.target.host),
+                    None,
+                    None,
+                    &[],
+                );
+                *current = None;
+                return HostStep::RemoteHub {
+                    ctx: Box::new(hub_ctx),
+                };
+            }
+            Ok(HostCtl::SubmitRemotePassword { password }) => {
+                remote_shared.submit_password(password);
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return HostStep::Done,
+            // Ignore other ctls while attaching.
+            Ok(_) | Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+        }
     }
 }
 
@@ -1309,7 +1717,58 @@ fn host_remote(
     }
     super::teardown_connection(handle, active.connection);
     let _ = handle.block_on(async { active.ssh_child.kill().await });
-    push_remote_state(push, "disconnected", None, None, None, None, None, &[]);
-    *current = None;
-    transition_to_step(transition)
+
+    // Keep RemoteCtx unless the transition is a full disconnect / local swapper / exit.
+    match transition {
+        push_loop::HostTransition::ToRemoteHub { .. } => {
+            // push_loop may not yet pass ctx; reconstruct hub from active.ctx.
+            push_remote_state(
+                push,
+                "ready",
+                Some(&active.ctx.host_id),
+                Some(&active.ctx.target.user),
+                Some(&active.ctx.target.host),
+                None,
+                None,
+                &[],
+            );
+            *current = None;
+            HostStep::RemoteHub {
+                ctx: Box::new(active.ctx),
+            }
+        }
+        push_loop::HostTransition::RemoteAttach {
+            session_id,
+            cwd,
+            ..
+        } => {
+            *current = None;
+            HostStep::RemoteAttach {
+                ctx: Box::new(active.ctx),
+                session_id,
+                cwd,
+            }
+        }
+        push_loop::HostTransition::Remote {
+            connection,
+            session_id,
+        } => {
+            // Another remote attach completed inside push_loop (rare).
+            *current = None;
+            HostStep::Remote {
+                active: connection,
+                session_id,
+            }
+        }
+        push_loop::HostTransition::DisconnectRemote
+        | push_loop::HostTransition::ToSwapper
+        | push_loop::HostTransition::Exit
+        | push_loop::HostTransition::Attach { .. } => {
+            // Full leave remote: drop ctx, clear state.
+            drop(active.ctx);
+            push_remote_state(push, "disconnected", None, None, None, None, None, &[]);
+            *current = None;
+            transition_to_step(transition)
+        }
+    }
 }

--- a/src-agent/src/app/runtime/client/push_loop.rs
+++ b/src-agent/src/app/runtime/client/push_loop.rs
@@ -106,14 +106,28 @@ pub(super) enum HostTransition {
     /// Detach and show the local session swapper (the daemon's socket closed, or it
     /// signalled `OpenSwapper`). `run_host_relay` rebuilds the hub from discovery.
     ToSwapper,
+    /// Host is authenticated/bootstrapped; show the remote hub (no SSH session child).
+    ToRemoteHub {
+        ctx: Box<super::remote_ctl::RemoteCtx>,
+    },
+    /// SSH-attach a specific remote session (existing id, or a freshly minted one with cwd).
+    RemoteAttach {
+        ctx: Box<super::remote_ctl::RemoteCtx>,
+        session_id: String,
+        cwd: Option<String>,
+    },
+    /// Live SSH-bridged remote session (after session attach succeeded).
     Remote {
         connection: Box<super::remote_ctl::ActiveRemote>,
         session_id: String,
     },
+    /// Drop remote context and return to the local swapper.
+    DisconnectRemote,
     /// Attach to this local session UUID (a hub `SelectSession`/`NewSession`, or a daemon
     /// `NewSession` hand-off). A minted uuid for a new session; an existing id otherwise.
     /// `workdir` is the folder a GUI `[+ new session]` native picker chose (the new
     /// session's working dir); `None` for every other attach inherits the host's cwd.
+    /// Local-only — never used while a remote ctx is live.
     Attach {
         id: String,
         workdir: Option<std::path::PathBuf>,
@@ -296,13 +310,13 @@ pub(super) fn push_loop(
 
     // --- REMOTE HOST CONNECT/DISCONNECT ---
     // Worker thread pushes state transitions (resolving → auth_required →
-    // connecting → connected, etc.) over this channel; the loop drains and
-    // pushes them as `RemoteState` envelopes. Shared state holds the password
-    // and disconnect senders for in-flight operations.
+    // bootstrapping → ready, etc.) over this channel; the loop drains and
+    // pushes them as `RemoteState` envelopes. Host connect stops at ready
+    // (no SSH session child); session attach is a separate HostStep.
     let (remote_state_tx, remote_state_rx) =
         std::sync::mpsc::channel::<super::remote_ctl::RemoteStateUpdate>();
-    let (remote_connected_tx, remote_connected_rx) =
-        std::sync::mpsc::channel::<super::remote_ctl::ActiveRemote>();
+    let (remote_ready_tx, remote_ready_rx) =
+        std::sync::mpsc::channel::<super::remote_ctl::ReadyRemote>();
     let remote_shared = std::sync::Arc::new(super::remote_ctl::RemoteSessionShared::new());
 
     // Fold the handshake's prebuffered frames first, through the SAME `apply_frame`
@@ -1003,7 +1017,7 @@ pub(super) fn push_loop(
                             serde_json::json!({
                                 "id": h.id, "name": h.name, "user": h.user, "host": h.host,
                                 "port": h.port, "keyPath": h.key_path,
-                                "connected": h.last_connected.is_some(),
+                                "connected": false,
                                 "lastConnected": h.last_connected,
                                 "tags": h.tags,
                             })
@@ -1017,7 +1031,7 @@ pub(super) fn push_loop(
                 // ─── Remote host connect/disconnect ────────────────────────
                 Ok(super::HostCtl::ConnectRemote { host_id }) => {
                     // Create a password exchange channel. The worker returns the
-                    // established remote transport through `remote_connected_tx`.
+                    // ready host context through `remote_ready_tx` (no session yet).
                     let (pw_tx, pw_rx) = std::sync::mpsc::channel::<String>();
                     let (attempt_id, cancelled) = remote_shared.begin(pw_tx);
                     push_remote_state(
@@ -1034,7 +1048,7 @@ pub(super) fn push_loop(
                         attempt_id,
                         host_id,
                         remote_state_tx.clone(),
-                        remote_connected_tx.clone(),
+                        remote_ready_tx.clone(),
                         pw_rx,
                         cancelled,
                         std::sync::Arc::clone(&remote_shared),
@@ -1230,7 +1244,7 @@ pub(super) fn push_loop(
             super::push_proto::push_installed_ext_detail(push, id, detail, error);
         }
 
-        // --- REMOTE HOST CONNECT: push state transitions, then open the transport ---
+        // --- REMOTE HOST CONNECT: push state transitions, then hand off to remote hub ---
         while let Ok(update) = remote_state_rx.try_recv() {
             if !remote_shared.is_current(update.attempt_id) {
                 continue;
@@ -1246,19 +1260,23 @@ pub(super) fn push_loop(
                 &update.sessions,
             );
         }
-        while let Ok(mut active) = remote_connected_rx.try_recv() {
-            if !remote_shared.is_current(active.attempt_id) {
-                let _ = tokio::runtime::Handle::current()
-                    .block_on(async { active.ssh_child.kill().await });
+        while let Ok(ready) = remote_ready_rx.try_recv() {
+            if !remote_shared.is_current(ready.attempt_id) {
                 continue;
             }
-            let session_id = match &active.connection.transport {
-                super::connect::TransportKind::Remote { session_id, .. } => session_id.clone(),
-                super::connect::TransportKind::Local { session_id } => session_id.clone(),
-            };
-            return HostTransition::Remote {
-                connection: Box::new(active),
-                session_id,
+            push_remote_state(
+                push,
+                "ready",
+                Some(&ready.ctx.host_id),
+                Some(&ready.ctx.target.user),
+                Some(&ready.ctx.target.host),
+                None,
+                None,
+                &ready.sessions,
+            );
+            // Leave the current (local) session and enter the remote hub.
+            return HostTransition::ToRemoteHub {
+                ctx: Box::new(ready.ctx),
             };
         }
 

--- a/src-agent/src/app/runtime/client/push_proto.rs
+++ b/src-agent/src/app/runtime/client/push_proto.rs
@@ -691,9 +691,11 @@ pub(super) enum PushEnvelope {
     // ─── Remote host connect/disconnect ──────────────────────────────────────
     /// Remote connection state pushed to React. `state` is one of:
     /// `"disconnected"`, `"resolving"`, `"auth_required"`, `"bootstrapping"`,
-    /// `"connecting"`, `"connected"`, `"error"`. Carries host identity + optional
-    /// `sessionId` (set once connected) + optional `error` (set on `"error"`) +
-    /// optional `sessions` (list of live remote sessions).
+    /// `"ready"`, `"connecting"`, `"connected"`, `"error"`.
+    /// `ready` = host authenticated, no session attached yet (remote hub).
+    /// `connected` = SSH session child live. Carries host identity + optional
+    /// `sessionId` (set once a session is attached) + optional `error` (set on
+    /// `"error"`) + optional `sessions` (list of live remote sessions).
     #[serde(rename_all = "camelCase")]
     RemoteState {
         state: String,
@@ -1037,7 +1039,7 @@ pub(super) fn push_oauth_state(
 
 /// Emit a one-shot `RemoteState` envelope for the GUI remote-host panel.
 /// `state` is one of: `"disconnected"`, `"resolving"`, `"auth_required"`,
-/// `"bootstrapping"`, `"connecting"`, `"connected"`, `"error"`.
+/// `"bootstrapping"`, `"ready"`, `"connecting"`, `"connected"`, `"error"`.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn push_remote_state(
     push: &dyn Fn(String),

--- a/src-agent/src/app/runtime/client/remote_ctl.rs
+++ b/src-agent/src/app/runtime/client/remote_ctl.rs
@@ -1,12 +1,52 @@
 //! Remote host connect/disconnect worker for the GUI host-relay bridge.
 //!
-//! Blocking SSH/auth work runs on a dedicated thread. Every attempt has a fresh
-//! cancellation token and monotonically increasing id so late worker results
-//! cannot replace a newer transport.
+//! Blocking SSH/auth work runs on a dedicated thread. Host connect and session
+//! attach are separate: connect stops at `ready` with a retained [`RemoteCtx`];
+//! session attach SSHes `koma server` only after the user picks a session or
+//! folder. Every attempt has a fresh cancellation token and monotonically
+//! increasing id so late worker results cannot replace a newer transport.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, Mutex};
+
+use crate::remote::auth::SshAuth;
+use crate::remote::RemoteTarget;
+
+/// Retained remote-host context after auth+bootstrap succeed and before/while a
+/// session is attached. Lives only on the host-relay thread — never serialised
+/// into a PushEnvelope (password must not leave process memory as wire JSON).
+///
+/// Password is stored as a plain string (same as TUI `RemoteContext`) so the
+/// ctx can be cloned across hub ↔ attach transitions; each SSH op rebuilds a
+/// short-lived [`SshAuth`] askpass file.
+#[derive(Clone)]
+pub(super) struct RemoteCtx {
+    pub host_id: String,
+    pub target: RemoteTarget,
+    pub password: Option<String>,
+    pub koma_path: String,
+}
+
+impl RemoteCtx {
+    /// Password string for off-thread SSH helpers that must rebuild [`SshAuth`]
+    /// (askpass files are single-owner). `None` when key auth is in use.
+    pub fn password(&self) -> Option<&str> {
+        self.password.as_deref()
+    }
+
+    /// Build a short-lived askpass context for one SSH operation.
+    pub fn make_auth(&self) -> anyhow::Result<Option<SshAuth>> {
+        match self.password.as_ref() {
+            Some(pw) => Ok(Some(SshAuth::from_password(pw.clone())?)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn host_label(&self) -> String {
+        format!("{}@{}", self.target.user, self.target.host)
+    }
+}
 
 pub(super) struct RemoteSessionShared {
     password_tx: Mutex<Option<(u64, Sender<String>)>>,
@@ -103,10 +143,21 @@ pub(super) struct RemoteStateUpdate {
     pub sessions: Vec<serde_json::Value>,
 }
 
+/// Live SSH-bridged remote session (after the user picked a session/folder).
 pub(super) struct ActiveRemote {
     pub attempt_id: u64,
     pub connection: super::connect::Connection,
     pub ssh_child: tokio::process::Child,
+    /// Host context retained across session teardown so `/resume` can return to
+    /// the remote hub without re-authing.
+    pub ctx: RemoteCtx,
+}
+
+/// Outcome of the host-connect worker: host is ready, no session attached yet.
+pub(super) struct ReadyRemote {
+    pub attempt_id: u64,
+    pub ctx: RemoteCtx,
+    pub sessions: Vec<serde_json::Value>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -114,7 +165,7 @@ pub(super) fn spawn_connect_worker(
     attempt_id: u64,
     host_id: String,
     state_tx: Sender<RemoteStateUpdate>,
-    connected_tx: Sender<ActiveRemote>,
+    ready_tx: Sender<ReadyRemote>,
     pw_rx: Receiver<String>,
     cancelled: Arc<AtomicBool>,
     shared: Arc<RemoteSessionShared>,
@@ -125,7 +176,7 @@ pub(super) fn spawn_connect_worker(
             attempt_id,
             host_id,
             state_tx,
-            connected_tx,
+            ready_tx,
             pw_rx,
             cancelled,
             shared,
@@ -134,19 +185,64 @@ pub(super) fn spawn_connect_worker(
     });
 }
 
+/// Attach (or create) a remote session over SSH using a retained [`RemoteCtx`].
+#[allow(clippy::too_many_arguments)]
+pub(super) fn spawn_session_worker(
+    attempt_id: u64,
+    ctx: RemoteCtx,
+    session_id: String,
+    cwd: Option<String>,
+    state_tx: Sender<RemoteStateUpdate>,
+    connected_tx: Sender<ActiveRemote>,
+    cancelled: Arc<AtomicBool>,
+    shared: Arc<RemoteSessionShared>,
+    handle: tokio::runtime::Handle,
+) {
+    std::thread::spawn(move || {
+        remote_session_worker(
+            attempt_id,
+            ctx,
+            session_id,
+            cwd,
+            state_tx,
+            connected_tx,
+            cancelled,
+            shared,
+            handle,
+        );
+    });
+}
+
+fn sessions_to_json(
+    sessions: &[crate::remote::sessions::DiscoveredSession],
+) -> Vec<serde_json::Value> {
+    sessions
+        .iter()
+        .map(|session| {
+            serde_json::json!({
+                "sessionId": session.session_id,
+                "name": session.name,
+                "pwd": session.pwd,
+                "working": session.working,
+                "isForeground": session.is_foreground
+            })
+        })
+        .collect()
+}
+
 #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 fn remote_connect_worker(
     attempt_id: u64,
     host_id: String,
     state_tx: Sender<RemoteStateUpdate>,
-    connected_tx: Sender<ActiveRemote>,
+    ready_tx: Sender<ReadyRemote>,
     pw_rx: Receiver<String>,
     cancelled: Arc<AtomicBool>,
     shared: Arc<RemoteSessionShared>,
-    handle: tokio::runtime::Handle,
+    _handle: tokio::runtime::Handle,
 ) {
-    use crate::remote::auth::{self, AuthProbe, SshAuth};
-    use crate::remote::{bootstrap, ssh, RemoteTarget};
+    use crate::remote::auth::{self, AuthProbe};
+    use crate::remote::{bootstrap, ssh};
 
     let is_cancelled = || cancelled.load(Ordering::Acquire) || !shared.is_current(attempt_id);
     let push_state = {
@@ -215,7 +311,7 @@ fn remote_connect_worker(
         return;
     }
 
-    let auth = match auth::probe_key_auth(&target) {
+    let password = match auth::probe_key_auth(&target) {
         AuthProbe::KeyReady => {
             shared.clear_password(attempt_id);
             None
@@ -241,21 +337,28 @@ fn remote_connect_worker(
                 }
             };
             shared.clear_password(attempt_id);
-            match SshAuth::from_password(password) {
-                Ok(auth) => Some(auth),
-                Err(error) => {
-                    push_state(
-                        "error",
-                        Some(&user_str),
-                        Some(&host_str),
-                        None,
-                        Some(&format!("auth setup failed: {error:#}")),
-                        Vec::new(),
-                    );
-                    shared.finish(attempt_id);
-                    return;
-                }
-            }
+            Some(password)
+        }
+    };
+
+    // Short-lived askpass for bootstrap + find_koma + session list.
+    let auth = match password
+        .as_ref()
+        .map(|p| SshAuth::from_password(p.clone()))
+        .transpose()
+    {
+        Ok(auth) => auth,
+        Err(error) => {
+            push_state(
+                "error",
+                Some(&user_str),
+                Some(&host_str),
+                None,
+                Some(&format!("auth setup failed: {error:#}")),
+                Vec::new(),
+            );
+            shared.finish(attempt_id);
+            return;
         }
     };
 
@@ -289,19 +392,6 @@ fn remote_connect_worker(
         return;
     }
 
-    let session_id = uuid::Uuid::new_v4().to_string();
-    push_state(
-        "connecting",
-        Some(&user_str),
-        Some(&host_str),
-        None,
-        None,
-        Vec::new(),
-    );
-    if is_cancelled() {
-        shared.finish(attempt_id);
-        return;
-    }
     let koma_path = match ssh::find_koma(&target, auth_ref) {
         Ok(path) => path,
         Err(error) => {
@@ -317,18 +407,147 @@ fn remote_connect_worker(
             return;
         }
     };
+    if is_cancelled() {
+        shared.finish(attempt_id);
+        return;
+    }
+
+    let sessions = crate::remote::sessions::list_sessions_over_ssh(&target, auth_ref)
+        .map(|s| sessions_to_json(&s))
+        .unwrap_or_default();
+    // Drop askpass before retaining the password-only ctx.
+    drop(auth);
+    if is_cancelled() {
+        shared.finish(attempt_id);
+        return;
+    }
+
+    // Host is live — no session UUID, no `ssh::connect`. Session attach is a
+    // separate user action (pick existing id or open a remote folder).
+    push_state(
+        "ready",
+        Some(&user_str),
+        Some(&host_str),
+        None,
+        None,
+        sessions.clone(),
+    );
+
+    if is_cancelled() {
+        shared.finish(attempt_id);
+        return;
+    }
+    let mut hosts = crate::remote::hosts::load_hosts();
+    if let Some(host) = hosts.hosts.iter_mut().find(|host| host.id == host_id) {
+        host.touch_last_connected();
+        let _ = crate::remote::hosts::save_hosts(&hosts);
+    }
+    if is_cancelled() {
+        shared.finish(attempt_id);
+        return;
+    }
+    shared.finish(attempt_id);
+    let _ = ready_tx.send(ReadyRemote {
+        attempt_id,
+        ctx: RemoteCtx {
+            host_id,
+            target,
+            password,
+            koma_path,
+        },
+        sessions,
+    });
+}
+
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+fn remote_session_worker(
+    attempt_id: u64,
+    ctx: RemoteCtx,
+    session_id: String,
+    cwd: Option<String>,
+    state_tx: Sender<RemoteStateUpdate>,
+    connected_tx: Sender<ActiveRemote>,
+    cancelled: Arc<AtomicBool>,
+    shared: Arc<RemoteSessionShared>,
+    handle: tokio::runtime::Handle,
+) {
+    use crate::remote::ssh;
+
+    let is_cancelled = || cancelled.load(Ordering::Acquire) || !shared.is_current(attempt_id);
+    let user_str = ctx.target.user.clone();
+    let host_str = ctx.target.host.clone();
+    let host_id = ctx.host_id.clone();
+    let push_state = {
+        let host_id = host_id.clone();
+        let state_tx = state_tx.clone();
+        move |state: &str,
+              user: Option<&str>,
+              host: Option<&str>,
+              session_id: Option<&str>,
+              error: Option<&str>,
+              sessions: Vec<serde_json::Value>| {
+            if !is_cancelled() {
+                let _ = state_tx.send(RemoteStateUpdate {
+                    attempt_id,
+                    state: state.to_string(),
+                    host_id: Some(host_id.clone()),
+                    user: user.map(str::to_string),
+                    host: host.map(str::to_string),
+                    session_id: session_id.map(str::to_string),
+                    error: error.map(str::to_string),
+                    sessions,
+                });
+            }
+        }
+    };
+
+    push_state(
+        "connecting",
+        Some(&user_str),
+        Some(&host_str),
+        Some(&session_id),
+        None,
+        Vec::new(),
+    );
+    if is_cancelled() {
+        shared.finish(attempt_id);
+        return;
+    }
+
+    let auth = match ctx.make_auth() {
+        Ok(auth) => auth,
+        Err(error) => {
+            push_state(
+                "error",
+                Some(&user_str),
+                Some(&host_str),
+                Some(&session_id),
+                Some(&format!("auth setup failed: {error:#}")),
+                Vec::new(),
+            );
+            shared.finish(attempt_id);
+            return;
+        }
+    };
+    let auth_ref = auth.as_ref();
     // `ssh::connect` uses tokio::process::Command::spawn synchronously, so the
     // worker thread must have an entered runtime while spawning SSH.
     let ssh_session = {
         let _rt_ctx = handle.enter();
-        match ssh::connect(&target, &session_id, auth_ref, None, &koma_path) {
+        match ssh::connect(
+            &ctx.target,
+            &session_id,
+            auth_ref,
+            cwd.as_deref(),
+            &ctx.koma_path,
+        ) {
             Ok(session) => session,
             Err(error) => {
                 push_state(
                     "error",
                     Some(&user_str),
                     Some(&host_str),
-                    None,
+                    Some(&session_id),
                     Some(&format!("ssh connect failed: {error:#}")),
                     Vec::new(),
                 );
@@ -361,7 +580,7 @@ fn remote_connect_worker(
                 "error",
                 Some(&user_str),
                 Some(&host_str),
-                None,
+                Some(&session_id),
                 Some(&format!("bridge failed: {error:#}")),
                 Vec::new(),
             );
@@ -375,21 +594,8 @@ fn remote_connect_worker(
         return;
     }
 
-    let sessions = crate::remote::sessions::list_sessions_over_ssh(&target, auth_ref)
-        .map(|sessions| {
-            sessions
-                .iter()
-                .map(|session| {
-                    serde_json::json!({
-                        "sessionId": session.session_id,
-                        "name": session.name,
-                        "pwd": session.pwd,
-                        "working": session.working,
-                        "isForeground": session.is_foreground
-                    })
-                })
-                .collect()
-        })
+    let sessions = crate::remote::sessions::list_sessions_over_ssh(&ctx.target, auth_ref)
+        .map(|s| sessions_to_json(&s))
         .unwrap_or_default();
     if is_cancelled() {
         let _ = handle.block_on(async { child.kill().await });
@@ -410,21 +616,12 @@ fn remote_connect_worker(
         shared.finish(attempt_id);
         return;
     }
-    let mut hosts = crate::remote::hosts::load_hosts();
-    if let Some(host) = hosts.hosts.iter_mut().find(|host| host.id == host_id) {
-        host.touch_last_connected();
-        let _ = crate::remote::hosts::save_hosts(&hosts);
-    }
-    if is_cancelled() {
-        let _ = handle.block_on(async { child.kill().await });
-        shared.finish(attempt_id);
-        return;
-    }
     shared.finish(attempt_id);
     if let Err(error) = connected_tx.send(ActiveRemote {
         attempt_id,
         connection,
         ssh_child: child,
+        ctx,
     }) {
         let mut active = error.0;
         let _ = handle.block_on(async { active.ssh_child.kill().await });

--- a/src-agent/src/app/runtime/client/remote_ctl_test.rs
+++ b/src-agent/src/app/runtime/client/remote_ctl_test.rs
@@ -1,4 +1,5 @@
-use super::RemoteSessionShared;
+use super::{RemoteCtx, RemoteSessionShared};
+use crate::remote::RemoteTarget;
 
 #[test]
 fn new_attempt_rejects_old_generation_and_closes_password_channel() {
@@ -21,4 +22,40 @@ fn finish_clears_password_sender() {
     let (attempt, _) = shared.begin(tx);
     shared.finish(attempt);
     assert!(rx.recv().is_err());
+}
+
+#[test]
+fn remote_ctx_is_cloneable_and_make_auth_key_mode() {
+    let ctx = RemoteCtx {
+        host_id: "h1".into(),
+        target: RemoteTarget {
+            user: "u".into(),
+            host: "example.com".into(),
+            port: None,
+            key: None,
+        },
+        password: None,
+        koma_path: "/home/u/.local/bin/koma".into(),
+    };
+    let cloned = ctx.clone();
+    assert_eq!(cloned.host_label(), "u@example.com");
+    assert!(cloned.make_auth().unwrap().is_none());
+    assert!(ctx.password().is_none());
+}
+
+#[test]
+fn remote_ctx_make_auth_password_mode() {
+    let ctx = RemoteCtx {
+        host_id: "h1".into(),
+        target: RemoteTarget {
+            user: "u".into(),
+            host: "example.com".into(),
+            port: Some(2222),
+            key: None,
+        },
+        password: Some("secret".into()),
+        koma_path: "/usr/bin/koma".into(),
+    };
+    let auth = ctx.make_auth().unwrap().expect("password auth");
+    assert_eq!(auth.password(), "secret");
 }

--- a/src-webgui/src/components/NewSessionMenu.tsx
+++ b/src-webgui/src/components/NewSessionMenu.tsx
@@ -83,12 +83,34 @@ export function NewSessionMenu({ afterPick, className = '' }: NewSessionMenuProp
   }
 
   const connectRemote = (hostId: string, name: string) => {
-    if (remoteState.state !== 'disconnected' && remoteState.state !== 'error') {
-      // Already connecting/connected — let the user know why nothing happened.
+    if (
+      remoteState.state !== 'disconnected' &&
+      remoteState.state !== 'error' &&
+      remoteState.state !== 'ready'
+    ) {
+      // Already connecting — let the user know why nothing happened.
+      // `ready` is allowed: host is live on the remote hub (Phase 1 may still
+      // block switching hosts from the menu; Disconnect first).
       const s = useKoma.getState()
       const seq = s.ui.toastSeq + 1
       useKoma.setState((prev) => ({
         ui: { ...prev.ui, toastSeq: seq, toast: { id: seq, text: `Already ${remoteState.state.replace('_', ' ')}`, kind: 'error' } },
+      }))
+      return
+    }
+    if (remoteState.state === 'ready') {
+      const s = useKoma.getState()
+      const seq = s.ui.toastSeq + 1
+      useKoma.setState((prev) => ({
+        ui: {
+          ...prev.ui,
+          toastSeq: seq,
+          toast: {
+            id: seq,
+            text: 'Already on a remote host — disconnect first',
+            kind: 'error',
+          },
+        },
       }))
       return
     }
@@ -149,11 +171,21 @@ export function NewSessionMenu({ afterPick, className = '' }: NewSessionMenuProp
                   <MenuItem
                     key={host.id}
                     onClick={() => connectRemote(host.id, host.name)}
-                    disabled={remoteState.state !== 'disconnected' && remoteState.state !== 'error'}
+                    disabled={
+                      remoteState.state !== 'disconnected' && remoteState.state !== 'error'
+                    }
                     icon={
-                      remoteState.hostId === host.id && remoteState.state !== 'error' && remoteState.state !== 'disconnected'
-                        ? <BrailleSpinner size={13} />
-                        : <Link2 size={13} />
+                      remoteState.hostId === host.id &&
+                      ['resolving', 'auth_required', 'bootstrapping', 'connecting'].includes(
+                        remoteState.state,
+                      ) ? (
+                        <BrailleSpinner size={13} />
+                      ) : remoteState.hostId === host.id &&
+                        (remoteState.state === 'ready' || remoteState.state === 'connected') ? (
+                        <Link2 size={13} className="text-koma-success" />
+                      ) : (
+                        <Link2 size={13} />
+                      )
                     }
                   >
                     <span className="font-medium">{host.name}</span>

--- a/src-webgui/src/components/SwitchingOverlay.tsx
+++ b/src-webgui/src/components/SwitchingOverlay.tsx
@@ -136,7 +136,9 @@ function LoadingSplash({ workspace, awareness }: { workspace: LoadPhase; awarene
 export function SwitchingOverlay({ onCancel }: SwitchingOverlayProps) {
   const to = useKoma((s) => s.ui.switchingTo)
   const remoteState = useKoma((s) => s.remoteState)
-  const remoteConnecting = !!to?.startsWith('remote ') && !['connected', 'error', 'disconnected'].includes(remoteState.state)
+  const remoteConnecting =
+    !!to?.startsWith('remote ') &&
+    !['ready', 'connected', 'error', 'disconnected'].includes(remoteState.state)
   const loading = useKoma((s) => s.ui.loading)
   const loadingDismissed = useKoma((s) => s.ui.loadingDismissed)
   const dismissLoading = useKoma((s) => s.dismissLoading)

--- a/src-webgui/src/components/panels/RemotePanel.tsx
+++ b/src-webgui/src/components/panels/RemotePanel.tsx
@@ -23,8 +23,10 @@ const emptyDraft = (): RemoteHostDraft => ({
   keyPath: '',
 })
 
-/** States where the connection is in-progress (not idle). */
+/** States where the connection is in-progress (not idle, not ready hub). */
 const ACTIVE_STATES = ['resolving', 'auth_required', 'bootstrapping', 'connecting']
+/** Host is live (ctx retained) — green dot / disconnect available. */
+const LIVE_STATES = ['ready', 'connecting', 'connected']
 
 export function RemotePanel() {
   const remoteHosts = useKoma((s) => s.remoteHosts)
@@ -69,9 +71,14 @@ export function RemotePanel() {
     })
   }
   const isBusy = ACTIVE_STATES.includes(remoteState.state)
+  const isHostLive = (hostId: string) =>
+    remoteState.hostId === hostId && LIVE_STATES.includes(remoteState.state)
   const handleConnect = (hostId: string) => {
-    if (isBusy) return
+    if (isBusy || remoteState.state === 'ready' || remoteState.state === 'connected') return
     push({ r: 'ConnectRemoteHost', hostId })
+  }
+  const handleDisconnect = () => {
+    push({ r: 'DisconnectRemoteHost', hostId: remoteState.hostId ?? '' })
   }
   const confirmDelete = (hostId: string) => {
     push({ r: 'DeleteRemoteHost', id: hostId })
@@ -268,13 +275,21 @@ export function RemotePanel() {
               <div className="flex items-center gap-2 min-w-0">
                 <span
                   className={`inline-block h-2.5 w-2.5 flex-none rounded-full ${
-                    host.connected
+                    isHostLive(host.id) || host.connected
                       ? 'bg-koma-success'
                       : host.lastConnected
                         ? 'bg-koma-warn'
                         : 'bg-koma-dim'
                   }`}
-                  title={formatLastSeen(host.lastConnected)}
+                  title={
+                    isHostLive(host.id)
+                      ? remoteState.state === 'ready'
+                        ? 'Host ready'
+                        : remoteState.state === 'connected'
+                          ? 'Session attached'
+                          : 'Connecting…'
+                      : formatLastSeen(host.lastConnected)
+                  }
                 />
                 <div className="min-w-0">
                   <div className="flex items-center gap-1.5">
@@ -286,14 +301,24 @@ export function RemotePanel() {
                 </div>
               </div>
               <div className="flex items-center gap-1">
-                <button
-                  disabled={isBusy}
-                  className="p-1 text-koma-accent hover:text-koma-fg disabled:cursor-not-allowed disabled:opacity-40"
-                  title="Connect"
-                  onClick={() => handleConnect(host.id)}
-                >
-                  <Link2 size={14} />
-                </button>
+                {isHostLive(host.id) ? (
+                  <button
+                    className="rounded border border-koma-border px-2 py-0.5 text-[11px] text-koma-fg opacity-80 hover:bg-koma-hover hover:opacity-100"
+                    title="Disconnect"
+                    onClick={handleDisconnect}
+                  >
+                    Disconnect
+                  </button>
+                ) : (
+                  <button
+                    disabled={isBusy || remoteState.state === 'ready' || remoteState.state === 'connected'}
+                    className="p-1 text-koma-accent hover:text-koma-fg disabled:cursor-not-allowed disabled:opacity-40"
+                    title="Connect"
+                    onClick={() => handleConnect(host.id)}
+                  >
+                    <Link2 size={14} />
+                  </button>
+                )}
                 <button
                   disabled={isBusy}
                   className="p-1 text-koma-dim hover:text-koma-fg disabled:cursor-not-allowed disabled:opacity-40"

--- a/src-webgui/src/store/koma.ts
+++ b/src-webgui/src/store/koma.ts
@@ -1379,7 +1379,7 @@ export type PushEnvelope =
 
   // Remote connection state pushed to React. State transitions during the
   // SSH connect sequence: disconnected → resolving → auth_required |
-  // bootstrapping → connecting → connected | error.
+  // bootstrapping → ready (host live, remote hub) → connecting → connected | error.
   | {
       k: 'RemoteState'
       state: string
@@ -1388,7 +1388,13 @@ export type PushEnvelope =
       host?: string | null
       sessionId?: string | null
       error?: string | null
-      sessions?: Array<{ sessionId: string; name: string; working: boolean; isForeground: boolean }>
+      sessions?: Array<{
+        sessionId: string
+        name: string
+        pwd?: string
+        working: boolean
+        isForeground: boolean
+      }>
     }
   | {
       k: 'RemotePathPicker'
@@ -1995,7 +2001,13 @@ type KomaState = {
     host: string | null
     sessionId: string | null
     error: string | null
-    sessions: Array<{ sessionId: string; name: string; working: boolean; isForeground: boolean }>
+    sessions: Array<{
+      sessionId: string
+      name: string
+      pwd?: string
+      working: boolean
+      isForeground: boolean
+    }>
   }
   remotePath: {
     state: 'idle' | 'listing' | 'ready' | 'error' | 'cancelled'
@@ -4085,7 +4097,7 @@ export const useKoma = create<KomaState>((set, get) => ({
             error: env.error ?? null,
             sessions: env.sessions ?? [],
           }
-          if (env.state === 'connected' || env.state === 'disconnected') {
+          if (env.state === 'connected' || env.state === 'disconnected' || env.state === 'ready') {
             return { remoteState, ui: { ...s.ui, switchingTo: null } }
           }
           if (env.state === 'error') {


### PR DESCRIPTION
Split host connect from session attach so SSH bootstrap ends in a retained RemoteCtx + ready state instead of minting a blank session. Add RemoteHub/RemoteAttach host steps and wire GUI ready handling.