### PR TITLE
fix(gui): braille remote path open, drop second-window, coding name w…

### DIFF
--- a/src-webgui/src/components/NewSessionMenu.tsx
+++ b/src-webgui/src/components/NewSessionMenu.tsx
@@ -43,8 +43,14 @@ export function NewSessionMenu({ afterPick, className = '' }: NewSessionMenuProp
   const req = useKoma((s) => s.req)
   const remoteHosts = useKoma((s) => s.remoteHosts)
   const remoteState = useKoma((s) => s.remoteState)
+  const remotePathState = useKoma((s) => s.remotePath.state)
   const startSwitching = useKoma((s) => s.startSwitching)
+  const requestRemotePath = useKoma((s) => s.requestRemotePath)
   const attachedId = useKoma((s) => s.session.id)
+  const remotePathBusy =
+    remotePathState === 'listing' ||
+    remotePathState === 'ready' ||
+    remotePathState === 'error'
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLButtonElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -72,8 +78,8 @@ export function NewSessionMenu({ afterPick, className = '' }: NewSessionMenuProp
 
   const pick = (kill: boolean) => {
     if (remoteState.state === 'ready' || remoteState.state === 'connected') {
-      // Remote hub: open the remote path picker instead of a local session.
-      req({ r: 'RequestRemotePath' })
+      // Remote hub: optimistic SSH path picker (guards re-entry + braille).
+      requestRemotePath()
       setOpen(false)
       afterPick?.()
       return
@@ -85,7 +91,7 @@ export function NewSessionMenu({ afterPick, className = '' }: NewSessionMenuProp
 
   const openFolder = () => {
     if (remoteState.state === 'ready' || remoteState.state === 'connected') {
-      req({ r: 'RequestRemotePath' })
+      requestRemotePath()
       setOpen(false)
       afterPick?.()
       return
@@ -167,11 +173,19 @@ export function NewSessionMenu({ afterPick, className = '' }: NewSessionMenuProp
             className="overflow-hidden rounded-md border border-koma-border bg-koma-panel py-1 shadow-sm"
           >
             {/* Local session options — always visible */}
-            <MenuItem onClick={openFolder} icon={<FolderOpen size={13} />}>
+            <MenuItem
+              onClick={openFolder}
+              disabled={remotePathBusy}
+              icon={
+                remotePathBusy ? <BrailleSpinner size={13} /> : <FolderOpen size={13} />
+              }
+            >
               New session
             </MenuItem>
             {attachedId && (
-              <MenuItem onClick={() => pick(true)}>New session + close current</MenuItem>
+              <MenuItem onClick={() => pick(true)} disabled={remotePathBusy}>
+                New session + close current
+              </MenuItem>
             )}
             {/* Remote hosts — always visible when any are saved */}
             {remoteHosts.length > 0 && (

--- a/src-webgui/src/components/RemotePathPicker.tsx
+++ b/src-webgui/src/components/RemotePathPicker.tsx
@@ -42,6 +42,9 @@ export function RemotePathPicker() {
     remotePath.state === 'listing' ||
     remotePath.state === 'ready' ||
     remotePath.state === 'error'
+  // Blocks double-click on "Select folder" minting two remote sessions before
+  // the optimistic dismiss unmounts the overlay.
+  const confirmingRef = useRef(false)
 
   const [query, setQuery] = useState('')
   const [focusTarget, setFocusTarget] = useState<FocusTarget>('search')
@@ -58,6 +61,7 @@ export function RemotePathPicker() {
       setFocusTarget('search')
       setHighlight(0)
       syncedPathRef.current = null
+      confirmingRef.current = false
       return
     }
     setFocusTarget('search')
@@ -136,12 +140,15 @@ export function RemotePathPicker() {
   if (!active) return null
 
   const cancel = () => {
+    confirmingRef.current = false
     req({ r: 'CancelRemotePath' })
     // Optimistic dismiss so Esc never leaves a stuck overlay if the host lags.
     useKoma.setState({ remotePath: { ...IDLE_PATH } })
   }
   const confirm = () => {
+    if (confirmingRef.current) return
     if (!remotePath.path || remotePath.state === 'listing') return
+    confirmingRef.current = true
     const path = remotePath.path
     req({ r: 'ConfirmRemotePath', path })
     // Optimistic close + switcher. Host also pushes cancelled + Switching;

--- a/src-webgui/src/components/ResumePalette.tsx
+++ b/src-webgui/src/components/ResumePalette.tsx
@@ -7,6 +7,7 @@ import { SessionRowActions, SessionRowConfirmStrip, type ArmedRow } from './Sess
 import { SessionBulkBar } from './SessionBulkBar'
 import { useSessionMultiSelect } from './sessionListSelection'
 import { useKoma, isDying } from '../store/koma'
+import { BrailleSpinner } from './BrailleSpinner'
 
 type ResumePaletteProps = {
   onClose: () => void
@@ -37,8 +38,10 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
   const history = useKoma((s) => s.hub.history)
   const req = useKoma((s) => s.req)
   const startSwitching = useKoma((s) => s.startSwitching)
+  const requestRemotePath = useKoma((s) => s.requestRemotePath)
   const dyingSessions = useKoma((s) => s.dyingSessions)
   const remoteState = useKoma((s) => s.remoteState)
+  const remotePathState = useKoma((s) => s.remotePath.state)
   const [query, setQuery] = useState('')
   // The single armed row (kill/delete confirm pill) across BOTH lists — arming
   // a different row disarms whichever was armed before.
@@ -97,10 +100,15 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
     onClose()
   }
 
+  const remotePathBusy =
+    remotePathState === 'listing' ||
+    remotePathState === 'ready' ||
+    remotePathState === 'error'
+
   const newSession = () => {
-    // Remote hub / attached remote: open remote path picker (not local folder dialog).
+    // Remote hub / attached remote: optimistic SSH path picker (guards re-entry).
     if (remoteState.state === 'ready' || remoteState.state === 'connected') {
-      req({ r: 'RequestRemotePath' })
+      requestRemotePath()
       onClose()
       return
     }
@@ -200,9 +208,14 @@ export function ResumePalette({ onClose }: ResumePaletteProps) {
                 <span className="flex items-center">
                   <button
                     onClick={newSession}
-                    className="flex items-center gap-1 text-[11px] text-koma-fg opacity-70 transition-colors hover:opacity-100"
+                    disabled={remotePathBusy}
+                    className="flex items-center gap-1 text-[11px] text-koma-fg opacity-70 transition-colors hover:opacity-100 disabled:cursor-wait disabled:opacity-50"
                   >
-                    <Plus size={12} className="flex-none" />
+                    {remotePathBusy ? (
+                      <BrailleSpinner size={12} className="flex-none" />
+                    ) : (
+                      <Plus size={12} className="flex-none" />
+                    )}
                     New session
                   </button>
                   <NewSessionMenu afterPick={onClose} />

--- a/src-webgui/src/components/SessionRowActions.tsx
+++ b/src-webgui/src/components/SessionRowActions.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Check, ExternalLink, Power, Trash2, X } from 'lucide-react'
+import { Check, Power, Trash2, X } from 'lucide-react'
 import { useKoma, isDying } from '../store/koma'
 import { BrailleSpinner } from './BrailleSpinner'
 
@@ -15,8 +15,6 @@ type SessionRowActionsProps = {
   kind: 'session' | 'history'
   armed: ArmedRow
   onArm: (row: ArmedRow) => void
-  /** When set, show "open in new window" for multi-window multi-attach. */
-  remoteHostId?: string | null
 }
 
 // Trailing ghost icon on a Cooking/History row. Meant to be rendered INSIDE a
@@ -31,12 +29,13 @@ type SessionRowActionsProps = {
 // (non-interactive) instead while `dyingSessions` carries a kind-matching
 // mark for this id — cleared automatically the moment a fresh Hub push
 // confirms the kill/delete landed (see koma.ts's Hub push handler).
-export function SessionRowActions({ id, kind, armed, onArm, remoteHostId }: SessionRowActionsProps) {
+//
+// Multi-window ("open in new window") is intentionally NOT offered here —
+// session lists are single-window by design.
+export function SessionRowActions({ id, kind, armed, onArm }: SessionRowActionsProps) {
   const dying = useKoma((s) => isDying(s.dyingSessions, id, kind))
   const theme = useKoma((s) => s.config.theme)
   const palettes = useKoma((s) => s.config.palettes)
-  const req = useKoma((s) => s.req)
-  const remoteState = useKoma((s) => s.remoteState)
 
   // Reserved for future row-action tints (confirm strip uses its own lookup).
   const _errorTint = useMemo(() => {
@@ -53,32 +52,9 @@ export function SessionRowActions({ id, kind, armed, onArm, remoteHostId }: Sess
   // in place of the row's normal content instead of this trailing slot.
   if (armed?.id === id && armed.kind === kind) return null
 
-  const hostId =
-    remoteHostId ??
-    (remoteState.state === 'ready' || remoteState.state === 'connected'
-      ? remoteState.hostId
-      : null)
-
   const Icon = kind === 'session' ? Power : Trash2
   return (
     <span className="flex h-full w-full flex-none items-center justify-end gap-0.5">
-      {kind === 'session' && (
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            req({
-              r: 'OpenSecondWindow',
-              sessionId: id,
-              ...(hostId ? { hostId } : {}),
-            })
-          }}
-          aria-label="Open in new window"
-          title="Open in new window"
-          className="flex h-full w-6 flex-none items-center justify-center text-koma-fg opacity-0 transition-opacity group-hover:opacity-40 hover:!opacity-100 focus-visible:opacity-100"
-        >
-          <ExternalLink size={12} className="flex-none" />
-        </button>
-      )}
       <button
         onClick={(e) => {
           e.stopPropagation()

--- a/src-webgui/src/components/StartScreen.tsx
+++ b/src-webgui/src/components/StartScreen.tsx
@@ -5,6 +5,7 @@ import { SessionRowActions, SessionRowConfirmStrip, type ArmedRow } from './Sess
 import { SessionBulkBar } from './SessionBulkBar'
 import { useSessionMultiSelect } from './sessionListSelection'
 import { useKoma, isDying } from '../store/koma'
+import { BrailleSpinner } from './BrailleSpinner'
 
 // Measures the component's own width with a ResizeObserver (a container query in
 // JS) so the start screen can flip stacked -> side-by-side against the ACTUAL
@@ -55,8 +56,10 @@ export function StartScreen() {
   const cooking = useKoma((s) => s.hub.cooking)
   const req = useKoma((s) => s.req)
   const startSwitching = useKoma((s) => s.startSwitching)
+  const requestRemotePath = useKoma((s) => s.requestRemotePath)
   const dyingSessions = useKoma((s) => s.dyingSessions)
   const remoteState = useKoma((s) => s.remoteState)
+  const remotePathState = useKoma((s) => s.remotePath.state)
   const [ref, width] = useContainerWidth<HTMLDivElement>()
   const wide = width >= 760
   // The single armed row (kill/delete confirm pill) across BOTH lists — arming
@@ -107,16 +110,21 @@ export function StartScreen() {
     startSwitching(name)
     req({ r: 'SelectSession', id })
   }
-  // No optimistic loader: the host opens a folder picker first and only
-  // attaches once a folder is confirmed (cancel would strand the loader).
-  // Remote hub uses the SSH path picker instead of the local native dialog.
+  // Local: no optimistic loader — host opens a native folder picker first and
+  // only attaches once confirmed (cancel would strand the loader).
+  // Remote hub: optimistic SSH path picker (requestRemotePath guards re-entry
+  // and shows braille listing immediately).
   const newSession = () => {
     if (remoteState.state === 'ready' || remoteState.state === 'connected') {
-      req({ r: 'RequestRemotePath' })
+      requestRemotePath()
       return
     }
     req({ r: 'NewSession' })
   }
+  const remotePathBusy =
+    remotePathState === 'listing' ||
+    remotePathState === 'ready' ||
+    remotePathState === 'error'
 
   const armRow = (row: ArmedRow) => {
     multi.clear()
@@ -164,23 +172,30 @@ export function StartScreen() {
         )}
       </div>
 
-      <div className="group flex items-center rounded-xl border border-koma-border bg-koma-panel transition-colors hover:border-koma-accent/60 hover:bg-koma-hover">
+      <div className={`group flex items-center rounded-xl border border-koma-border bg-koma-panel transition-colors ${remotePathBusy ? 'opacity-70' : 'hover:border-koma-accent/60 hover:bg-koma-hover'}`}>
         <button
           onClick={newSession}
-          className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-left"
+          disabled={remotePathBusy}
+          className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-left disabled:cursor-wait"
         >
           <span className="flex h-9 w-9 flex-none items-center justify-center rounded-lg bg-koma-accent/15 text-koma-accent">
-            <FolderPlus size={18} />
+            {remotePathBusy ? <BrailleSpinner size={18} /> : <FolderPlus size={18} />}
           </span>
           <span className="min-w-0 flex-1">
             <span className="block text-[13px] font-semibold text-koma-fg">New session</span>
             <span className="block text-[11px] text-koma-fg opacity-45">
-              {remoteTarget
-                ? `Pick a folder on ${remoteTarget}`
-                : 'Start working in your default directory'}
+              {remotePathBusy
+                ? 'Opening remote folder picker…'
+                : remoteTarget
+                  ? `Pick a folder on ${remoteTarget}`
+                  : 'Start working in your default directory'}
             </span>
           </span>
-          <ArrowRight size={16} className="flex-none text-koma-fg opacity-30 transition group-hover:translate-x-0.5 group-hover:opacity-70" />
+          {remotePathBusy ? (
+            <span className="flex-none" />
+          ) : (
+            <ArrowRight size={16} className="flex-none text-koma-fg opacity-30 transition group-hover:translate-x-0.5 group-hover:opacity-70" />
+          )}
         </button>
         <NewSessionMenu className="pr-3" />
       </div>

--- a/src-webgui/src/components/panels/CodingPanel.tsx
+++ b/src-webgui/src/components/panels/CodingPanel.tsx
@@ -267,7 +267,7 @@ function TreeNode({
             <button
               type="button"
               onClick={() => (entry.isDir ? onToggle(entry.path) : onOpenFile(entry.path))}
-              className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+              className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden text-left"
               title={entry.path || entry.name}
             >
               {entry.isDir ? (
@@ -279,35 +279,41 @@ function TreeNode({
               ) : (
                 <File size={13} className="flex-none opacity-70" />
               )}
-              <span className="min-w-0 truncate">{entry.name}</span>
+              {/* Truncates at the panel wall while idle. Hover expands the action
+                  gutter below, which shrinks this flex slot so ellipsis moves to
+                  the button edge instead of a permanently reserved gutter. */}
+              <span className="min-w-0 flex-1 truncate">{entry.name}</span>
             </button>
 
-            {!draft ? <div className="flex flex-none items-center opacity-0 group-hover:opacity-100">
-              {entry.isDir && (
-                <>
-                  <IconBtn label="New file" faded onClick={() => onStartCreate(entry.path, 'file')}>
-                    <FilePlus size={12} />
-                  </IconBtn>
-                  <IconBtn label="New folder" faded onClick={() => onStartCreate(entry.path, 'dir')}>
-                    <FolderPlus size={12} />
-                  </IconBtn>
-                  <IconBtn label="Refresh" faded onClick={() => onRefresh(entry.path)}>
-                    <RefreshCw size={12} />
-                  </IconBtn>
-                </>
-              )}
-              <IconBtn label="Rename" faded onClick={() => onStartRename(entry.path)}>
-                <Pencil size={12} />
-              </IconBtn>
-              <IconBtn
-                label="Delete"
-                tone="red"
-                faded
-                onClick={() => onStartDelete(entry.path, entry.isDir)}
-              >
-                <Trash2 size={12} />
-              </IconBtn>
-            </div> : null}
+            {/* Idle: max-w-0 so actions take no flex width (no premature ellipsis).
+                Hover: expand and show. opacity alone would still reserve space. */}
+            {!draft ? (
+              <div className="flex max-w-0 flex-none items-center overflow-hidden opacity-0 transition-[max-width,opacity] duration-100 group-hover:max-w-[140px] group-hover:opacity-100">
+                {entry.isDir && (
+                  <>
+                    <IconBtn label="New file" onClick={() => onStartCreate(entry.path, 'file')}>
+                      <FilePlus size={12} />
+                    </IconBtn>
+                    <IconBtn label="New folder" onClick={() => onStartCreate(entry.path, 'dir')}>
+                      <FolderPlus size={12} />
+                    </IconBtn>
+                    <IconBtn label="Refresh" onClick={() => onRefresh(entry.path)}>
+                      <RefreshCw size={12} />
+                    </IconBtn>
+                  </>
+                )}
+                <IconBtn label="Rename" onClick={() => onStartRename(entry.path)}>
+                  <Pencil size={12} />
+                </IconBtn>
+                <IconBtn
+                  label="Delete"
+                  tone="red"
+                  onClick={() => onStartDelete(entry.path, entry.isDir)}
+                >
+                  <Trash2 size={12} />
+                </IconBtn>
+              </div>
+            ) : null}
 
             {dirty ? (
               <span

--- a/src-webgui/src/store/koma.ts
+++ b/src-webgui/src/store/koma.ts
@@ -2179,6 +2179,10 @@ type KomaState = {
   // loader — the eventual Snapshot for the target session still lands and is
   // applied normally.
   cancelSwitching: () => void
+  // Open the remote folder picker. Optimistic `listing` so the overlay + braille
+  // spinner appear on the first click (SSH list_dirs can lag). No-ops while the
+  // picker is already open so double-clicks don't spawn duplicate SSH listings.
+  requestRemotePath: () => void
   dismissLoading: () => void
   // Dismiss the active toast (auto-dismiss timer, or a manual close). No-op if
   // the id no longer matches the current toast (a newer toast already replaced
@@ -4309,6 +4313,29 @@ export const useKoma = create<KomaState>((set, get) => ({
   requestScrollBottom: () => set((s) => ({ ui: { ...s.ui, scrollTick: s.ui.scrollTick + 1 } })),
   startSwitching: (name) => set((s) => ({ ui: { ...s.ui, switchingTo: name } })),
   cancelSwitching: () => set((s) => ({ ui: { ...s.ui, switchingTo: null } })),
+  requestRemotePath: () => {
+    const s = get()
+    // Picker already visible / in-flight — drop the duplicate click.
+    if (
+      s.remotePath.state === 'listing' ||
+      s.remotePath.state === 'ready' ||
+      s.remotePath.state === 'error'
+    ) {
+      return
+    }
+    // Optimistic open: RemotePathPicker mounts immediately with a braille
+    // spinner while the host SSH-lists "~". Host RemotePathPicker push replaces
+    // this with the authoritative path/dirs.
+    set({
+      remotePath: {
+        state: 'listing',
+        path: '~',
+        dirs: [],
+        error: null,
+      },
+    })
+    get().req({ r: 'RequestRemotePath' })
+  },
   dismissLoading: () => set((s) => ({ ui: { ...s.ui, loadingDismissed: true } })),
   dismissToast: (id) =>
     set((s) => (s.ui.toast?.id === id ? { ui: { ...s.ui, toast: null } } : s)),


### PR DESCRIPTION
…idth

- Optimistic requestRemotePath with listing spinner and re-entry guard
- Guard ConfirmRemotePath double-fire; disable New session while busy
- Remove Open in new window from session rows (single-window by design)
- Coding tree: hover-expand action gutter so names use full panel width idle