### PR TITLE
fix(gui): leave session on remote disconnect + solid titlebar

### DIFF
--- a/src-agent/src/app/runtime/client/push_loop.rs
+++ b/src-agent/src/app/runtime/client/push_loop.rs
@@ -1167,9 +1167,13 @@ pub(super) fn push_loop(
                 }
                 Ok(super::HostCtl::DisconnectRemote) | Ok(super::HostCtl::CancelRemoteConnect) => {
                     // During connect/auth, dropping the password sender releases the
-                    // worker. Once connected, push_loop has already transitioned to
-                    // the remote transport; its normal detach path handles cleanup.
+                    // worker. Once a remote session is live, we must leave the attach
+                    // entirely — otherwise the GUI keeps a stale session.id and stays
+                    // stuck on ChatView over a dead SSH bridge.
                     remote_shared.cancel();
+                    if remote_ctx.is_some() {
+                        return HostTransition::DisconnectRemote;
+                    }
                     push_remote_state(push, "disconnected", None, None, None, None, None, &[]);
                 }
                 Ok(super::HostCtl::SubmitRemotePassword { password }) => {

--- a/src-webgui/src/components/Titlebar.tsx
+++ b/src-webgui/src/components/Titlebar.tsx
@@ -84,7 +84,7 @@ export function Titlebar({ onSearch, onRename, onTerminal, overlayOpen }: Titleb
             onClick={onTerminal}
             title="New Terminal"
             aria-label="New Terminal"
-            className="pointer-events-auto mr-2 flex h-[22px] items-center gap-1.5 rounded-md border border-koma-border bg-koma-panel px-2 text-[12px] text-koma-fg opacity-70 transition-colors hover:bg-koma-hover hover:opacity-100"
+            className="pointer-events-auto mr-2 flex h-[22px] items-center gap-1.5 rounded-md border border-koma-border bg-koma-panel px-2 text-[12px] text-koma-fg transition-colors hover:bg-koma-hover"
           >
             <SquareTerminal size={13} className="flex-none" />
           </button>
@@ -93,7 +93,7 @@ export function Titlebar({ onSearch, onRename, onTerminal, overlayOpen }: Titleb
             transition={CMD_SEARCH_SPRING}
             onClick={onSearch}
             title="Change session"
-            className={`pointer-events-auto flex h-[22px] ${CMD_SEARCH_WIDTH} items-center justify-start gap-2 rounded-md border border-koma-border bg-koma-panel px-2.5 text-[12px] text-koma-fg opacity-70 transition-colors hover:bg-koma-hover hover:opacity-100`}
+            className={`pointer-events-auto flex h-[22px] ${CMD_SEARCH_WIDTH} items-center justify-start gap-2 rounded-md border border-koma-border bg-koma-panel px-2.5 text-[12px] text-koma-fg transition-colors hover:bg-koma-hover`}
           >
             <motion.span layout="position" className="flex items-center gap-2">
               <Terminal size={13} className="flex-none" />
@@ -119,7 +119,7 @@ export function Titlebar({ onSearch, onRename, onTerminal, overlayOpen }: Titleb
                 onClick={onRename}
                 title="Rename session"
                 aria-label="Rename session"
-                className="pointer-events-auto flex h-[22px] items-center gap-1.5 rounded-md border border-koma-border bg-koma-panel px-2.5 text-[12px] text-koma-fg opacity-70 transition-colors hover:bg-koma-hover hover:opacity-100"
+                className="pointer-events-auto flex h-[22px] items-center gap-1.5 rounded-md border border-koma-border bg-koma-panel px-2.5 text-[12px] text-koma-fg transition-colors hover:bg-koma-hover"
               >
                 <motion.span layout="position" className="flex items-center gap-1.5">
                   <PenLine size={13} className="flex-none" />
@@ -134,7 +134,7 @@ export function Titlebar({ onSearch, onRename, onTerminal, overlayOpen }: Titleb
                 className={`pointer-events-auto flex h-[22px] items-center gap-1.5 rounded-md border border-koma-border bg-koma-panel px-2.5 text-[12px] transition-colors ${
                   working
                     ? 'text-koma-dim opacity-40'
-                    : 'text-koma-fg opacity-70 hover:bg-koma-hover hover:opacity-100'
+                    : 'text-koma-fg hover:bg-koma-hover'
                 }`}
               >
                 <FoldVertical size={13} className="flex-none" />

--- a/src-webgui/src/components/panels/RemotePanel.tsx
+++ b/src-webgui/src/components/panels/RemotePanel.tsx
@@ -32,6 +32,7 @@ export function RemotePanel() {
   const remoteHosts = useKoma((s) => s.remoteHosts)
   const remoteState = useKoma((s) => s.remoteState)
   const push = useKoma((s) => s.req)
+  const detachSession = useKoma((s) => s.detachSession)
   const [view, setView] = useState<RemotePanelView>({ kind: 'list' })
   const [query, setQuery] = useState('')
   const [editId, setEditId] = useState<string | null>(null)
@@ -78,6 +79,9 @@ export function RemotePanel() {
     push({ r: 'ConnectRemoteHost', hostId })
   }
   const handleDisconnect = () => {
+    // Optimistic: drop the dead session view immediately so StartScreen shows
+    // while the host tears down the SSH bridge (RemoteState also detaches).
+    if (useKoma.getState().session.id != null) detachSession()
     push({ r: 'DisconnectRemoteHost', hostId: remoteState.hostId ?? '' })
   }
   const confirmDelete = (hostId: string) => {

--- a/src-webgui/src/routes/index.tsx
+++ b/src-webgui/src/routes/index.tsx
@@ -251,7 +251,9 @@ function RootLayout() {
         onSearch={() => setOverlay('resume')}
         onRename={() => setOverlay('rename')}
         onTerminal={handleTerminal}
-        overlayOpen={overlay !== 'none'}
+        // Hide cmdbar pills while resume/rename OR remote cwd picker is open —
+        // same morph handoff rename uses (layoutId stays free for the overlay).
+        overlayOpen={overlay !== 'none' || remotePathOpen}
       />
       <div className="absolute inset-x-0 top-8 bottom-0 flex overflow-hidden">
         <ActivityBar

--- a/src-webgui/src/store/koma.ts
+++ b/src-webgui/src/store/koma.ts
@@ -4167,6 +4167,26 @@ export const useKoma = create<KomaState>((set, get) => ({
         set(() => ({ remoteHosts: env.hosts }))
         break
       case 'RemoteState':
+        // Leaving a remote attach (disconnect / back to hub / connect bounce) must
+        // clear session.id so routes flip StartScreen — same job as detachSession
+        // after kill. Host no longer owns this GUI session once RemoteState says
+        // ready (hub, no session) or disconnected after a live remote.
+        {
+          const prev = get().remoteState
+          const hadLiveRemote =
+            prev.state === 'ready' ||
+            prev.state === 'connected' ||
+            prev.state === 'connecting' ||
+            prev.state === 'auth_required' ||
+            prev.state === 'bootstrapping' ||
+            prev.state === 'resolving'
+          const leaveToHub = env.state === 'ready' && get().session.id != null
+          const leaveToLocal =
+            env.state === 'disconnected' && hadLiveRemote && get().session.id != null
+          if (leaveToHub || leaveToLocal) {
+            get().detachSession()
+          }
+        }
         set((s) => {
           const remoteState = {
             state: env.state,


### PR DESCRIPTION
- push_loop returns DisconnectRemote while remote-attached so SSH tears down
- RemoteState ready/disconnected detaches stale session → StartScreen
- RemotePanel disconnect optimistically detaches
- Titlebar pills solid when enabled; opacity only when disabled
- Hide cmdbar while remote cwd picker open (rename/resume parity)