### PR TITLE
feat(gui): Tutorial tab with koma-free coach and driver.js tours

### DIFF
--- a/src-agent/src/app/runtime/client/host.rs
+++ b/src-agent/src/app/runtime/client/host.rs
@@ -36,6 +36,7 @@ use super::push_proto::{
     push_remote_state, push_route_list, push_settings_values, push_switching, push_usage_preview,
 };
 use super::store_host;
+use super::tutorial_host;
 use super::swapper::build_local_hub;
 use super::{push_loop, render, HostCtl, StreamView};
 
@@ -890,6 +891,9 @@ fn host_swapper<P: Fn(String) + Clone + Send + 'static>(
             // (shared with `push_loop`'s attached twin).
             Ok(HostCtl::StoreBrowse { query, category }) => {
                 store_host::spawn_store_browse(P::clone(push), query, category);
+            }
+            Ok(HostCtl::TutorialChat { id, messages }) => {
+                tutorial_host::spawn_tutorial_chat(P::clone(push), id, messages);
             }
             Ok(HostCtl::StoreDetail { id }) => {
                 store_host::spawn_store_detail(P::clone(push), id);

--- a/src-agent/src/app/runtime/client/mod.rs
+++ b/src-agent/src/app/runtime/client/mod.rs
@@ -29,6 +29,7 @@
 //! | `git_host`  | off-thread GIT/key `HostCtl` bodies shared by `host` + `push_loop` |
 //! | `git_host_mut` | `git_host`'s G5b destructive spawn flavors, split out for size |
 //! | `store_host` | off-thread extension-STORE browse/detail/installed-list `HostCtl` bodies shared by `host` + `push_loop` |
+//! | `tutorial_host` | off-thread GUI Tutorial koma-free chat `HostCtl` body shared by `host` + `push_loop` |
 //! | `host`      | GUI host-relay layer (`run_host_relay`, the swapper/attached FSM) |
 //! | `host_catalogue` | un-attached model/route/agents/oauth catalogue builders for `host` |
 //! | `host_config` | Pre-session (swapper) config-apply helpers for `host`           |
@@ -79,6 +80,7 @@ mod remote_ctl;
 mod render;
 mod shadow;
 mod store_host;
+pub(crate) mod tutorial_host;
 mod swapper;
 mod swapper_keys;
 mod terminal_host;
@@ -619,6 +621,12 @@ pub(super) enum HostCtl {
     GitActivity {
         path: Option<String>,
         limit: u32,
+    },
+    /// GUI Tutorial tab chat turn: thin host-local koma-free completion (no daemon,
+    /// no session). See `tutorial_host`. `id` is a client turn id echoed on the reply.
+    TutorialChat {
+        id: String,
+        messages: Vec<tutorial_host::TutorialMsg>,
     },
     /// Extension-STORE browse (Store tab search/filter, or a mount-time fetch on the
     /// home screen): fetch the koma.run catalogue. NEVER touches the daemon regardless

--- a/src-agent/src/app/runtime/client/push_loop.rs
+++ b/src-agent/src/app/runtime/client/push_loop.rs
@@ -24,11 +24,13 @@ use super::project_config::{push_config, ConfigProjection};
 use super::push_intercept;
 use super::push_proto::{
     push_analytics, push_ext_op_result, push_file_diff, push_installed_extensions,
-    push_remote_state, push_store_catalogue, push_store_detail, push_switching, push_usage_preview,
+    push_remote_state, push_store_catalogue, push_store_detail, push_switching, push_tutorial_chat_done,
+    push_usage_preview,
 };
 use super::render::{advance_local_animations, ConnectRemoteRequest, FRAME_BUDGET};
 use super::shadow::apply_frame;
 use super::store_host;
+use super::tutorial_host;
 
 /// Snapshot of the full `Status` envelope payload.
 /// `(working, toast, toast_kind, tokens_in, tokens_cached, tokens_out, cost, mode)`.
@@ -310,6 +312,11 @@ pub(super) fn push_loop(
         Option<crate::ipc::proto::InstalledExtensionDetailWire>,
         Option<String>,
     )>();
+
+    // --- GUI Tutorial chat (TutorialChat) ---
+    // Blocking koma-free HTTP; host-local regardless of attach state.
+    let (tutorial_chat_tx, tutorial_chat_rx) =
+        std::sync::mpsc::channel::<tutorial_host::TutorialChatResult>();
 
     // --- REMOTE HOST CONNECT/DISCONNECT ---
     // Worker thread pushes state transitions (resolving → auth_required →
@@ -923,6 +930,13 @@ pub(super) fn push_loop(
                         category,
                     );
                 }
+                Ok(super::HostCtl::TutorialChat { id, messages }) => {
+                    tutorial_host::spawn_tutorial_chat_attached(
+                        tutorial_chat_tx.clone(),
+                        id,
+                        messages,
+                    );
+                }
                 Ok(super::HostCtl::StoreDetail { id }) => {
                     store_host::spawn_store_detail_attached(store_detail_tx.clone(), id);
                 }
@@ -1359,6 +1373,10 @@ pub(super) fn push_loop(
         }
         while let Ok((id, detail, error)) = installed_detail_rx.try_recv() {
             super::push_proto::push_installed_ext_detail(push, id, detail, error);
+        }
+
+        while let Ok(result) = tutorial_chat_rx.try_recv() {
+            push_tutorial_chat_done(push, result.id, result.text, result.tour, result.error);
         }
 
         // --- REMOTE HOST CONNECT: push state transitions, then hand off to remote hub ---

--- a/src-agent/src/app/runtime/client/push_proto.rs
+++ b/src-agent/src/app/runtime/client/push_proto.rs
@@ -482,6 +482,18 @@ pub(super) enum PushEnvelope {
         ok: bool,
         error: Option<String>,
     },
+    /// One-shot reply to a GUI Tutorial tab chat turn (`GuiReq::TutorialChat`).
+    /// `id` echoes the client turn id; `text` is the coach reply with the TOUR
+    /// trailer stripped; `tour` is an optional tour id to offer; `error` is set
+    /// (and `text` empty) on network/parse failure so the tab can fall back to
+    /// static topics.
+    #[serde(rename_all = "camelCase")]
+    TutorialChatDone {
+        id: String,
+        text: String,
+        tour: Option<String>,
+        error: Option<String>,
+    },
     /// Full detail of one locally-installed extension — the reply to
     /// `GetInstalledExtensionDetail`. `detail` is `null` when the extension is not
     /// in the registry. `id` echoes the requested extension id for stale-reply protection.
@@ -953,6 +965,25 @@ pub(super) fn push_store_catalogue(
     error: Option<String>,
 ) {
     super::render::emit(push, &PushEnvelope::StoreCatalogue { items, error });
+}
+
+/// Emit a one-shot `TutorialChatDone` envelope for the GUI Tutorial tab.
+pub(super) fn push_tutorial_chat_done(
+    push: &dyn Fn(String),
+    id: String,
+    text: String,
+    tour: Option<String>,
+    error: Option<String>,
+) {
+    super::render::emit(
+        push,
+        &PushEnvelope::TutorialChatDone {
+            id,
+            text,
+            tour,
+            error,
+        },
+    );
 }
 
 /// Emit a one-shot `StoreItemDetail` envelope for the GUI Store detail pane. Shared the

--- a/src-agent/src/app/runtime/client/tutorial_host.rs
+++ b/src-agent/src/app/runtime/client/tutorial_host.rs
@@ -1,0 +1,253 @@
+//! Host-side GUI Tutorial chat — thin koma-free client for the Tutorial tab.
+//!
+//! Runs on a one-shot [`std::thread::spawn`] worker (blocking `reqwest`), never on
+//! the tokio runtime and never through a session daemon. Mirrors [`super::store_host`]:
+//! works identically pre-session (hub / swapper) and attached.
+//!
+//! Auth is the keyless koma-free dual-header pair (`X-Koma` install id +
+//! `X-Session` tutorial-scoped id). Does NOT call `SetupKomaFree` / does NOT
+//! steal Main roles — tutorial traffic must not mutate the user's model config
+//! beyond ensuring a non-empty `install_id` (required header).
+
+use std::sync::mpsc::Sender;
+
+use crate::config::{APP_TITLE, HTTP_REFERER};
+use crate::model::app_config::{new_uuid, AppConfig};
+use crate::service::koma_free::{KOMA_FREE_ENDPOINT, KOMA_FREE_MODEL};
+
+/// Stable system prompt: short multilingual help + optional tour id router.
+/// The model must end with a single `TOUR: <id>` or `TOUR: none` line the host
+/// strips before showing the user-facing text.
+const SYSTEM_PROMPT: &str = r#"You are koma's in-app GUI tutorial coach. Reply in the user's language.
+Be brief (2–6 short sentences). Explain where to click in the real desktop GUI.
+Do not invent features. Do not claim you can edit files or run tools — you only guide.
+
+Known guided tours (offer when relevant; user confirms before launch):
+- oauth-setup — connect a provider via OAuth, then pick/add a model
+- provider-setup — add a custom/API-key provider, add a model, select it in the composer
+- activity-bar — activity bar + sidebar panels overview
+- sessions-hub — start/resume sessions
+- composer — message box, model picker, attachments
+- agents — sub-agents panel
+- git — source control panel
+- mcp — MCP servers panel
+- remote — remote SSH hosts
+- store — extension store
+- settings — settings tab
+- connector — Connector panel (providers / OAuth / models)
+
+End EVERY reply with exactly one final line, nothing after it:
+TOUR: <id>
+or
+TOUR: none
+"#;
+
+/// One chat message on the wire (role + content).
+#[derive(Debug, Clone)]
+pub struct TutorialMsg {
+    pub role: String,
+    pub content: String,
+}
+
+/// Result of one tutorial turn (attached channel payload / push fields).
+pub(super) struct TutorialChatResult {
+    pub id: String,
+    pub text: String,
+    pub tour: Option<String>,
+    pub error: Option<String>,
+}
+
+// ─── DETACHED (host_swapper): push straight through the cloned sink ───────────
+
+/// `HostCtl::TutorialChat` while detached.
+pub(super) fn spawn_tutorial_chat(
+    push: impl Fn(String) + Send + 'static,
+    id: String,
+    messages: Vec<TutorialMsg>,
+) {
+    std::thread::spawn(move || {
+        let result = run_tutorial_chat(id, messages);
+        super::push_proto::push_tutorial_chat_done(
+            &push,
+            result.id,
+            result.text,
+            result.tour,
+            result.error,
+        );
+    });
+}
+
+// ─── ATTACHED (push_loop): reply over mpsc, drained by the fold loop ──────────
+
+/// `HostCtl::TutorialChat` while attached.
+pub(super) fn spawn_tutorial_chat_attached(
+    tx: Sender<TutorialChatResult>,
+    id: String,
+    messages: Vec<TutorialMsg>,
+) {
+    std::thread::spawn(move || {
+        let _ = tx.send(run_tutorial_chat(id, messages));
+    });
+}
+
+// ─── Core ────────────────────────────────────────────────────────────────────
+
+fn run_tutorial_chat(id: String, messages: Vec<TutorialMsg>) -> TutorialChatResult {
+    match complete(messages) {
+        Ok(raw) => {
+            let (text, tour) = split_tour_trailer(&raw);
+            TutorialChatResult {
+                id,
+                text,
+                tour,
+                error: None,
+            }
+        }
+        Err(e) => TutorialChatResult {
+            id,
+            text: String::new(),
+            tour: None,
+            error: Some(e),
+        },
+    }
+}
+
+/// Blocking OpenAI-compatible chat-completions call against koma-free (`stream: false`).
+fn complete(messages: Vec<TutorialMsg>) -> Result<String, String> {
+    let mut cfg = AppConfig::load();
+    if cfg.install_id.is_empty() {
+        cfg.install_id = new_uuid();
+        // Persist only the install id mint — no provider/model mutation.
+        let _ = cfg.save();
+    }
+    let install_id = cfg.install_id.clone();
+    // Tutorial-scoped session header — NOT a hub/session uuid.
+    let session_id = format!("tutorial-{}", install_id);
+
+    let mut wire_msgs: Vec<serde_json::Value> = Vec::with_capacity(messages.len() + 1);
+    wire_msgs.push(serde_json::json!({
+        "role": "system",
+        "content": SYSTEM_PROMPT,
+    }));
+    for m in &messages {
+        let role = match m.role.as_str() {
+            "assistant" => "assistant",
+            _ => "user",
+        };
+        // Cap each message to keep the free-tier payload small.
+        let content: String = m.content.chars().take(4000).collect();
+        if content.trim().is_empty() {
+            continue;
+        }
+        wire_msgs.push(serde_json::json!({ "role": role, "content": content }));
+    }
+    // Keep only the last ~12 turns + system to bound context.
+    if wire_msgs.len() > 13 {
+        let system = wire_msgs.remove(0);
+        let keep = wire_msgs.split_off(wire_msgs.len().saturating_sub(12));
+        wire_msgs = std::iter::once(system).chain(keep).collect();
+    }
+
+    let body = serde_json::json!({
+        "model": KOMA_FREE_MODEL,
+        "stream": false,
+        "messages": wire_msgs,
+    });
+
+    let url = format!("{KOMA_FREE_ENDPOINT}/chat/completions");
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .map_err(|e| format!("http client: {e}"))?;
+
+    let resp = client
+        .post(&url)
+        .header("X-Koma", &install_id)
+        .header("X-Session", &session_id)
+        .header("HTTP-Referer", HTTP_REFERER)
+        .header("X-Title", APP_TITLE)
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .send()
+        .map_err(|e| format!("koma-free request failed: {e}"))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .map_err(|e| format!("koma-free read body: {e}"))?;
+    if !status.is_success() {
+        let snippet: String = text.chars().take(240).collect();
+        return Err(format!("koma-free HTTP {status}: {snippet}"));
+    }
+
+    let v: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| format!("koma-free bad JSON: {e}"))?;
+    let content = v
+        .pointer("/choices/0/message/content")
+        .and_then(|c| c.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "koma-free returned empty content".to_string())?;
+    Ok(content.to_string())
+}
+
+/// Split a trailing `TOUR: <id>` / `TOUR: none` line from the model reply.
+fn split_tour_trailer(raw: &str) -> (String, Option<String>) {
+    let trimmed = raw.trim_end();
+    let Some((head, last)) = trimmed.rsplit_once('\n') else {
+        // Single-line reply — still accept a bare TOUR line (unlikely).
+        return parse_tour_line(trimmed)
+            .map(|t| (String::new(), t))
+            .unwrap_or_else(|| (trimmed.to_string(), None));
+    };
+    if let Some(tour) = parse_tour_line(last.trim()) {
+        return (head.trim_end().to_string(), tour);
+    }
+    (trimmed.to_string(), None)
+}
+
+fn parse_tour_line(line: &str) -> Option<Option<String>> {
+    let rest = line
+        .strip_prefix("TOUR:")
+        .or_else(|| line.strip_prefix("tour:"))?
+        .trim();
+    if rest.is_empty() || rest.eq_ignore_ascii_case("none") {
+        return Some(None);
+    }
+    // Allow only known-looking ids (kebab-case).
+    if rest
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && rest.len() < 64
+    {
+        Some(Some(rest.to_string()))
+    } else {
+        Some(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_tour_trailer_extracts_id() {
+        let (text, tour) = split_tour_trailer("Open Connector.\n\nTOUR: oauth-setup\n");
+        assert_eq!(text, "Open Connector.");
+        assert_eq!(tour.as_deref(), Some("oauth-setup"));
+    }
+
+    #[test]
+    fn split_tour_trailer_none() {
+        let (text, tour) = split_tour_trailer("Just a tip.\nTOUR: none");
+        assert_eq!(text, "Just a tip.");
+        assert_eq!(tour, None);
+    }
+
+    #[test]
+    fn split_tour_trailer_missing() {
+        let (text, tour) = split_tour_trailer("No trailer here.");
+        assert_eq!(text, "No trailer here.");
+        assert_eq!(tour, None);
+    }
+}

--- a/src-agent/src/app/runtime/gui/dispatch.rs
+++ b/src-agent/src/app/runtime/gui/dispatch.rs
@@ -716,6 +716,19 @@ pub(super) fn handle_gui_req(req: GuiReq, ctx: &GuiReqCtx) {
         GuiReq::OpenExternal { url } => {
             let _ = crate::service::oauth::browser::open_in_browser(&url);
         }
+        // GUI Tutorial tab chat: HOST-LOCAL thin koma-free completion — ALWAYS
+        // routed to the host-relay thread, never the daemon, regardless of attach
+        // state (works from the hub with zero session). See `tutorial_host`.
+        GuiReq::TutorialChat { id, messages } => {
+            let messages = messages
+                .into_iter()
+                .map(|m| crate::app::runtime::client::tutorial_host::TutorialMsg {
+                    role: m.role,
+                    content: m.content,
+                })
+                .collect();
+            let _ = ctx.ctl.send(HostCtl::TutorialChat { id, messages });
+        }
         // Extension STORE browse/detail/installed-list: HOST-LOCAL — ALWAYS routed to the
         // host-relay thread, never the daemon, regardless of attach state, same reasoning
         // as `GitStatus`/`FileDiff`. koma.run browse/detail is a PUBLIC (no-auth) network

--- a/src-agent/src/app/runtime/gui/proto.rs
+++ b/src-agent/src/app/runtime/gui/proto.rs
@@ -54,6 +54,13 @@ pub(super) enum ClientMsg {
     Req(GuiReq),
 }
 
+/// One message in a GUI Tutorial chat turn (`GuiReq::TutorialChat`).
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct TutorialChatMsg {
+    pub role: String,
+    pub content: String,
+}
+
 /// The native-React client -> host request, carried inside [`ClientMsg::Req`] and
 /// internally tagged on `r`. Mirrors the JS→Rust half of the host-relay bridge
 /// contract exactly:
@@ -744,6 +751,16 @@ pub(super) enum GuiReq {
     /// no push.
     OpenExternal {
         url: String,
+    },
+
+    /// GUI Tutorial tab: one chat turn against the keyless koma-free endpoint.
+    /// HOST-LOCAL (no daemon, works pre-session). `id` is a client-generated turn
+    /// id echoed on `TutorialChatDone`. `messages` is the rolling transcript
+    /// (user/assistant only — system prompt is host-owned).
+    #[serde(rename_all = "camelCase")]
+    TutorialChat {
+        id: String,
+        messages: Vec<TutorialChatMsg>,
     },
 
     // ─── GUI extension STORE surface (browse / install / uninstall) ──────────────

--- a/src-webgui/package-lock.json
+++ b/src-webgui/package-lock.json
@@ -14,6 +14,7 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "@xyflow/react": "^12.11.2",
+        "driver.js": "^1.3.5",
         "framer-motion": "^12.42.2",
         "lottie-react": "^2.4.1",
         "lucide-react": "^1.23.0",
@@ -3243,6 +3244,12 @@
       "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
       "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/driver.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.3.5.tgz",
+      "integrity": "sha512-exkp49hXuujvTOZ3zYgySWRlEAa8/3nA8glYjtuZjmkTdsQITXivBsW1ytyhKQx3WkeYaovlnvVcLbtTaN86kA==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.388",

--- a/src-webgui/package.json
+++ b/src-webgui/package.json
@@ -16,6 +16,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.11.2",
+    "driver.js": "^1.3.5",
     "framer-motion": "^12.42.2",
     "lottie-react": "^2.4.1",
     "lucide-react": "^1.23.0",

--- a/src-webgui/src/components/ActivityBar.tsx
+++ b/src-webgui/src/components/ActivityBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { Files, GitBranch, Blocks, Bot, ChartColumn, CircleHelp, Settings, MoreHorizontal, Puzzle, Code2, VectorSquare, Brain, Network, Server } from 'lucide-react'
+import { Files, GitBranch, Blocks, Bot, ChartColumn, CircleHelp, Settings, MoreHorizontal, Puzzle, Code2, VectorSquare, Brain, Network, Server, GraduationCap } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import type { SidebarView } from './Sidebar'
 import { useKoma, resolveActivityBarOrder } from '../store/koma'
@@ -10,6 +10,7 @@ type ActivityBarProps = {
   onSelect: (view: SidebarView) => void
   onSettings?: () => void
   onHelp?: () => void
+  onTutorial?: () => void
 }
 
 type ActivityBarItem = { view: SidebarView; icon: LucideIcon; label: string }
@@ -52,9 +53,10 @@ export const ACTIVITY_BAR_ITEMS: ActivityBarItem[] = [
 // Per-button footprint used for the overflow measurement below: the iconBtn's
 // h-10 (40px) plus the strip's gap-0.5 (2px) between siblings.
 const ITEM_H = 42
-// Help + Settings are fixed chrome (never reorderable/hideable/overflow-able),
-// always pinned at the bottom — reserved out of the measured height first.
-const FOOTER_H = ITEM_H * 2
+// Tutorial + Help + Settings are fixed chrome (never reorderable/hideable/
+// overflow-able), always pinned at the bottom — reserved out of the measured
+// height first.
+const FOOTER_H = ITEM_H * 3
 
 // Thin icon strip. Selecting a view switches the sidebar panel; the active
 // view shows the left indicator bar. The managed items (ACTIVITY_BAR_ITEMS)
@@ -65,7 +67,7 @@ const FOOTER_H = ITEM_H * 2
 // (both inert re: active-state — neither is a `SidebarView` — and neither is
 // part of the managed/reorderable list), Help directly above Settings, the
 // overflow button (when shown) directly above Help.
-export function ActivityBar({ activeView, sidebarOpen, onSelect, onSettings, onHelp }: ActivityBarProps) {
+export function ActivityBar({ activeView, sidebarOpen, onSelect, onSettings, onHelp, onTutorial }: ActivityBarProps) {
   const order = useKoma((s) => s.activityBar.order)
   const hidden = useKoma((s) => s.activityBar.hidden)
   const setActivityBarOrder = useKoma((s) => s.setActivityBarOrder)
@@ -219,6 +221,7 @@ export function ActivityBar({ activeView, sidebarOpen, onSelect, onSettings, onH
   return (
     <div
       ref={containerRef}
+      data-tour="activity-bar"
       className="flex w-12 flex-none flex-col items-center gap-0.5 border-r border-koma-border bg-koma-panel2 pt-1.5"
     >
       {barItems.map((item) => {
@@ -252,6 +255,7 @@ export function ActivityBar({ activeView, sidebarOpen, onSelect, onSettings, onH
             onClick={() => pickItem(item)}
             title={label}
             aria-label={label}
+            data-tour-view={item.ext ? undefined : view}
             className={`${iconBtn} ${active ? '!opacity-100' : ''} ${dragging ? 'opacity-25' : ''} ${
               dragOver ? 'ring-1 ring-inset ring-koma-accent/60' : ''
             }`}
@@ -300,8 +304,18 @@ export function ActivityBar({ activeView, sidebarOpen, onSelect, onSettings, onH
       )}
 
       <button
-        onClick={onHelp}
+        onClick={onTutorial}
+        data-tour-open="tutorial"
         className={`${iconBtn} ${showMenuButton ? '' : 'mt-auto'}`}
+        title="Tutorial"
+        aria-label="Tutorial"
+      >
+        <GraduationCap size={22} strokeWidth={1.6} />
+      </button>
+      <button
+        onClick={onHelp}
+        data-tour-open="help"
+        className={iconBtn}
         title="Help"
         aria-label="Help"
       >
@@ -309,6 +323,7 @@ export function ActivityBar({ activeView, sidebarOpen, onSelect, onSettings, onH
       </button>
       <button
         onClick={onSettings}
+        data-tour-open="settings"
         className={`${iconBtn} mb-1.5`}
         title="Settings"
         aria-label="Settings"

--- a/src-webgui/src/components/Composer.tsx
+++ b/src-webgui/src/components/Composer.tsx
@@ -529,7 +529,7 @@ export function Composer() {
     // claude.ai-style composer pinned at the bottom: a single rounded card
     // (textarea on top, an action bar below) that grows with its content. Drag
     // a file anywhere over the card to attach; the card rings on drag-over.
-    <div className="px-2 pb-3 pt-1">
+    <div className="px-2 pb-3 pt-1" data-tour="composer">
       {/* Pending-steer queue: submits made while the turn is cooking are queued
           daemon-side (cap 5) rather than starting a new turn. Show the queued
           previews above the composer so the user knows they're stacked up. */}

--- a/src-webgui/src/components/ModelPicker.tsx
+++ b/src-webgui/src/components/ModelPicker.tsx
@@ -104,7 +104,7 @@ export function ModelPicker() {
   }
 
   return (
-    <div ref={ref} className="relative">
+    <div ref={ref} className="relative" data-tour="model-picker">
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}

--- a/src-webgui/src/components/StartScreen.tsx
+++ b/src-webgui/src/components/StartScreen.tsx
@@ -344,7 +344,7 @@ export function StartScreen() {
   )
 
   return (
-    <div ref={ref} className="h-full w-full overflow-y-auto">
+    <div ref={ref} className="h-full w-full overflow-y-auto" data-tour="start-screen">
       <div className="mx-auto w-full max-w-[980px] px-6 py-10">
         <div className={`flex gap-6 ${wide ? 'flex-row items-start' : 'flex-col'}`}>
           {actions}

--- a/src-webgui/src/components/TabBar.tsx
+++ b/src-webgui/src/components/TabBar.tsx
@@ -1,4 +1,4 @@
-import { MessageSquare, FileDiff, Settings, CircleHelp, Bot, Terminal, GitGraph, BarChart3, Blocks, Puzzle, Code2, X, ChevronLeft, ChevronRight, Package, Network, SquareTerminal } from 'lucide-react'
+import { MessageSquare, FileDiff, Settings, CircleHelp, GraduationCap, Bot, Terminal, GitGraph, BarChart3, Blocks, Puzzle, Code2, X, ChevronLeft, ChevronRight, Package, Network, SquareTerminal } from 'lucide-react'
 import { useKoma } from '../store/koma'
 import { useRef, useEffect, useState, useCallback, type MouseEvent as ReactMouseEvent } from 'react'
 import { fileKey } from '../store/coding'
@@ -267,6 +267,43 @@ export function TabBar() {
                 {accent}
                 <CircleHelp size={13} className="flex-none opacity-80" />
                 <span className="truncate">Help</span>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    closeTab(t.id)
+                  }}
+                  aria-label="Close tab"
+                  title="Close"
+                  className={`ml-0.5 flex h-4 w-4 flex-none items-center justify-center rounded transition hover:bg-koma-hover hover:!opacity-100 ${
+                    active ? 'opacity-70' : 'opacity-0 group-hover:opacity-70'
+                  }`}
+                >
+                  <X size={12} />
+                </button>
+              </div>
+            )
+          }
+
+          // Tutorial tab: closeable singleton, graduation icon + fixed title.
+          if (t.kind === 'tutorial') {
+            return (
+              <div
+                key={t.id}
+                ref={(el) => {
+                  tabRefs.current.set(t.id, el)
+                }}
+                role="button"
+                tabIndex={0}
+                onClick={() => activateTab(t.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') activateTab(t.id)
+                }}
+                title="Tutorial"
+                className={`${base} ${tone} cursor-pointer pl-3 pr-1.5`}
+              >
+                {accent}
+                <GraduationCap size={13} className="flex-none opacity-80" />
+                <span className="truncate">Tutorial</span>
                 <button
                   onClick={(e) => {
                     e.stopPropagation()

--- a/src-webgui/src/components/TutorialPaperclip.tsx
+++ b/src-webgui/src/components/TutorialPaperclip.tsx
@@ -1,0 +1,130 @@
+// Pixel paperclip mascot for the Tutorial tab input.
+// Pure CSS/div pixels — theme-aware via currentColor (text-koma-accent).
+
+import { useEffect, useState } from 'react'
+
+export type PaperclipMood = 'idle' | 'think' | 'point' | 'wave'
+
+type Props = {
+  mood?: PaperclipMood
+  onClick?: () => void
+  className?: string
+  title?: string
+}
+
+// 12×14 bitmap, 1 = filled. Classic sideways clip silhouette (very small).
+const FRAMES: number[][][] = [
+  // idle
+  [
+    [0,0,0,1,1,1,0,0,0,0,0,0],
+    [0,0,1,0,0,0,1,0,0,0,0,0],
+    [0,0,1,0,0,0,1,0,0,0,0,0],
+    [0,0,1,0,0,0,1,1,1,0,0,0],
+    [0,0,1,0,0,0,0,0,0,1,0,0],
+    [0,0,1,0,0,0,0,0,0,1,0,0],
+    [0,0,1,0,0,0,0,0,0,1,0,0],
+    [0,0,1,0,0,0,0,0,0,1,0,0],
+    [0,0,0,1,0,0,0,0,1,0,0,0],
+    [0,0,0,0,1,1,1,1,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,0,0,0],
+  ],
+  // bounce / think (shifted up 1)
+  [
+    [0,0,0,1,1,1,0,0,0,0,0,0],
+    [0,0,1,0,0,0,1,0,0,0,0,0],
+    [0,0,1,0,0,0,1,1,1,0,0,0],
+    [0,0,1,0,0,0,0,0,0,1,0,0],
+    [0,0,1,0,0,0,0,0,0,1,0,0],
+    [0,0,1,0,0,0,0,0,0,1,0,0],
+    [0,0,1,0,0,0,0,0,0,1,0,0],
+    [0,0,0,1,0,0,0,0,1,0,0,0],
+    [0,0,0,0,1,1,1,1,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,0,0,0],
+  ],
+  // point (lean right)
+  [
+    [0,0,0,0,1,1,1,0,0,0,0,0],
+    [0,0,0,1,0,0,0,1,0,0,0,0],
+    [0,0,0,1,0,0,0,1,0,0,0,0],
+    [0,0,0,1,0,0,0,1,1,1,0,0],
+    [0,0,0,1,0,0,0,0,0,0,1,0],
+    [0,0,0,1,0,0,0,0,0,0,1,0],
+    [0,0,0,1,0,0,0,0,0,0,1,0],
+    [0,0,0,1,0,0,0,0,0,0,1,0],
+    [0,0,0,0,1,0,0,0,0,1,0,0],
+    [0,0,0,0,0,1,1,1,1,0,0,0],
+    [0,0,0,0,0,0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,1,1,1,1],
+    [0,0,0,0,0,0,0,0,0,0,0,1],
+    [0,0,0,0,0,0,0,0,0,0,0,0],
+  ],
+]
+
+export function TutorialPaperclip({ mood = 'idle', onClick, className = '', title }: Props) {
+  const [frame, setFrame] = useState(0)
+
+  useEffect(() => {
+    if (mood === 'idle') {
+      setFrame(0)
+      return
+    }
+    if (mood === 'point') {
+      setFrame(2)
+      return
+    }
+    // think / wave — alternate 0/1
+    setFrame(1)
+    const t = window.setInterval(() => {
+      setFrame((f) => (f === 0 ? 1 : 0))
+    }, mood === 'think' ? 280 : 180)
+    return () => window.clearInterval(t)
+  }, [mood])
+
+  const grid = FRAMES[frame] ?? FRAMES[0]
+  const px = 2
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title ?? 'Tutorial coach'}
+      aria-label="Tutorial coach"
+      className={`relative flex h-10 w-10 flex-none items-center justify-center rounded-md text-koma-accent transition hover:bg-koma-hover ${className}`}
+    >
+      <span
+        className="block"
+        style={{
+          width: 12 * px,
+          height: 14 * px,
+          position: 'relative',
+        }}
+        aria-hidden
+      >
+        {grid.map((row, y) =>
+          row.map((cell, x) =>
+            cell ? (
+              <span
+                key={`${x}-${y}`}
+                className="absolute bg-current"
+                style={{
+                  left: x * px,
+                  top: y * px,
+                  width: px,
+                  height: px,
+                  imageRendering: 'pixelated',
+                }}
+              />
+            ) : null,
+          ),
+        )}
+      </span>
+    </button>
+  )
+}

--- a/src-webgui/src/components/TutorialTab.tsx
+++ b/src-webgui/src/components/TutorialTab.tsx
@@ -1,0 +1,303 @@
+import { useEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEvent, type ReactNode } from 'react'
+import { GraduationCap, Play, Send, Sparkles } from 'lucide-react'
+import { useKoma } from '../store/koma'
+import { TutorialPaperclip, type PaperclipMood } from './TutorialPaperclip'
+import {
+  TOUR_CATALOGUE,
+  startTour,
+  tourMeta,
+  type TourId,
+} from '../lib/tutorialTours'
+
+// In-app Tutorial tab: NLP coach over host-proxied koma-free + driver.js tours.
+// Theme-aware end-to-end (koma-* tokens only). No daemon session required.
+
+export default function TutorialTab() {
+  const messages = useKoma((s) => s.tutorial.messages)
+  const busy = useKoma((s) => s.tutorial.busy)
+  const error = useKoma((s) => s.tutorial.error)
+  const pendingTour = useKoma((s) => s.tutorial.pendingTour)
+  const sendTutorialChat = useKoma((s) => s.sendTutorialChat)
+  const clearTutorialPendingTour = useKoma((s) => s.clearTutorialPendingTour)
+  const clearTutorialError = useKoma((s) => s.clearTutorialError)
+
+  const [draft, setDraft] = useState('')
+  const [showTopics, setShowTopics] = useState(true)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }, [messages, busy, pendingTour, error])
+
+  const mood: PaperclipMood = useMemo(() => {
+    if (busy) return 'think'
+    if (pendingTour) return 'point'
+    if (messages.length === 0) return 'wave'
+    return 'idle'
+  }, [busy, pendingTour, messages.length])
+
+  const pendingMeta = tourMeta(pendingTour)
+
+  const submit = (text: string) => {
+    const t = text.trim()
+    if (!t || busy) return
+    setDraft('')
+    setShowTopics(false)
+    clearTutorialError()
+    sendTutorialChat(t)
+  }
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    submit(draft)
+  }
+
+  const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      submit(draft)
+    }
+  }
+
+  const launchTour = (id: string) => {
+    clearTutorialPendingTour()
+    startTour(id as TourId)
+  }
+
+  const setupTours = TOUR_CATALOGUE.filter((t) => t.kind === 'setup')
+  const spotlights = TOUR_CATALOGUE.filter((t) => t.kind === 'spotlight')
+
+  return (
+    <div className="flex h-full w-full min-w-0 flex-col bg-koma-bg text-koma-fg">
+      {/* Header */}
+      <header className="flex flex-none items-center gap-2 border-b border-koma-border bg-koma-panel2 px-4 py-2.5">
+        <GraduationCap size={16} className="text-koma-accent opacity-90" />
+        <div className="min-w-0 flex-1">
+          <div className="text-[13px] font-semibold">Tutorial</div>
+          <div className="text-[11px] text-koma-fg opacity-45">
+            Ask how to do something, or pick a guided tour. Powered by koma free (no session).
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowTopics((v) => !v)}
+          className="rounded-md border border-koma-border px-2 py-1 text-[11px] text-koma-fg opacity-70 transition hover:bg-koma-hover hover:opacity-100"
+        >
+          {showTopics ? 'Hide topics' : 'Topics'}
+        </button>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        {/* Topic rail */}
+        {showTopics && (
+          <aside className="flex w-56 flex-none flex-col gap-3 overflow-y-auto border-r border-koma-border bg-koma-panel2 p-3">
+            <RailSection title="Setup recipes">
+              {setupTours.map((t) => (
+                <TopicButton
+                  key={t.id}
+                  title={t.title}
+                  blurb={t.blurb}
+                  onAsk={() => submit(`How do I ${t.title.toLowerCase()}?`)}
+                  onTour={() => launchTour(t.id)}
+                />
+              ))}
+            </RailSection>
+            <RailSection title="Feature spotlights">
+              {spotlights.map((t) => (
+                <TopicButton
+                  key={t.id}
+                  title={t.title}
+                  blurb={t.blurb}
+                  onAsk={() => submit(`What is ${t.title}?`)}
+                  onTour={() => launchTour(t.id)}
+                />
+              ))}
+            </RailSection>
+          </aside>
+        )}
+
+        {/* Chat column */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            {messages.length === 0 && !busy && (
+              <div className="mx-auto flex max-w-xl flex-col items-start gap-3 pt-6">
+                <div className="flex items-center gap-2 text-koma-accent">
+                  <Sparkles size={16} />
+                  <span className="text-[13px] font-semibold">Ask the coach</span>
+                </div>
+                <p className="text-[12.5px] leading-relaxed text-koma-fg opacity-60">
+                  Try natural language — any language works. Examples:
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {[
+                    'gimana cara konek provider',
+                    'how do I add an API key model',
+                    'what is the agents panel',
+                    'how do I connect SSH remote',
+                  ].map((q) => (
+                    <button
+                      key={q}
+                      type="button"
+                      onClick={() => submit(q)}
+                      className="rounded-full border border-koma-border bg-koma-panel px-2.5 py-1 text-[11.5px] text-koma-fg opacity-75 transition hover:border-koma-accent/40 hover:bg-koma-hover hover:opacity-100"
+                    >
+                      {q}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="mx-auto flex max-w-2xl flex-col gap-3">
+              {messages.map((m) => (
+                <div
+                  key={m.id}
+                  className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}
+                >
+                  <div
+                    className={`max-w-[85%] rounded-lg px-3 py-2 text-[12.5px] leading-relaxed ${
+                      m.role === 'user'
+                        ? 'bg-koma-band text-koma-fg'
+                        : 'border border-koma-border bg-koma-panel text-koma-fg'
+                    }`}
+                  >
+                    <div className="whitespace-pre-wrap">{m.content}</div>
+                    {m.tour && (
+                      <button
+                        type="button"
+                        onClick={() => launchTour(m.tour!)}
+                        className="mt-2 inline-flex items-center gap-1 rounded-md border border-koma-accent/40 bg-koma-accent/10 px-2 py-1 text-[11px] font-medium text-koma-accent transition hover:bg-koma-accent/20"
+                      >
+                        <Play size={11} />
+                        Start tour: {tourMeta(m.tour)?.title ?? m.tour}
+                      </button>
+                    )}
+                  </div>
+                </div>
+              ))}
+
+              {busy && (
+                <div className="flex justify-start">
+                  <div className="rounded-lg border border-koma-border bg-koma-panel px-3 py-2 text-[12px] text-koma-fg opacity-55">
+                    Thinking…
+                  </div>
+                </div>
+              )}
+
+              {error && (
+                <div className="rounded-md border border-koma-error/40 bg-koma-error/10 px-3 py-2 text-[12px] text-koma-error">
+                  {error}
+                  <div className="mt-1 text-[11px] opacity-80">
+                    Use Topics on the left for offline guided tours.
+                  </div>
+                </div>
+              )}
+
+              {pendingTour && pendingMeta && !busy && (
+                <div className="flex items-center gap-2 rounded-md border border-koma-accent/35 bg-koma-accent/10 px-3 py-2">
+                  <span className="min-w-0 flex-1 text-[12px] text-koma-fg">
+                    Suggested tour: <strong className="text-koma-accent">{pendingMeta.title}</strong>
+                    <span className="opacity-55"> — {pendingMeta.blurb}</span>
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => launchTour(pendingTour)}
+                    className="flex-none rounded-md bg-koma-accent px-2.5 py-1 text-[11px] font-semibold text-koma-bg transition hover:opacity-90"
+                  >
+                    Start
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => clearTutorialPendingTour()}
+                    className="flex-none rounded-md px-2 py-1 text-[11px] text-koma-fg opacity-55 hover:bg-koma-hover hover:opacity-90"
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Input + paperclip */}
+          <form
+            onSubmit={onSubmit}
+            className="flex flex-none items-end gap-2 border-t border-koma-border bg-koma-panel2 px-3 py-2.5"
+          >
+            <TutorialPaperclip
+              mood={mood}
+              onClick={() => setShowTopics((v) => !v)}
+              title="Toggle topics"
+            />
+            <textarea
+              ref={inputRef}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={onKeyDown}
+              rows={1}
+              placeholder="Ask how to do something in the GUI…"
+              disabled={busy}
+              className="max-h-28 min-h-[40px] min-w-0 flex-1 resize-y rounded-md border border-koma-border bg-koma-bg px-3 py-2 text-[12.5px] text-koma-fg outline-none placeholder:text-koma-fg placeholder:opacity-35 focus:border-koma-accent/50 disabled:opacity-50"
+            />
+            <button
+              type="submit"
+              disabled={busy || !draft.trim()}
+              aria-label="Send"
+              className="flex h-10 w-10 flex-none items-center justify-center rounded-md bg-koma-accent text-koma-bg transition hover:opacity-90 disabled:opacity-35"
+            >
+              <Send size={15} />
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function RailSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div>
+      <div className="mb-1 px-1 text-[10px] font-semibold uppercase tracking-wider text-koma-fg opacity-40">
+        {title}
+      </div>
+      <div className="flex flex-col gap-1">{children}</div>
+    </div>
+  )
+}
+
+function TopicButton({
+  title,
+  blurb,
+  onAsk,
+  onTour,
+}: {
+  title: string
+  blurb: string
+  onAsk: () => void
+  onTour: () => void
+}) {
+  return (
+    <div className="rounded-md border border-koma-border bg-koma-bg/40 p-2">
+      <div className="text-[12px] font-medium text-koma-fg">{title}</div>
+      <div className="mt-0.5 text-[10.5px] leading-snug text-koma-fg opacity-50">{blurb}</div>
+      <div className="mt-1.5 flex gap-1">
+        <button
+          type="button"
+          onClick={onAsk}
+          className="rounded px-1.5 py-0.5 text-[10.5px] text-koma-fg opacity-70 transition hover:bg-koma-hover hover:opacity-100"
+        >
+          Ask
+        </button>
+        <button
+          type="button"
+          onClick={onTour}
+          className="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10.5px] text-koma-accent transition hover:bg-koma-hover"
+        >
+          <Play size={10} /> Tour
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src-webgui/src/components/panels/ConnectorPanel.tsx
+++ b/src-webgui/src/components/panels/ConnectorPanel.tsx
@@ -105,7 +105,7 @@ export function ConnectorPanel() {
   ]
 
   return (
-    <div className="relative h-full overflow-hidden">
+    <div className="relative h-full overflow-hidden" data-tour="connector-panel">
       <AnimatePresence initial={false}>
         {view.kind === 'list' ? (
           <motion.div

--- a/src-webgui/src/koma.d.ts
+++ b/src-webgui/src/koma.d.ts
@@ -299,6 +299,13 @@ declare global {
     // host-local side effect (spawns the OS opener, fire-and-forget): no
     // session/attach needed, no reply, no push.
     | { r: 'OpenExternal'; url: string }
+    // GUI Tutorial tab: one chat turn via host-proxied koma-free (no daemon).
+    // Reply lands as TutorialChatDone (id echoed).
+    | {
+        r: 'TutorialChat'
+        id: string
+        messages: { role: string; content: string }[]
+      }
     // Extension STORE (koma.run marketplace). Browse/detail hit the PUBLIC store
     // endpoints; install/uninstall mutate the live daemon (managers + config), so
     // the whole family is forwarded to the attached daemon. Replies land as the

--- a/src-webgui/src/lib/tutorialTours.ts
+++ b/src-webgui/src/lib/tutorialTours.ts
@@ -1,0 +1,366 @@
+// Guided product tours for the GUI Tutorial tab (driver.js).
+// All popover chrome is themed via CSS vars (--koma-*) — see styles.css
+// `.koma-driver-theme`. Tours open real surfaces when cheap; otherwise they
+// spotlight whatever is already mounted.
+
+import { driver, type DriveStep, type Config } from 'driver.js'
+import 'driver.js/dist/driver.css'
+
+export type TourId =
+  | 'oauth-setup'
+  | 'provider-setup'
+  | 'activity-bar'
+  | 'sessions-hub'
+  | 'composer'
+  | 'agents'
+  | 'git'
+  | 'mcp'
+  | 'remote'
+  | 'store'
+  | 'settings'
+  | 'connector'
+
+export type TourMeta = {
+  id: TourId
+  title: string
+  blurb: string
+  /** Setup recipe (multi-step) vs one-shot spotlight. */
+  kind: 'setup' | 'spotlight'
+}
+
+export const TOUR_CATALOGUE: TourMeta[] = [
+  {
+    id: 'oauth-setup',
+    title: 'OAuth → model',
+    blurb: 'Connect a provider with browser sign-in, then pick a model.',
+    kind: 'setup',
+  },
+  {
+    id: 'provider-setup',
+    title: 'API provider → model',
+    blurb: 'Add a custom endpoint + key, create a model, select it.',
+    kind: 'setup',
+  },
+  {
+    id: 'activity-bar',
+    title: 'Activity bar',
+    blurb: 'Left strip of panels — Explore, Git, Agents, and more.',
+    kind: 'spotlight',
+  },
+  {
+    id: 'sessions-hub',
+    title: 'Sessions hub',
+    blurb: 'Start a new session or resume an existing one.',
+    kind: 'spotlight',
+  },
+  {
+    id: 'composer',
+    title: 'Composer',
+    blurb: 'Message box, model picker, attachments, shell with !.',
+    kind: 'spotlight',
+  },
+  {
+    id: 'connector',
+    title: 'Connector',
+    blurb: 'Providers, OAuth accounts, and models in one panel.',
+    kind: 'spotlight',
+  },
+  {
+    id: 'agents',
+    title: 'Agents',
+    blurb: 'Built-in and custom sub-agents.',
+    kind: 'spotlight',
+  },
+  {
+    id: 'git',
+    title: 'Source control',
+    blurb: 'Git status, diffs, branches, and remotes.',
+    kind: 'spotlight',
+  },
+  {
+    id: 'mcp',
+    title: 'MCP',
+    blurb: 'Model Context Protocol servers.',
+    kind: 'spotlight',
+  },
+  {
+    id: 'remote',
+    title: 'Remote',
+    blurb: 'SSH hosts and remote sessions.',
+    kind: 'spotlight',
+  },
+  {
+    id: 'store',
+    title: 'Extensions',
+    blurb: 'Browse and install extensions from koma.run.',
+    kind: 'spotlight',
+  },
+  {
+    id: 'settings',
+    title: 'Settings',
+    blurb: 'Theme, keys, appearance, and more.',
+    kind: 'spotlight',
+  },
+]
+
+const BASE: Config = {
+  animate: true,
+  overlayOpacity: 0.55,
+  stagePadding: 6,
+  stageRadius: 6,
+  allowClose: true,
+  smoothScroll: true,
+  popoverClass: 'koma-driver-theme',
+  nextBtnText: 'Next',
+  prevBtnText: 'Back',
+  doneBtnText: 'Done',
+  progressText: '{{current}} / {{total}}',
+  showProgress: true,
+}
+
+function step(
+  sel: string,
+  title: string,
+  description: string,
+  side: 'top' | 'right' | 'bottom' | 'left' = 'right',
+): DriveStep {
+  return {
+    element: sel,
+    popover: {
+      title,
+      description,
+      side,
+      align: 'start',
+    },
+  }
+}
+
+/** Best-effort open of a sidebar view before a tour that needs it. */
+function openSidebarView(view: string) {
+  try {
+    // Activity bar buttons carry data-tour-view="<view>".
+    const btn = document.querySelector(`[data-tour-view="${view}"]`) as HTMLElement | null
+    btn?.click()
+  } catch {
+    /* ignore */
+  }
+}
+
+function openSingleton(kind: 'settings' | 'help' | 'tutorial') {
+  try {
+    const btn = document.querySelector(`[data-tour-open="${kind}"]`) as HTMLElement | null
+    btn?.click()
+  } catch {
+    /* ignore */
+  }
+}
+
+function stepsFor(id: TourId): DriveStep[] {
+  switch (id) {
+    case 'oauth-setup':
+      return [
+        step(
+          '[data-tour-view="connector"]',
+          'Open Connector',
+          'Providers, OAuth, and models live here. Click Connector on the activity bar.',
+        ),
+        step(
+          '[data-tour="connector-panel"], [data-tour-view="connector"]',
+          'OAuth section',
+          'In Connector, expand OAuth and pick a provider (Codex, Claude, koma.run, …). Sign-in opens your browser — koma never sees your password.',
+        ),
+        step(
+          '[data-tour="connector-panel"], [data-tour-view="connector"]',
+          'Add or pick a model',
+          'After the account shows Connected, add a model (or use one the provider exposes) and assign the Main role.',
+        ),
+        step(
+          '[data-tour="model-picker"], [data-tour="composer"]',
+          'Select in the composer',
+          'Open the model picker on the chat composer and choose the new model for this session.',
+          'top',
+        ),
+      ]
+    case 'provider-setup':
+      return [
+        step(
+          '[data-tour-view="connector"]',
+          'Open Connector',
+          'Custom API-key providers are managed in Connector → Providers.',
+        ),
+        step(
+          '[data-tour="connector-panel"], [data-tour-view="connector"]',
+          'Add provider',
+          'Choose Add provider, pick a preset or Custom, enter endpoint + API key, then save.',
+        ),
+        step(
+          '[data-tour="connector-panel"], [data-tour-view="connector"]',
+          'Add model',
+          'Under Models, add a global Main model bound to that provider (live catalogue search when the endpoint supports it).',
+        ),
+        step(
+          '[data-tour="model-picker"], [data-tour="composer"]',
+          'Select in the composer',
+          'Use the composer model picker so the session Main points at your new model.',
+          'top',
+        ),
+      ]
+    case 'activity-bar':
+      return [
+        step(
+          '[data-tour="activity-bar"]',
+          'Activity bar',
+          'This strip switches sidebar panels. Drag to reorder; hide items from Settings → Sidebar. Overflow goes into ⋯.',
+        ),
+        step(
+          '[data-tour-open="tutorial"]',
+          'Tutorial & Help',
+          'Tutorial (this tab) and Help sit pinned at the bottom — always available, not reorderable.',
+        ),
+      ]
+    case 'sessions-hub':
+      return [
+        step(
+          '[data-tour="sessions-hub"], [data-tour="start-screen"], main',
+          'Sessions hub',
+          'With no session attached you get the start screen: new session, open folder, resume, and remote. Resume also lives in the titlebar search.',
+        ),
+      ]
+    case 'composer':
+      return [
+        step(
+          '[data-tour="composer"], main',
+          'Composer',
+          'Type to chat. ! runs a local shell line. @ references files. Attachments and the model picker sit on the footer row.',
+          'top',
+        ),
+      ]
+    case 'connector':
+      return [
+        step(
+          '[data-tour-view="connector"]',
+          'Connector',
+          'Single place for providers, OAuth accounts, and models. The free tier is picker-only — it does not appear as an editable provider row.',
+        ),
+      ]
+    case 'agents':
+      return [
+        step(
+          '[data-tour-view="agents"]',
+          'Agents',
+          'Browse built-in and custom sub-agents. Open a row to edit prompts and tools; spawn from chat with the task tool.',
+        ),
+      ]
+    case 'git':
+      return [
+        step(
+          '[data-tour-view="git"]',
+          'Source control',
+          'Status, stage, commit, diffs, branches, stash, and remotes — host-local git, same repo as your session workdir.',
+        ),
+      ]
+    case 'mcp':
+      return [
+        step(
+          '[data-tour-view="mcp"]',
+          'MCP',
+          'Add Model Context Protocol servers (stdio or HTTP). Tools show up for the agent once the server is connected.',
+        ),
+      ]
+    case 'remote':
+      return [
+        step(
+          '[data-tour-view="remote"]',
+          'Remote',
+          'Save SSH hosts, connect, pick a remote cwd, and attach a remote session. Keys live under Settings → SSH Keys.',
+        ),
+      ]
+    case 'store':
+      return [
+        step(
+          '[data-tour-view="store"]',
+          'Extensions',
+          'Browse the koma.run store and manage installed extensions. Some contribute activity-bar panels of their own.',
+        ),
+      ]
+    case 'settings':
+      return [
+        step(
+          '[data-tour-open="settings"]',
+          'Settings',
+          'Theme, appearance, coding autosave, SSH keys, activity-bar layout, and account links.',
+        ),
+      ]
+    default:
+      return []
+  }
+}
+
+let active: ReturnType<typeof driver> | null = null
+
+/** Start a named tour. Destroys any previous driver instance first. */
+export function startTour(id: TourId | string): boolean {
+  const tourId = TOUR_CATALOGUE.some((t) => t.id === id) ? (id as TourId) : null
+  if (!tourId) return false
+
+  // Nudge UI toward the right surface before highlighting.
+  switch (tourId) {
+    case 'oauth-setup':
+    case 'provider-setup':
+    case 'connector':
+      openSidebarView('connector')
+      break
+    case 'agents':
+      openSidebarView('agents')
+      break
+    case 'git':
+      openSidebarView('git')
+      break
+    case 'mcp':
+      openSidebarView('mcp')
+      break
+    case 'remote':
+      openSidebarView('remote')
+      break
+    case 'store':
+      openSidebarView('store')
+      break
+    case 'settings':
+      openSingleton('settings')
+      break
+    default:
+      break
+  }
+
+  active?.destroy()
+  const steps = stepsFor(tourId).filter((s) => {
+    if (typeof s.element === 'string') {
+      // Keep steps whose selector might match later; driver handles missing lightly.
+      return true
+    }
+    return true
+  })
+  if (steps.length === 0) return false
+
+  active = driver({
+    ...BASE,
+    steps,
+    onDestroyStarted: () => {
+      active?.destroy()
+      active = null
+    },
+  })
+  // Small delay so sidebar panel mount can paint.
+  window.setTimeout(() => active?.drive(), 120)
+  return true
+}
+
+export function stopTour() {
+  active?.destroy()
+  active = null
+}
+
+export function tourMeta(id: string | null | undefined): TourMeta | undefined {
+  if (!id) return undefined
+  return TOUR_CATALOGUE.find((t) => t.id === id)
+}

--- a/src-webgui/src/routes/index.tsx
+++ b/src-webgui/src/routes/index.tsx
@@ -70,6 +70,7 @@ function RootLayout() {
   const req = useKoma((s) => s.req)
   const openSettingsTab = useKoma((s) => s.openSettingsTab)
   const openHelpTab = useKoma((s) => s.openHelpTab)
+  const openTutorialTab = useKoma((s) => s.openTutorialTab)
   const openTerminalTab = useKoma((s) => s.openTerminalTab)
   // Counter for generating unique terminal IDs.
   const terminalCountRef = useRef(0)
@@ -250,6 +251,7 @@ function RootLayout() {
           onSelect={selectView}
           onSettings={openSettingsTab}
           onHelp={openHelpTab}
+          onTutorial={openTutorialTab}
         />
         {sidebarOpen && (
           <>
@@ -309,6 +311,9 @@ const SettingsTab = lazy(() => import('../components/SettingsTab'))
 
 // Help page — lazy so its chunk only loads when the (?) button is first clicked.
 const HelpTab = lazy(() => import('../components/HelpTab'))
+
+// Tutorial coach — lazy so driver.js + chat UI only load when first opened.
+const TutorialTab = lazy(() => import('../components/TutorialTab'))
 
 // Per-agent editor — lazy so its chunk only loads when the Agents panel's
 // first row (or "+ Add agent") is clicked.
@@ -386,6 +391,12 @@ function TabbedMain() {
             <div key={t.id} className={`absolute inset-0 ${activeTabId === t.id ? '' : 'hidden'}`}>
               <Suspense fallback={<DiffFallback />}>
                 <HelpTab />
+              </Suspense>
+            </div>
+          ) : t.kind === 'tutorial' ? (
+            <div key={t.id} className={`absolute inset-0 ${activeTabId === t.id ? '' : 'hidden'}`}>
+              <Suspense fallback={<DiffFallback />}>
+                <TutorialTab />
               </Suspense>
             </div>
           ) : t.kind === 'agent' ? (

--- a/src-webgui/src/store/koma.ts
+++ b/src-webgui/src/store/koma.ts
@@ -717,6 +717,8 @@ export type Tab =
   // (?) button, directly above Settings. Deduped by the fixed id 'help';
   // closeable like a diff tab. Mirrors the Settings tab's plumbing exactly.
   | { id: 'help'; kind: 'help' }
+  // Singleton Tutorial coach tab (NLP + driver.js). ActivityBar above Help.
+  | { id: 'tutorial'; kind: 'tutorial' }
   | {
       // Stable id — `diff:${path}` for a File-changed diff (find-by-path is
       // trivial), or `gitdiff:${staged ? 'staged' : 'unstaged'}:${path}` for a
@@ -1092,6 +1094,14 @@ export type PushEnvelope =
   // spinner). On success the authoritative registry reply is the following
   // InstalledExtensions push; `ok:false` + `error` surfaces a failure.
   | { k: 'ExtensionOpResult'; id: string; ok: boolean; error: string | null }
+  // Reply to TutorialChat — coach text + optional tour id (host strips TOUR: trailer).
+  | {
+      k: 'TutorialChatDone'
+      id: string
+      text: string
+      tour: string | null
+      error: string | null
+    }
   // Out-of-band reply to a GuiReq ExtPanelMsg (W9 panel bridge) — the
   // extension's `panel.msg` invoke outcome, re-pushed by the host from the
   // daemon's ExtPanelReply. Routed straight to the matching panel iframe via
@@ -1519,6 +1529,24 @@ type OAuthSlice = {
 // the InstalledExtensions push after every install/uninstall). `busy` covers a
 // browse/detail fetch OR an in-flight install/uninstall (the grid/detail show a
 // spinner); `error` is the last store/op error string (null when clear).
+// GUI Tutorial tab local transcript + in-flight turn. Not a real session —
+// host-proxied koma-free only. Transcript stays in memory for the window life.
+type TutorialMsg = {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  tour?: string | null
+}
+type TutorialSlice = {
+  messages: TutorialMsg[]
+  busy: boolean
+  error: string | null
+  // Client turn id awaiting TutorialChatDone (stale-drop).
+  pendingId: string | null
+  // Latest offered tour id from the coach (also mirrored on the assistant msg).
+  pendingTour: string | null
+}
+
 type StoreSlice = {
   catalogue: StoreItem[]
   detail: StoreDetail | null
@@ -1858,6 +1886,7 @@ type KomaState = {
   config: ConfigSlice
   oauth: OAuthSlice
   store: StoreSlice
+  tutorial: TutorialSlice
   // Persisted ActivityBar order/visibility layout (see `ActivityBarLayout`).
   activityBar: ActivityBarLayout
   // Live per-provider model-id catalogue, keyed by the most recent
@@ -2162,6 +2191,13 @@ type KomaState = {
   // Open (or focus) the singleton Help tab (id 'help'): find-or-create, activate
   // it. No wire request — the Help tab is static content, unlike Settings.
   openHelpTab: () => void
+  // Open (or focus) the singleton Tutorial tab (id 'tutorial').
+  openTutorialTab: () => void
+  // Send one Tutorial coach turn (host koma-free). Appends the user message
+  // optimistically; assistant lands on TutorialChatDone.
+  sendTutorialChat: (text: string) => void
+  clearTutorialPendingTour: () => void
+  clearTutorialError: () => void
   // ActivityBar drag-reorder: replace the persisted order wholesale (the caller
   // — ActivityBar's drop handler — computes the full reordered id list) and
   // write it through to localStorage.
@@ -2498,6 +2534,14 @@ const initialStore: StoreSlice = {
   opResult: null,
 }
 
+const initialTutorial: TutorialSlice = {
+  messages: [],
+  busy: false,
+  error: null,
+  pendingId: null,
+  pendingTour: null,
+}
+
 // Read once at module load (mirrors how `initialSession`/`initialUi` etc. seed
 // the store) — persisted ActivityBar layout, or an empty pair on a fresh
 // install / storage failure.
@@ -2685,6 +2729,7 @@ export const useKoma = create<KomaState>((set, get) => ({
   config: initialConfig,
   oauth: initialOAuth,
   store: initialStore,
+  tutorial: initialTutorial,
   activityBar: initialActivityBar,
   modelList: initialModelList,
   routeList: initialRouteList,
@@ -3262,6 +3307,41 @@ export const useKoma = create<KomaState>((set, get) => ({
           store: { ...s.store, catalogue: env.items, busy: false, error: env.error },
         }))
         break
+      case 'TutorialChatDone': {
+        // Stale-drop if a newer turn is in flight.
+        const pending = get().tutorial.pendingId
+        if (pending && env.id !== pending) break
+        set((s) => {
+          const msgs = [...s.tutorial.messages]
+          if (env.error) {
+            return {
+              tutorial: {
+                ...s.tutorial,
+                busy: false,
+                pendingId: null,
+                error: env.error,
+              },
+            }
+          }
+          msgs.push({
+            id: env.id,
+            role: 'assistant',
+            content: env.text || '(no reply)',
+            tour: env.tour,
+          })
+          return {
+            tutorial: {
+              ...s.tutorial,
+              messages: msgs,
+              busy: false,
+              pendingId: null,
+              pendingTour: env.tour,
+              error: null,
+            },
+          }
+        })
+        break
+      }
       // Store detail reply: fill `detail` (null on error) + clear busy. A failed
       // fetch surfaces `error` and leaves the detail null (the tab shows the
       // error), so the grid's own error isn't clobbered by a later detail error
@@ -4221,6 +4301,44 @@ export const useKoma = create<KomaState>((set, get) => ({
       const tabs: Tab[] = exists ? s.ui.tabs : [...s.ui.tabs, { id: 'help', kind: 'help' }]
       return { ui: { ...s.ui, tabs, activeTabId: 'help' } }
     })
+  },
+  openTutorialTab: () => {
+    set((s) => {
+      const exists = s.ui.tabs.some((t) => t.id === 'tutorial')
+      const tabs: Tab[] =
+        exists ? s.ui.tabs : [...s.ui.tabs, { id: 'tutorial', kind: 'tutorial' }]
+      return { ui: { ...s.ui, tabs, activeTabId: 'tutorial' } }
+    })
+  },
+  sendTutorialChat: (text) => {
+    const content = text.trim()
+    if (!content) return
+    const id =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `t-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const userMsg: TutorialMsg = { id: `${id}-u`, role: 'user', content }
+    set((s) => ({
+      tutorial: {
+        ...s.tutorial,
+        messages: [...s.tutorial.messages, userMsg],
+        busy: true,
+        error: null,
+        pendingId: id,
+        pendingTour: null,
+      },
+    }))
+    // Rolling transcript for the host (user/assistant only).
+    const wire = get().tutorial.messages
+      .filter((m) => m.role === 'user' || m.role === 'assistant')
+      .map((m) => ({ role: m.role, content: m.content }))
+    get().req({ r: 'TutorialChat', id, messages: wire })
+  },
+  clearTutorialPendingTour: () => {
+    set((s) => ({ tutorial: { ...s.tutorial, pendingTour: null } }))
+  },
+  clearTutorialError: () => {
+    set((s) => ({ tutorial: { ...s.tutorial, error: null } }))
   },
   setActivityBarOrder: (order) => {
     set((s) => {

--- a/src-webgui/src/styles.css
+++ b/src-webgui/src/styles.css
@@ -333,3 +333,49 @@ svg.animate-spin {
 }
 *::-webkit-scrollbar-thumb:hover { background: var(--color-koma-fg, #aaa); }
 *::-webkit-scrollbar-corner { background: transparent; }
+
+/* driver.js popover themed to koma palette (Tutorial tours). */
+.koma-driver-theme {
+  background: var(--koma-bg, #0b0e14) !important;
+  color: var(--koma-fg, #c8d3f5) !important;
+  border: 1px solid color-mix(in srgb, var(--koma-fg, #c8d3f5) 12%, var(--koma-bg, #0b0e14)) !important;
+  border-radius: 8px !important;
+  box-shadow: 0 8px 28px color-mix(in srgb, #000 45%, transparent) !important;
+}
+.koma-driver-theme .driver-popover-title {
+  color: var(--koma-fg, #c8d3f5) !important;
+  font-size: 13px !important;
+  font-weight: 600 !important;
+}
+.koma-driver-theme .driver-popover-description {
+  color: color-mix(in srgb, var(--koma-fg, #c8d3f5) 70%, transparent) !important;
+  font-size: 12px !important;
+  line-height: 1.5 !important;
+}
+.koma-driver-theme .driver-popover-progress-text {
+  color: var(--koma-dim, #adadad) !important;
+  font-size: 11px !important;
+}
+.koma-driver-theme .driver-popover-prev-btn,
+.koma-driver-theme .driver-popover-next-btn,
+.koma-driver-theme .driver-popover-close-btn {
+  background: color-mix(in srgb, var(--koma-fg, #c8d3f5) 8%, var(--koma-bg, #0b0e14)) !important;
+  color: var(--koma-fg, #c8d3f5) !important;
+  border: 1px solid color-mix(in srgb, var(--koma-fg, #c8d3f5) 14%, var(--koma-bg, #0b0e14)) !important;
+  text-shadow: none !important;
+  border-radius: 6px !important;
+}
+.koma-driver-theme .driver-popover-next-btn {
+  background: var(--koma-accent, #39ff14) !important;
+  color: var(--koma-bg, #0b0e14) !important;
+  border-color: transparent !important;
+}
+.koma-driver-theme .driver-popover-arrow-side-left,
+.koma-driver-theme .driver-popover-arrow-side-right,
+.koma-driver-theme .driver-popover-arrow-side-top,
+.koma-driver-theme .driver-popover-arrow-side-bottom {
+  border-color: var(--koma-bg, #0b0e14) !important;
+}
+.driver-overlay {
+  background-color: color-mix(in srgb, #000 55%, transparent) !important;
+}


### PR DESCRIPTION
Add a singleton Tutorial tab above Help with an NLP coach over host-proxied koma-free (no daemon), pixel paperclip chrome, static topic fallback, and themed driver.js guided tours for setup recipes and feature spotlights.