### PR TITLE
feat: LSP host client + Monaco bridge, drag-upload and download

### DIFF
--- a/src-agent/Cargo.toml
+++ b/src-agent/Cargo.toml
@@ -9,7 +9,7 @@ winresource = "0.1"
 
 [dependencies]
 ratatui = "0.30.2"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "net", "io-util", "io-std", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "net", "io-util", "io-std", "signal", "process"] }
 reqwest = { version = "0.12", features = ["json", "stream", "blocking", "native-tls-vendored"] }
 dom_smoothie = "0.18.0"
 fast_html2md = "0.0.62"

--- a/src-agent/src/app/runtime/client/file_ops.rs
+++ b/src-agent/src/app/runtime/client/file_ops.rs
@@ -25,6 +25,11 @@ use super::HostCtl;
 /// `tooLarge: true` rather than shipping multi-megabyte content into Monaco.
 const FILE_READ_SIZE_CAP: u64 = 5 * 1024 * 1024;
 
+/// Cap on binary upload/download through the GUI bridge (~25 MiB decoded).
+/// Larger than the Monaco text-read cap: drag-upload / save-as carry raw bytes
+/// as base64, not editor buffers.
+const FILE_BYTES_SIZE_CAP: u64 = 25 * 1024 * 1024;
+
 /// Directory basenames excluded from Coding panel tree listings.
 const EXCLUDED_DIRS: &[&str] = &[".git", ".koma", "node_modules", "target"];
 
@@ -104,6 +109,32 @@ pub(crate) struct FileDeleteResult {
     pub error: Option<String>,
     #[serde(skip)]
     pub mutated: bool,
+}
+
+/// Binary write (drag-upload) result for Coding panel / remote-fs.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FileWriteBytesResult {
+    pub root: String,
+    pub path: String,
+    pub request_id: String,
+    pub error: Option<String>,
+    #[serde(skip)]
+    pub mutated: bool,
+}
+
+/// Binary download result for Coding panel / remote-fs.
+/// `bytes_b64` is standard base64 of the file body when successful.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FileDownloadBytesResult {
+    pub root: String,
+    pub path: String,
+    pub request_id: String,
+    pub bytes_b64: Option<String>,
+    pub size: u64,
+    pub too_large: bool,
+    pub error: Option<String>,
 }
 
 /// Handle one File* HostCtl by computing the result and pushing it back.
@@ -236,6 +267,46 @@ pub(super) fn handle_file_ctl(
             if r.mutated {
                 refresh_git_status(push, session);
             }
+        }
+        HostCtl::FileWriteBytes {
+            root,
+            path,
+            bytes_b64,
+            overwrite,
+            request_id,
+        } => {
+            let r = exec_file_write_bytes(root, path, bytes_b64, *overwrite, request_id, workdirs);
+            emit(
+                push,
+                &PushEnvelope::FileWriteBytes {
+                    root: r.root,
+                    path: r.path,
+                    request_id: r.request_id,
+                    error: r.error,
+                },
+            );
+            if r.mutated {
+                refresh_git_status(push, session);
+            }
+        }
+        HostCtl::FileDownloadBytes {
+            root,
+            path,
+            request_id,
+        } => {
+            let r = exec_file_download_bytes(root, path, request_id, workdirs);
+            emit(
+                push,
+                &PushEnvelope::FileDownloadBytes {
+                    root: r.root,
+                    path: r.path,
+                    request_id: r.request_id,
+                    bytes_b64: r.bytes_b64,
+                    size: r.size,
+                    too_large: r.too_large,
+                    error: r.error,
+                },
+            );
         }
         _ => {}
     }
@@ -554,6 +625,151 @@ pub(crate) fn exec_file_delete(
         },
         Err(e) => fail(e),
     }
+}
+
+/// Write raw bytes (base64-encoded on the wire) under the workdir sandbox.
+/// Used for drag-upload from the Coding tree (local copy or remote upload).
+pub(crate) fn exec_file_write_bytes(
+    root: &str,
+    path: &str,
+    bytes_b64: &str,
+    overwrite: bool,
+    request_id: &str,
+    workdirs: &[PathBuf],
+) -> FileWriteBytesResult {
+    let fail = |error: String| FileWriteBytesResult {
+        root: root.to_string(),
+        path: path.to_string(),
+        request_id: request_id.to_string(),
+        error: Some(error),
+        mutated: false,
+    };
+
+    if path.is_empty() || path == "." {
+        return fail("refusing to write workspace root".to_string());
+    }
+
+    let bytes = match decode_b64(bytes_b64) {
+        Ok(b) => b,
+        Err(e) => return fail(e),
+    };
+    if bytes.len() as u64 > FILE_BYTES_SIZE_CAP {
+        return fail(format!(
+            "file too large (max {} MiB)",
+            FILE_BYTES_SIZE_CAP / (1024 * 1024)
+        ));
+    }
+
+    let abs = match resolve_contained(root, path, workdirs) {
+        Ok(p) => p,
+        Err(e) => return fail(e),
+    };
+
+    if abs.exists() {
+        if abs.is_dir() {
+            return fail("destination is a directory".to_string());
+        }
+        if !overwrite {
+            return fail("path already exists".to_string());
+        }
+    }
+
+    if let Some(parent) = abs.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            return fail(format!("failed to create parent dirs: {e}"));
+        }
+    }
+
+    if let Err(e) = std::fs::write(&abs, &bytes) {
+        return fail(format!("failed to write file: {e}"));
+    }
+
+    FileWriteBytesResult {
+        root: root.to_string(),
+        path: path.to_string(),
+        request_id: request_id.to_string(),
+        error: None,
+        mutated: true,
+    }
+}
+
+/// Read raw bytes for download / save-as. Returns standard base64.
+pub(crate) fn exec_file_download_bytes(
+    root: &str,
+    path: &str,
+    request_id: &str,
+    workdirs: &[PathBuf],
+) -> FileDownloadBytesResult {
+    let fail = |error: String, too_large: bool| FileDownloadBytesResult {
+        root: root.to_string(),
+        path: path.to_string(),
+        request_id: request_id.to_string(),
+        bytes_b64: None,
+        size: 0,
+        too_large,
+        error: Some(error),
+    };
+
+    if path.is_empty() || path == "." {
+        return fail("refusing to download workspace root".to_string(), false);
+    }
+
+    let abs = match resolve_contained(root, path, workdirs) {
+        Ok(p) => p,
+        Err(e) => return fail(e, false),
+    };
+
+    if !abs.exists() {
+        return fail("path does not exist".to_string(), false);
+    }
+    if abs.is_dir() {
+        return fail("cannot download a directory".to_string(), false);
+    }
+
+    let meta = match std::fs::metadata(&abs) {
+        Ok(m) => m,
+        Err(e) => return fail(format!("failed to stat file: {e}"), false),
+    };
+    let size = meta.len();
+    if size > FILE_BYTES_SIZE_CAP {
+        return FileDownloadBytesResult {
+            root: root.to_string(),
+            path: path.to_string(),
+            request_id: request_id.to_string(),
+            bytes_b64: None,
+            size,
+            too_large: true,
+            error: Some(format!(
+                "file too large to download (max {} MiB)",
+                FILE_BYTES_SIZE_CAP / (1024 * 1024)
+            )),
+        };
+    }
+
+    let bytes = match std::fs::read(&abs) {
+        Ok(b) => b,
+        Err(e) => return fail(format!("failed to read file: {e}"), false),
+    };
+
+    use base64::Engine as _;
+    let bytes_b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    FileDownloadBytesResult {
+        root: root.to_string(),
+        path: path.to_string(),
+        request_id: request_id.to_string(),
+        bytes_b64: Some(bytes_b64),
+        size,
+        too_large: false,
+        error: None,
+    }
+}
+
+fn decode_b64(s: &str) -> Result<Vec<u8>, String> {
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD
+        .decode(s.trim())
+        .or_else(|_| base64::engine::general_purpose::STANDARD_NO_PAD.decode(s.trim()))
+        .map_err(|e| format!("invalid base64: {e}"))
 }
 
 /// Best-effort GIT panel refresh after a Coding-panel mutation.

--- a/src-agent/src/app/runtime/client/file_ops_test.rs
+++ b/src-agent/src/app/runtime/client/file_ops_test.rs
@@ -342,5 +342,44 @@ fn handle_file_ctl_routes_create_tree_rename_delete() {
     assert_eq!(json_for_request(&sink, "ctl-d")["requestId"], "ctl-d");
     assert!(!dir.join("readme.md").exists());
 
+    // Binary write + download round-trip (drag-upload / save-as path).
+    use base64::Engine as _;
+    let payload = b"hello\0binary\xff";
+    let b64 = base64::engine::general_purpose::STANDARD.encode(payload);
+    handle_file_ctl(
+        &HostCtl::FileWriteBytes {
+            root: root_s.clone(),
+            path: "blob.bin".into(),
+            bytes_b64: b64,
+            overwrite: false,
+            request_id: "ctl-w".into(),
+        },
+        push.as_ref(),
+        &workdirs,
+        None,
+    );
+    let w = json_for_request(&sink, "ctl-w");
+    assert!(w["error"].is_null(), "{w}");
+    assert_eq!(std::fs::read(dir.join("blob.bin")).unwrap(), payload);
+
+    handle_file_ctl(
+        &HostCtl::FileDownloadBytes {
+            root: root_s.clone(),
+            path: "blob.bin".into(),
+            request_id: "ctl-dl".into(),
+        },
+        push.as_ref(),
+        &workdirs,
+        None,
+    );
+    let dl = json_for_request(&sink, "ctl-dl");
+    assert!(dl["error"].is_null(), "{dl}");
+    assert_eq!(dl["tooLarge"], false);
+    assert_eq!(dl["size"], payload.len() as u64);
+    let got = base64::engine::general_purpose::STANDARD
+        .decode(dl["bytesB64"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(got, payload);
+
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/src-agent/src/app/runtime/client/host.rs
+++ b/src-agent/src/app/runtime/client/host.rs
@@ -293,8 +293,10 @@ pub(in crate::app::runtime) fn run_host_relay(
                 &ctl_rx,
                 &mut push_state,
                 current_session_id.as_deref(),
-                &terminal_manager,
-                &lsp_manager,
+                &HostLocalManagers {
+                    terminal: std::sync::Arc::clone(&terminal_manager),
+                    lsp: std::sync::Arc::clone(&lsp_manager),
+                },
             ),
             HostStep::RemoteHub { ctx } => host_remote_hub(
                 &handle,
@@ -541,6 +543,13 @@ pub(super) fn spawn_delete_and_refresh(ctl_tx: std::sync::mpsc::Sender<HostCtl>,
 // and `build_host_oauth_state` moved to the sibling `host_catalogue` module (file size) —
 // see the `use super::host_catalogue::{...}` import above.
 
+/// Host-local managers shared across the swapper control loop (PTY + LSP).
+/// Bundled so `host_swapper` stays under the clippy arg limit without an allow.
+struct HostLocalManagers {
+    terminal: std::sync::Arc<std::sync::Mutex<super::terminal_host::TerminalManager>>,
+    lsp: std::sync::Arc<std::sync::Mutex<crate::lsp::LspManager>>,
+}
+
 /// The SWAPPER arm: build the hub from cross-daemon discovery, push it, and block for
 /// a control message. A `Ready` (page reload) re-discovers + re-pushes; a
 /// `Select`/`New` resolves to an attach; a closed control channel (window gone) ends
@@ -555,9 +564,10 @@ fn host_swapper<P: Fn(String) + Clone + Send + 'static>(
     ctl_rx: &std::sync::mpsc::Receiver<HostCtl>,
     push_state: &mut push_loop::PushState,
     current: Option<&str>,
-    terminal_manager: &std::sync::Arc<std::sync::Mutex<super::terminal_host::TerminalManager>>,
-    lsp_manager: &std::sync::Arc<std::sync::Mutex<crate::lsp::LspManager>>,
+    managers: &HostLocalManagers,
 ) -> HostStep {
+    let terminal_manager = &managers.terminal;
+    let lsp_manager = &managers.lsp;
     // Build + push the hub (discovery blocks briefly; fine — nothing renders here).
     let hub = build_local_hub(current);
     push_state.reset();

--- a/src-agent/src/app/runtime/client/host.rs
+++ b/src-agent/src/app/runtime/client/host.rs
@@ -246,6 +246,11 @@ pub(in crate::app::runtime) fn run_host_relay(
     let terminal_manager = std::sync::Arc::new(std::sync::Mutex::new(
         super::terminal_host::TerminalManager::new(push.clone()),
     ));
+    // Host-spawned language servers for Monaco (completion/hover/definition/diagnostics).
+    // Shared across swapper/attached like TerminalManager so open docs survive attach.
+    let lsp_manager = std::sync::Arc::new(std::sync::Mutex::new(
+        crate::lsp::LspManager::new(push.clone()),
+    ));
 
     // Startup: attach directly to `--session`, else open cold into the swapper.
     // With `remote_target` + `session`, open a second-window remote attach
@@ -289,6 +294,7 @@ pub(in crate::app::runtime) fn run_host_relay(
                 &mut push_state,
                 current_session_id.as_deref(),
                 &terminal_manager,
+                &lsp_manager,
             ),
             HostStep::RemoteHub { ctx } => host_remote_hub(
                 &handle,
@@ -299,6 +305,7 @@ pub(in crate::app::runtime) fn run_host_relay(
                 &mut current_session_id,
                 *ctx,
                 &terminal_manager,
+                &lsp_manager,
             ),
             HostStep::RemoteAttach {
                 ctx,
@@ -318,6 +325,7 @@ pub(in crate::app::runtime) fn run_host_relay(
                 session_id,
                 cwd,
                 &terminal_manager,
+                &lsp_manager,
             ),
             HostStep::Remote { active, session_id } => host_remote(
                 &handle,
@@ -332,6 +340,7 @@ pub(in crate::app::runtime) fn run_host_relay(
                 *active,
                 session_id,
                 &terminal_manager,
+                &lsp_manager,
             ),
             HostStep::Attach { id, workdir } => host_attached(
                 &handle,
@@ -346,6 +355,7 @@ pub(in crate::app::runtime) fn run_host_relay(
                 id,
                 workdir,
                 &terminal_manager,
+                &lsp_manager,
             ),
         };
     }
@@ -354,6 +364,7 @@ pub(in crate::app::runtime) fn run_host_relay(
     // the runtime drop since reader threads hold Arc clones of the push sink.
     {
         let _ = terminal_manager.lock().map(|mut mgr| mgr.cleanup_all());
+        let _ = lsp_manager.lock().map(|mut mgr| mgr.cleanup_all());
     }
 
     // Drop the runtime LAST so the active connection's reader task is cancelled after
@@ -545,6 +556,7 @@ fn host_swapper<P: Fn(String) + Clone + Send + 'static>(
     push_state: &mut push_loop::PushState,
     current: Option<&str>,
     terminal_manager: &std::sync::Arc<std::sync::Mutex<super::terminal_host::TerminalManager>>,
+    lsp_manager: &std::sync::Arc<std::sync::Mutex<crate::lsp::LspManager>>,
 ) -> HostStep {
     // Build + push the hub (discovery blocks briefly; fine — nothing renders here).
     let hub = build_local_hub(current);
@@ -665,7 +677,9 @@ fn host_swapper<P: Fn(String) + Clone + Send + 'static>(
             | Ok(ctl @ HostCtl::FileSave { .. })
             | Ok(ctl @ HostCtl::FileCreate { .. })
             | Ok(ctl @ HostCtl::FileRename { .. })
-            | Ok(ctl @ HostCtl::FileDelete { .. }) => {
+            | Ok(ctl @ HostCtl::FileDelete { .. })
+            | Ok(ctl @ HostCtl::FileWriteBytes { .. })
+            | Ok(ctl @ HostCtl::FileDownloadBytes { .. }) => {
                 let push2 = P::clone(push);
                 let workdirs = current
                     .and_then(super::diff::session_workdirs_for)
@@ -915,6 +929,49 @@ fn host_swapper<P: Fn(String) + Clone + Send + 'static>(
             }
             Ok(HostCtl::LspUninstall { id }) => {
                 super::lsp_host::spawn_lsp_uninstall(P::clone(push), id);
+            }
+
+            Ok(HostCtl::LspDidOpen { root, path, language_id, text }) => {
+                super::lsp_host::handle_client_ctl(
+                    HostCtl::LspDidOpen { root, path, language_id, text },
+                    std::sync::Arc::clone(lsp_manager),
+                );
+            }
+            Ok(HostCtl::LspDidChange { root, path, text }) => {
+                super::lsp_host::handle_client_ctl(
+                    HostCtl::LspDidChange { root, path, text },
+                    std::sync::Arc::clone(lsp_manager),
+                );
+            }
+            Ok(HostCtl::LspDidSave { root, path, text }) => {
+                super::lsp_host::handle_client_ctl(
+                    HostCtl::LspDidSave { root, path, text },
+                    std::sync::Arc::clone(lsp_manager),
+                );
+            }
+            Ok(HostCtl::LspDidClose { root, path }) => {
+                super::lsp_host::handle_client_ctl(
+                    HostCtl::LspDidClose { root, path },
+                    std::sync::Arc::clone(lsp_manager),
+                );
+            }
+            Ok(HostCtl::LspCompletion { root, path, line, character, request_id }) => {
+                super::lsp_host::handle_client_ctl(
+                    HostCtl::LspCompletion { root, path, line, character, request_id },
+                    std::sync::Arc::clone(lsp_manager),
+                );
+            }
+            Ok(HostCtl::LspHover { root, path, line, character, request_id }) => {
+                super::lsp_host::handle_client_ctl(
+                    HostCtl::LspHover { root, path, line, character, request_id },
+                    std::sync::Arc::clone(lsp_manager),
+                );
+            }
+            Ok(HostCtl::LspDefinition { root, path, line, character, request_id }) => {
+                super::lsp_host::handle_client_ctl(
+                    HostCtl::LspDefinition { root, path, line, character, request_id },
+                    std::sync::Arc::clone(lsp_manager),
+                );
             }
             // Extension STORE browse/detail/installed-list opened while detached
             // (StartScreen / swapper, e.g. the Store tab mounting on the home screen
@@ -1441,6 +1498,7 @@ fn host_attached(
     id: String,
     workdir: Option<std::path::PathBuf>,
     terminal_manager: &std::sync::Arc<std::sync::Mutex<super::terminal_host::TerminalManager>>,
+    lsp_manager: &std::sync::Arc<std::sync::Mutex<crate::lsp::LspManager>>,
 ) -> HostStep {
     let mut conn = match attach_session_headless(handle, &id, workdir.as_deref()) {
         Ok(c) => c,
@@ -1480,6 +1538,7 @@ fn host_attached(
             live_marks,
             live_view,
             terminal_manager,
+            lsp_manager,
             None, // local attach
             None, // no remote-fs
             None, // no remote-git
@@ -1572,6 +1631,7 @@ fn host_remote_hub<P: Fn(String) + Clone + Send + 'static>(
     current: &mut Option<String>,
     ctx: super::remote_ctl::RemoteCtx,
     terminal_manager: &std::sync::Arc<std::sync::Mutex<super::terminal_host::TerminalManager>>,
+    lsp_manager: &std::sync::Arc<std::sync::Mutex<crate::lsp::LspManager>>,
 ) -> HostStep {
     *current = None;
     push_state.reset();
@@ -1844,6 +1904,49 @@ fn host_remote_hub<P: Fn(String) + Clone + Send + 'static>(
                     mgr.kill(&id);
                 }
             }
+
+            Ok(HostCtl::LspDidOpen { root, path, language_id, text }) => {
+                super::lsp_host::handle_client_ctl(
+                    HostCtl::LspDidOpen { root, path, language_id, text },
+                    std::sync::Arc::clone(lsp_manager),
+                );
+            }
+            Ok(HostCtl::LspDidChange { root, path, text }) => {
+                super::lsp_host::handle_client_ctl(
+                    HostCtl::LspDidChange { root, path, text },
+                    std::sync::Arc::clone(lsp_manager),
+                );
+            }
+            Ok(HostCtl::LspDidSave { root, path, text }) => {
+                super::lsp_host::handle_client_ctl(
+                    HostCtl::LspDidSave { root, path, text },
+                    std::sync::Arc::clone(lsp_manager),
+                );
+            }
+            Ok(HostCtl::LspDidClose { root, path }) => {
+                super::lsp_host::handle_client_ctl(
+                    HostCtl::LspDidClose { root, path },
+                    std::sync::Arc::clone(lsp_manager),
+                );
+            }
+            Ok(HostCtl::LspCompletion { root, path, line, character, request_id }) => {
+                super::lsp_host::handle_client_ctl(
+                    HostCtl::LspCompletion { root, path, line, character, request_id },
+                    std::sync::Arc::clone(lsp_manager),
+                );
+            }
+            Ok(HostCtl::LspHover { root, path, line, character, request_id }) => {
+                super::lsp_host::handle_client_ctl(
+                    HostCtl::LspHover { root, path, line, character, request_id },
+                    std::sync::Arc::clone(lsp_manager),
+                );
+            }
+            Ok(HostCtl::LspDefinition { root, path, line, character, request_id }) => {
+                super::lsp_host::handle_client_ctl(
+                    HostCtl::LspDefinition { root, path, line, character, request_id },
+                    std::sync::Arc::clone(lsp_manager),
+                );
+            }
             Ok(HostCtl::KillSession(id)) => {
                 // Kill the remote session-daemon; stay on this host hub.
                 // Distinct from DisconnectRemote (leave host, daemons keep cooking).
@@ -1889,6 +1992,7 @@ fn host_remote_attach(
     session_id: String,
     cwd: Option<String>,
     terminal_manager: &std::sync::Arc<std::sync::Mutex<super::terminal_host::TerminalManager>>,
+    lsp_manager: &std::sync::Arc<std::sync::Mutex<crate::lsp::LspManager>>,
 ) -> HostStep {
     let (remote_state_tx, remote_state_rx) =
         std::sync::mpsc::channel::<super::remote_ctl::RemoteStateUpdate>();
@@ -1986,6 +2090,7 @@ fn host_remote_attach(
                 active,
                 sid,
                 terminal_manager,
+                lsp_manager,
             );
         }
 
@@ -2032,6 +2137,7 @@ fn host_remote(
     mut active: super::remote_ctl::ActiveRemote,
     session_id: String,
     terminal_manager: &std::sync::Arc<std::sync::Mutex<super::terminal_host::TerminalManager>>,
+    lsp_manager: &std::sync::Arc<std::sync::Mutex<crate::lsp::LspManager>>,
 ) -> HostStep {
     *current = Some(session_id);
     if let Ok(mut g) = live_req.lock() {
@@ -2053,6 +2159,7 @@ fn host_remote(
             live_marks,
             live_view,
             terminal_manager,
+            lsp_manager,
             Some(&active.ctx),
             active.fs.as_ref(),
             active.git.as_ref(),

--- a/src-agent/src/app/runtime/client/lsp_host.rs
+++ b/src-agent/src/app/runtime/client/lsp_host.rs
@@ -1,5 +1,6 @@
 //! Host-side language-server status / install / uninstall for the GUI Settings
-//! "Language servers" section.
+//! "Language servers" section, plus the live [`crate::lsp::LspManager`] dispatch
+//! for Monaco doc-sync and language features.
 //!
 //! Entirely host-local (never the daemon), mirroring [`super::keys`]: a
 //! `std::thread::spawn` worker does the blocking work (`reqwest`, npm, pip, go).
@@ -8,6 +9,10 @@
 //! - **detached** (`host_swapper`): push replies straight through a cloned sink
 //! - **attached** (`push_loop`): send replies over an `mpsc` channel drained by
 //!   the fold loop (the fold's `push` is `&dyn Fn(String)` and cannot be cloned)
+//!
+//! Language-client ops (didOpen / completion / …) run on a short-lived worker
+//! thread holding `Arc<Mutex<LspManager>>` so a slow `initialize` never blocks
+//! the 16ms host control loop.
 
 use std::sync::mpsc::Sender;
 
@@ -184,5 +189,128 @@ fn is_managed_installable(id: &str) -> bool {
             | "gopls"
             | "vscode-langservers"
             | "bash-language-server"
+    )
+}
+
+// ─── Language client (LspManager) ────────────────────────────────────────────
+
+use std::sync::{Arc, Mutex};
+
+use super::push_proto::{push_lsp_completion, push_lsp_definition, push_lsp_hover};
+use super::HostCtl;
+use crate::lsp::LspManager;
+
+/// Dispatch one language-client HostCtl on a worker thread.
+///
+/// Notifications (didOpen/Change/Save/Close) are fire-and-forget.
+/// Requests always push a typed reply so Monaco providers never hang.
+/// Replies go through the manager's own push sink (same Arc the reader
+/// thread uses for diagnostics), so this works from both the detached
+/// swapper (cloneable push) and the attached fold (`&dyn Fn` only).
+pub(super) fn handle_client_ctl(ctl: HostCtl, mgr: Arc<Mutex<LspManager>>) {
+    std::thread::spawn(move || {
+        let push = match mgr.lock() {
+            Ok(g) => g.push_sink(),
+            Err(_) => return,
+        };
+        match ctl {
+            HostCtl::LspDidOpen {
+                root,
+                path,
+                language_id,
+                text,
+            } => {
+                if let Ok(mut g) = mgr.lock() {
+                    if let Err(e) = g.did_open(&root, &path, &language_id, &text) {
+                        // Missing server is expected until install — don't spam the error log
+                        // for "no language server for .md" style misses on every open.
+                        if !e.contains("no language server") && !e.contains("not installed") {
+                            crate::model::store::append_global_error_log(
+                                "lsp",
+                                &format!("didOpen {path}: {e}"),
+                            );
+                        }
+                    }
+                }
+            }
+            HostCtl::LspDidChange { root, path, text } => {
+                if let Ok(mut g) = mgr.lock() {
+                    let _ = g.did_change(&root, &path, &text);
+                }
+            }
+            HostCtl::LspDidSave { root, path, text } => {
+                if let Ok(mut g) = mgr.lock() {
+                    let _ = g.did_save(&root, &path, text.as_deref());
+                }
+            }
+            HostCtl::LspDidClose { root, path } => {
+                if let Ok(mut g) = mgr.lock() {
+                    let _ = g.did_close_path(&root, &path);
+                }
+            }
+            HostCtl::LspCompletion {
+                root,
+                path,
+                line,
+                character,
+                request_id,
+            } => {
+                let (items, error) = match mgr.lock() {
+                    Ok(mut g) => match g.completion(&root, &path, line, character) {
+                        Ok(items) => (items, None),
+                        Err(e) => (Vec::new(), Some(e)),
+                    },
+                    Err(_) => (Vec::new(), Some("lsp manager lock poisoned".into())),
+                };
+                push_lsp_completion(&*push, request_id, items, error);
+            }
+            HostCtl::LspHover {
+                root,
+                path,
+                line,
+                character,
+                request_id,
+            } => {
+                let (hover, error) = match mgr.lock() {
+                    Ok(mut g) => match g.hover(&root, &path, line, character) {
+                        Ok(h) => (h, None),
+                        Err(e) => (None, Some(e)),
+                    },
+                    Err(_) => (None, Some("lsp manager lock poisoned".into())),
+                };
+                push_lsp_hover(&*push, request_id, hover, error);
+            }
+            HostCtl::LspDefinition {
+                root,
+                path,
+                line,
+                character,
+                request_id,
+            } => {
+                let (locations, error) = match mgr.lock() {
+                    Ok(mut g) => match g.definition(&root, &path, line, character) {
+                        Ok(locs) => (locs, None),
+                        Err(e) => (Vec::new(), Some(e)),
+                    },
+                    Err(_) => (Vec::new(), Some("lsp manager lock poisoned".into())),
+                };
+                push_lsp_definition(&*push, request_id, locations, error);
+            }
+            _ => {}
+        }
+    });
+}
+
+/// Returns true when `ctl` is a language-client op handled by [`handle_client_ctl`].
+pub(super) fn is_client_ctl(ctl: &HostCtl) -> bool {
+    matches!(
+        ctl,
+        HostCtl::LspDidOpen { .. }
+            | HostCtl::LspDidChange { .. }
+            | HostCtl::LspDidSave { .. }
+            | HostCtl::LspDidClose { .. }
+            | HostCtl::LspCompletion { .. }
+            | HostCtl::LspHover { .. }
+            | HostCtl::LspDefinition { .. }
     )
 }

--- a/src-agent/src/app/runtime/client/mod.rs
+++ b/src-agent/src/app/runtime/client/mod.rs
@@ -727,6 +727,22 @@ pub(super) enum HostCtl {
         path: String,
         request_id: String,
     },
+    /// Coding panel: write raw bytes (drag-upload / remote upload). `bytes_b64`
+    /// is standard base64 of the file body. When `overwrite` is false, existing
+    /// paths are rejected.
+    FileWriteBytes {
+        root: String,
+        path: String,
+        bytes_b64: String,
+        overwrite: bool,
+        request_id: String,
+    },
+    /// Coding panel: read raw bytes for download / save-as.
+    FileDownloadBytes {
+        root: String,
+        path: String,
+        request_id: String,
+    },
     /// Settings "Language servers": resolve every first-wave server (managed /
     /// PATH / missing) and push an `LspStatus` envelope. Host-local only.
     LspStatus,
@@ -742,6 +758,55 @@ pub(super) enum HostCtl {
     /// touches PATH copies. Followed by a fresh `LspStatus`.
     LspUninstall {
         id: String,
+    },
+    // ─── Language client (host-spawned JSON-RPC) ───────────────────────────
+    /// Coding tab opened a text file: `textDocument/didOpen` (lazy server start).
+    LspDidOpen {
+        root: String,
+        path: String,
+        language_id: String,
+        text: String,
+    },
+    /// Editor content changed: full-document `textDocument/didChange`.
+    LspDidChange {
+        root: String,
+        path: String,
+        text: String,
+    },
+    /// File saved: `textDocument/didSave`.
+    LspDidSave {
+        root: String,
+        path: String,
+        text: Option<String>,
+    },
+    /// Coding tab closed: `textDocument/didClose` + clear markers.
+    LspDidClose {
+        root: String,
+        path: String,
+    },
+    /// `textDocument/completion` — reply `LspCompletion` with `request_id`.
+    LspCompletion {
+        root: String,
+        path: String,
+        line: u32,
+        character: u32,
+        request_id: String,
+    },
+    /// `textDocument/hover` — reply `LspHover` with `request_id`.
+    LspHover {
+        root: String,
+        path: String,
+        line: u32,
+        character: u32,
+        request_id: String,
+    },
+    /// `textDocument/definition` — reply `LspDefinition` with `request_id`.
+    LspDefinition {
+        root: String,
+        path: String,
+        line: u32,
+        character: u32,
+        request_id: String,
     },
     /// Import-graph visualization: call the linker daemon's
     /// `Visualization` query and push the result back as an `ImportGraph` envelope.

--- a/src-agent/src/app/runtime/client/push_loop.rs
+++ b/src-agent/src/app/runtime/client/push_loop.rs
@@ -162,6 +162,7 @@ pub(super) fn push_loop(
     live_marks: &std::sync::Arc<std::sync::Mutex<Vec<usize>>>,
     live_view: &std::sync::Arc<std::sync::Mutex<super::StreamView>>,
     terminal_manager: &std::sync::Arc<std::sync::Mutex<super::terminal_host::TerminalManager>>,
+    lsp_manager: &std::sync::Arc<std::sync::Mutex<crate::lsp::LspManager>>,
     // When set, this fold is an SSH-bridged remote session: leave/kill returns to
     // the remote hub (not the local swapper), and KillSession uses remote SSH kill.
     remote_ctx: Option<&super::remote_ctl::RemoteCtx>,
@@ -969,6 +970,91 @@ pub(super) fn push_loop(
                 Ok(super::HostCtl::LspUninstall { id }) => {
                     super::lsp_host::spawn_lsp_uninstall_attached(lsp_tx.clone(), id);
                 }
+
+
+                Ok(super::HostCtl::LspDidOpen { root, path, language_id, text }) => {
+
+                    super::lsp_host::handle_client_ctl(
+
+                        super::HostCtl::LspDidOpen { root, path, language_id, text },
+
+                        std::sync::Arc::clone(lsp_manager),
+
+                    );
+
+                }
+
+                Ok(super::HostCtl::LspDidChange { root, path, text }) => {
+
+                    super::lsp_host::handle_client_ctl(
+
+                        super::HostCtl::LspDidChange { root, path, text },
+
+                        std::sync::Arc::clone(lsp_manager),
+
+                    );
+
+                }
+
+                Ok(super::HostCtl::LspDidSave { root, path, text }) => {
+
+                    super::lsp_host::handle_client_ctl(
+
+                        super::HostCtl::LspDidSave { root, path, text },
+
+                        std::sync::Arc::clone(lsp_manager),
+
+                    );
+
+                }
+
+                Ok(super::HostCtl::LspDidClose { root, path }) => {
+
+                    super::lsp_host::handle_client_ctl(
+
+                        super::HostCtl::LspDidClose { root, path },
+
+                        std::sync::Arc::clone(lsp_manager),
+
+                    );
+
+                }
+
+                Ok(super::HostCtl::LspCompletion { root, path, line, character, request_id }) => {
+
+                    super::lsp_host::handle_client_ctl(
+
+                        super::HostCtl::LspCompletion { root, path, line, character, request_id },
+
+                        std::sync::Arc::clone(lsp_manager),
+
+                    );
+
+                }
+
+                Ok(super::HostCtl::LspHover { root, path, line, character, request_id }) => {
+
+                    super::lsp_host::handle_client_ctl(
+
+                        super::HostCtl::LspHover { root, path, line, character, request_id },
+
+                        std::sync::Arc::clone(lsp_manager),
+
+                    );
+
+                }
+
+                Ok(super::HostCtl::LspDefinition { root, path, line, character, request_id }) => {
+
+                    super::lsp_host::handle_client_ctl(
+
+                        super::HostCtl::LspDefinition { root, path, line, character, request_id },
+
+                        std::sync::Arc::clone(lsp_manager),
+
+                    );
+
+                }
                 // Extension STORE browse/detail/installed-list: NEVER touches the
                 // daemon (host-side only, regardless of attach state) — spawn the
                 // blocking network/config work off this thread via the shared
@@ -1014,7 +1100,9 @@ pub(super) fn push_loop(
                 | Ok(ctl @ super::HostCtl::FileSave { .. })
                 | Ok(ctl @ super::HostCtl::FileCreate { .. })
                 | Ok(ctl @ super::HostCtl::FileRename { .. })
-                | Ok(ctl @ super::HostCtl::FileDelete { .. }) => {
+                | Ok(ctl @ super::HostCtl::FileDelete { .. })
+                | Ok(ctl @ super::HostCtl::FileWriteBytes { .. })
+                | Ok(ctl @ super::HostCtl::FileDownloadBytes { .. }) => {
                     if let Some(fs) = remote_fs {
                         fs.handle_file_ctl(&ctl, push);
                     } else if remote_ctx.is_some() {
@@ -1786,6 +1874,30 @@ fn push_remote_fs_unavailable(ctl: &super::HostCtl, push: &dyn Fn(String)) {
             root: root.clone(),
             path: path.clone(),
             request_id: request_id.clone(),
+            error: Some(ERR.into()),
+        },
+        super::HostCtl::FileWriteBytes {
+            root,
+            path,
+            request_id,
+            ..
+        } => PushEnvelope::FileWriteBytes {
+            root: root.clone(),
+            path: path.clone(),
+            request_id: request_id.clone(),
+            error: Some(ERR.into()),
+        },
+        super::HostCtl::FileDownloadBytes {
+            root,
+            path,
+            request_id,
+        } => PushEnvelope::FileDownloadBytes {
+            root: root.clone(),
+            path: path.clone(),
+            request_id: request_id.clone(),
+            bytes_b64: None,
+            size: 0,
+            too_large: false,
             error: Some(ERR.into()),
         },
         _ => return,

--- a/src-agent/src/app/runtime/client/push_proto.rs
+++ b/src-agent/src/app/runtime/client/push_proto.rs
@@ -691,6 +691,25 @@ pub(super) enum PushEnvelope {
         request_id: String,
         error: Option<String>,
     },
+    /// Coding panel: binary write (drag-upload) reply.
+    #[serde(rename_all = "camelCase")]
+    FileWriteBytes {
+        root: String,
+        path: String,
+        request_id: String,
+        error: Option<String>,
+    },
+    /// Coding panel: binary download reply. `bytes_b64` is standard base64.
+    #[serde(rename_all = "camelCase")]
+    FileDownloadBytes {
+        root: String,
+        path: String,
+        request_id: String,
+        bytes_b64: Option<String>,
+        size: u64,
+        too_large: bool,
+        error: Option<String>,
+    },
     /// Settings "Language servers": full catalogue status (managed / PATH / missing).
     #[serde(rename_all = "camelCase")]
     LspStatus {
@@ -703,6 +722,33 @@ pub(super) enum PushEnvelope {
     LspInstall {
         id: String,
         pct: u8,
+        error: Option<String>,
+    },
+    /// `textDocument/publishDiagnostics` — replaces markers for `uri`.
+    #[serde(rename_all = "camelCase")]
+    LspDiagnostics {
+        uri: String,
+        diagnostics: Vec<crate::lsp::LspDiagnostic>,
+    },
+    /// Reply to `LspCompletion` (always, so Monaco never hangs).
+    #[serde(rename_all = "camelCase")]
+    LspCompletion {
+        request_id: String,
+        items: Vec<crate::lsp::LspCompletionItem>,
+        error: Option<String>,
+    },
+    /// Reply to `LspHover`.
+    #[serde(rename_all = "camelCase")]
+    LspHover {
+        request_id: String,
+        hover: Option<crate::lsp::LspHover>,
+        error: Option<String>,
+    },
+    /// Reply to `LspDefinition`.
+    #[serde(rename_all = "camelCase")]
+    LspDefinition {
+        request_id: String,
+        locations: Vec<crate::lsp::LspLocation>,
         error: Option<String>,
     },
     /// One-shot import-graph visualization result answering a `GuiReq::ImportGraph`
@@ -1135,6 +1181,57 @@ pub(super) fn push_terminal_exit(push: &dyn Fn(String), id: &str, code: Option<i
 /// Emit a one-shot `LspStatus` envelope for Settings "Language servers".
 pub(super) fn push_lsp_status(push: &dyn Fn(String), servers: Vec<crate::lsp::ServerStatus>) {
     super::render::emit(push, &PushEnvelope::LspStatus { servers });
+}
+
+/// Emit `LspCompletion` reply (always — Monaco provider must not hang).
+pub(super) fn push_lsp_completion(
+    push: &dyn Fn(String),
+    request_id: String,
+    items: Vec<crate::lsp::LspCompletionItem>,
+    error: Option<String>,
+) {
+    super::render::emit(
+        push,
+        &PushEnvelope::LspCompletion {
+            request_id,
+            items,
+            error,
+        },
+    );
+}
+
+/// Emit `LspHover` reply.
+pub(super) fn push_lsp_hover(
+    push: &dyn Fn(String),
+    request_id: String,
+    hover: Option<crate::lsp::LspHover>,
+    error: Option<String>,
+) {
+    super::render::emit(
+        push,
+        &PushEnvelope::LspHover {
+            request_id,
+            hover,
+            error,
+        },
+    );
+}
+
+/// Emit `LspDefinition` reply.
+pub(super) fn push_lsp_definition(
+    push: &dyn Fn(String),
+    request_id: String,
+    locations: Vec<crate::lsp::LspLocation>,
+    error: Option<String>,
+) {
+    super::render::emit(
+        push,
+        &PushEnvelope::LspDefinition {
+            request_id,
+            locations,
+            error,
+        },
+    );
 }
 
 /// Emit a one-shot `LspInstall` progress/result frame.

--- a/src-agent/src/app/runtime/client/remote_fs_client.rs
+++ b/src-agent/src/app/runtime/client/remote_fs_client.rs
@@ -170,7 +170,9 @@ fn req_id_of(req: &RemoteFsReq) -> Option<String> {
         | RemoteFsReq::Save { request_id, .. }
         | RemoteFsReq::Create { request_id, .. }
         | RemoteFsReq::Rename { request_id, .. }
-        | RemoteFsReq::Delete { request_id, .. } => Some(request_id.clone()),
+        | RemoteFsReq::Delete { request_id, .. }
+        | RemoteFsReq::WriteBytes { request_id, .. }
+        | RemoteFsReq::DownloadBytes { request_id, .. } => Some(request_id.clone()),
         _ => None,
     }
 }
@@ -239,6 +241,28 @@ fn hostctl_to_req(ctl: &super::HostCtl) -> Option<RemoteFsReq> {
             path: path.clone(),
             request_id: request_id.clone(),
         }),
+        super::HostCtl::FileWriteBytes {
+            root,
+            path,
+            bytes_b64,
+            overwrite,
+            request_id,
+        } => Some(RemoteFsReq::WriteBytes {
+            root: root.clone(),
+            path: path.clone(),
+            bytes_b64: bytes_b64.clone(),
+            overwrite: *overwrite,
+            request_id: request_id.clone(),
+        }),
+        super::HostCtl::FileDownloadBytes {
+            root,
+            path,
+            request_id,
+        } => Some(RemoteFsReq::DownloadBytes {
+            root: root.clone(),
+            path: path.clone(),
+            request_id: request_id.clone(),
+        }),
         _ => None,
     }
 }
@@ -286,6 +310,21 @@ fn push_rep(push: &dyn Fn(String), rep: RemoteFsRep) {
             root: r.root,
             path: r.path,
             request_id: r.request_id,
+            error: r.error,
+        },
+        RemoteFsRep::WriteBytes(r) => PushEnvelope::FileWriteBytes {
+            root: r.root,
+            path: r.path,
+            request_id: r.request_id,
+            error: r.error,
+        },
+        RemoteFsRep::DownloadBytes(r) => PushEnvelope::FileDownloadBytes {
+            root: r.root,
+            path: r.path,
+            request_id: r.request_id,
+            bytes_b64: r.bytes_b64,
+            size: r.size,
+            too_large: r.too_large,
             error: r.error,
         },
         RemoteFsRep::Error { error, request_id } => {

--- a/src-agent/src/app/runtime/gui/dispatch.rs
+++ b/src-agent/src/app/runtime/gui/dispatch.rs
@@ -918,6 +918,32 @@ pub(super) fn handle_gui_req(req: GuiReq, ctx: &GuiReqCtx) {
                 request_id,
             });
         }
+        GuiReq::FileWriteBytes {
+            root,
+            path,
+            bytes_b64,
+            overwrite,
+            request_id,
+        } => {
+            let _ = ctx.ctl.send(HostCtl::FileWriteBytes {
+                root,
+                path,
+                bytes_b64,
+                overwrite,
+                request_id,
+            });
+        }
+        GuiReq::FileDownloadBytes {
+            root,
+            path,
+            request_id,
+        } => {
+            let _ = ctx.ctl.send(HostCtl::FileDownloadBytes {
+                root,
+                path,
+                request_id,
+            });
+        }
         // Language servers: host-local status/install/uninstall under ~/.koma/lsp/.
         GuiReq::LspStatus => {
             let _ = ctx.ctl.send(HostCtl::LspStatus);
@@ -927,6 +953,73 @@ pub(super) fn handle_gui_req(req: GuiReq, ctx: &GuiReqCtx) {
         }
         GuiReq::LspUninstall { id } => {
             let _ = ctx.ctl.send(HostCtl::LspUninstall { id });
+        }
+        GuiReq::LspDidOpen {
+            root,
+            path,
+            language_id,
+            text,
+        } => {
+            let _ = ctx.ctl.send(HostCtl::LspDidOpen {
+                root,
+                path,
+                language_id,
+                text,
+            });
+        }
+        GuiReq::LspDidChange { root, path, text } => {
+            let _ = ctx.ctl.send(HostCtl::LspDidChange { root, path, text });
+        }
+        GuiReq::LspDidSave { root, path, text } => {
+            let _ = ctx.ctl.send(HostCtl::LspDidSave { root, path, text });
+        }
+        GuiReq::LspDidClose { root, path } => {
+            let _ = ctx.ctl.send(HostCtl::LspDidClose { root, path });
+        }
+        GuiReq::LspCompletion {
+            root,
+            path,
+            line,
+            character,
+            request_id,
+        } => {
+            let _ = ctx.ctl.send(HostCtl::LspCompletion {
+                root,
+                path,
+                line,
+                character,
+                request_id,
+            });
+        }
+        GuiReq::LspHover {
+            root,
+            path,
+            line,
+            character,
+            request_id,
+        } => {
+            let _ = ctx.ctl.send(HostCtl::LspHover {
+                root,
+                path,
+                line,
+                character,
+                request_id,
+            });
+        }
+        GuiReq::LspDefinition {
+            root,
+            path,
+            line,
+            character,
+            request_id,
+        } => {
+            let _ = ctx.ctl.send(HostCtl::LspDefinition {
+                root,
+                path,
+                line,
+                character,
+                request_id,
+            });
         }
         // Write error log: host-local, unconditional, fire-and-forget.
         GuiReq::WriteErrorLog { message } => {

--- a/src-agent/src/app/runtime/gui/proto.rs
+++ b/src-agent/src/app/runtime/gui/proto.rs
@@ -950,6 +950,25 @@ pub(super) enum GuiReq {
         #[serde(rename = "requestId")]
         request_id: String,
     },
+    /// Coding panel: write raw bytes (drag-upload). `bytes_b64` is standard
+    /// base64. When `overwrite` is false, existing paths are rejected.
+    FileWriteBytes {
+        root: String,
+        path: String,
+        #[serde(rename = "bytesB64")]
+        bytes_b64: String,
+        #[serde(default)]
+        overwrite: bool,
+        #[serde(rename = "requestId")]
+        request_id: String,
+    },
+    /// Coding panel: read raw bytes for download / save-as.
+    FileDownloadBytes {
+        root: String,
+        path: String,
+        #[serde(rename = "requestId")]
+        request_id: String,
+    },
 
     // ─── Language servers (Settings + editor banner) ──────────────────────────
     // Host-local only (never the daemon): resolve / install / uninstall under
@@ -971,6 +990,61 @@ pub(super) enum GuiReq {
     /// Reply: `LspInstall` ack + fresh `LspStatus`.
     LspUninstall {
         id: String,
+    },
+    // ─── Language client (Monaco providers + doc sync) ───────────────────────
+    // Host-local only: LspManager owns stdio JSON-RPC to ~/.koma/lsp binaries.
+    /// Coding tab open / content load: `textDocument/didOpen`.
+    LspDidOpen {
+        root: String,
+        path: String,
+        #[serde(rename = "languageId")]
+        language_id: String,
+        text: String,
+    },
+    /// Editor dirty change: full-document `textDocument/didChange`.
+    LspDidChange {
+        root: String,
+        path: String,
+        text: String,
+    },
+    /// After successful save: `textDocument/didSave`.
+    LspDidSave {
+        root: String,
+        path: String,
+        #[serde(default)]
+        text: Option<String>,
+    },
+    /// Coding tab closed: `textDocument/didClose`.
+    LspDidClose {
+        root: String,
+        path: String,
+    },
+    /// Monaco completion provider. Reply: `LspCompletion`.
+    LspCompletion {
+        root: String,
+        path: String,
+        line: u32,
+        character: u32,
+        #[serde(rename = "requestId")]
+        request_id: String,
+    },
+    /// Monaco hover provider. Reply: `LspHover`.
+    LspHover {
+        root: String,
+        path: String,
+        line: u32,
+        character: u32,
+        #[serde(rename = "requestId")]
+        request_id: String,
+    },
+    /// Monaco definition provider. Reply: `LspDefinition`.
+    LspDefinition {
+        root: String,
+        path: String,
+        line: u32,
+        character: u32,
+        #[serde(rename = "requestId")]
+        request_id: String,
     },
 
     // ─── Frontend error logging ───────────────────────────────────────────────

--- a/src-agent/src/app/runtime/manage/doctor.rs
+++ b/src-agent/src/app/runtime/manage/doctor.rs
@@ -854,15 +854,14 @@ fn check_language_servers() -> CheckResult {
                 .unwrap_or_default()
         ));
     }
-    details.push(format!(
+    details.push(
         "optional — install with: koma lsp install --all  (or install.sh --with-lsp)"
-    ));
+            .to_string(),
+    );
     let headline = format!(
         "Language servers ({managed} managed, {on_path} on PATH, {missing}/{total} missing)"
     );
-    if missing == total {
-        CheckResult::warn(headline, details)
-    } else if missing > 0 {
+    if missing > 0 {
         CheckResult::warn(headline, details)
     } else {
         CheckResult::ok(headline)

--- a/src-agent/src/app/runtime/remote_fs_proto.rs
+++ b/src-agent/src/app/runtime/remote_fs_proto.rs
@@ -6,8 +6,8 @@
 //! host can forward replies without remapping.
 
 use super::client::file_ops::{
-    FileCreateResult, FileDeleteResult, FileReadResult, FileRenameResult, FileSaveResult,
-    FileTreeResult,
+    FileCreateResult, FileDeleteResult, FileDownloadBytesResult, FileReadResult, FileRenameResult,
+    FileSaveResult, FileTreeResult, FileWriteBytesResult,
 };
 
 /// Request from the local host to a remote `koma remote-fs` process.
@@ -52,6 +52,18 @@ pub(crate) enum RemoteFsReq {
         path: String,
         request_id: String,
     },
+    WriteBytes {
+        root: String,
+        path: String,
+        bytes_b64: String,
+        overwrite: bool,
+        request_id: String,
+    },
+    DownloadBytes {
+        root: String,
+        path: String,
+        request_id: String,
+    },
 }
 
 /// Reply from remote-fs. Bodies mirror PushEnvelope File* fields.
@@ -72,6 +84,8 @@ pub(crate) enum RemoteFsRep {
     Create(FileCreateResult),
     Rename(FileRenameResult),
     Delete(FileDeleteResult),
+    WriteBytes(FileWriteBytesResult),
+    DownloadBytes(FileDownloadBytesResult),
     /// Catch-all for protocol/parse errors on a request that had no op body.
     Error {
         error: String,

--- a/src-agent/src/app/runtime/remote_fs_svc.rs
+++ b/src-agent/src/app/runtime/remote_fs_svc.rs
@@ -178,5 +178,29 @@ fn handle_req(req: RemoteFsReq, roots: &mut Vec<PathBuf>) -> RemoteFsRep {
             &request_id,
             roots,
         )),
+        RemoteFsReq::WriteBytes {
+            root,
+            path,
+            bytes_b64,
+            overwrite,
+            request_id,
+        } => RemoteFsRep::WriteBytes(file_ops::exec_file_write_bytes(
+            &root,
+            &path,
+            &bytes_b64,
+            overwrite,
+            &request_id,
+            roots,
+        )),
+        RemoteFsReq::DownloadBytes {
+            root,
+            path,
+            request_id,
+        } => RemoteFsRep::DownloadBytes(file_ops::exec_file_download_bytes(
+            &root,
+            &path,
+            &request_id,
+            roots,
+        )),
     }
 }

--- a/src-agent/src/lsp/catalog.rs
+++ b/src-agent/src/lsp/catalog.rs
@@ -41,8 +41,7 @@ pub struct ServerSpec {
     /// - GoInstall: `module@latest` path (without the `@latest` suffix stored here)
     pub package: &'static str,
     /// Extra argv after the binary when spawning (e.g. `["--stdio"]` for node CLIs).
-    /// Reserved for the future host-spawned LspManager; unused by install/resolve.
-    #[allow(dead_code)]
+    /// Consumed by [`crate::lsp::client::LspManager`]; unused by install/resolve.
     pub args: &'static [&'static str],
 }
 

--- a/src-agent/src/lsp/client.rs
+++ b/src-agent/src/lsp/client.rs
@@ -1,0 +1,1045 @@
+//! Host-spawned LSP JSON-RPC client (stdio, Content-Length framing).
+//!
+//! One process per catalogue server id, lazily started on first document open.
+//! Completions / hover / definition are request/response; diagnostics arrive as
+//! `textDocument/publishDiagnostics` notifications and are pushed to the GUI.
+//!
+//! Threading mirrors [`crate::app::runtime::client::terminal_host`]: a reader
+//! thread owns stdout, the control loop (via [`LspManager`]) owns stdin writes
+//! under a mutex. No dependency on tower-lsp / lsp-types — wire shapes are
+//! hand-rolled `serde_json::Value`s for the small v1 surface.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use super::catalog::{self, ServerSpec};
+use super::resolve::{self, Source};
+
+/// Default timeout for LSP request/response round-trips.
+const REQ_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// One diagnostic pushed to the GUI (Monaco markers + Problems drawer).
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LspDiagnostic {
+    pub uri: String,
+    /// 0-based line.
+    pub line: u32,
+    /// 0-based character.
+    pub character: u32,
+    /// 0-based end line.
+    pub end_line: u32,
+    /// 0-based end character.
+    pub end_character: u32,
+    /// LSP DiagnosticSeverity: 1=Error 2=Warning 3=Info 4=Hint.
+    pub severity: u8,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+}
+
+/// One completion item for Monaco.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LspCompletionItem {
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub insert_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub documentation: Option<String>,
+}
+
+/// Hover payload for Monaco.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LspHover {
+    pub contents: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub range: Option<LspRange>,
+}
+
+/// A 0-based range in a document.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LspRange {
+    pub start_line: u32,
+    pub start_character: u32,
+    pub end_line: u32,
+    pub end_character: u32,
+}
+
+/// Go-to-definition location.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LspLocation {
+    pub uri: String,
+    pub range: LspRange,
+}
+
+/// Internal reply from the reader thread to a waiting request.
+enum PendingReply {
+    Ok(serde_json::Value),
+    Err(String),
+}
+
+struct OpenDoc {
+    server_id: String,
+    language_id: String,
+    #[allow(dead_code)]
+    version: i32,
+}
+
+struct ServerSession {
+    /// Catalogue id (e.g. `rust-analyzer`).
+    #[allow(dead_code)]
+    id: String,
+    /// Workspace root this process was initialized for (absolute).
+    #[allow(dead_code)]
+    root: PathBuf,
+    child: Child,
+    stdin: Arc<Mutex<ChildStdin>>,
+    next_id: AtomicU64,
+    pending: Arc<Mutex<HashMap<u64, Sender<PendingReply>>>>,
+    /// Language ids this multi-binary session was spawned for (vscode-langservers).
+    #[allow(dead_code)]
+    language_ids: Vec<String>,
+}
+
+/// Host-owned map of live language servers + open documents.
+pub struct LspManager {
+    servers: HashMap<String, ServerSession>,
+    /// file URI → open doc metadata.
+    docs: HashMap<String, OpenDoc>,
+    /// Push sink for diagnostics (and future server-log envelopes).
+    push: Arc<dyn Fn(String) + Send + Sync>,
+}
+
+impl LspManager {
+    pub fn new(push: impl Fn(String) + Send + Sync + 'static) -> Self {
+        Self {
+            servers: HashMap::new(),
+            docs: HashMap::new(),
+            push: Arc::new(push),
+        }
+    }
+
+    /// Kill every live server. Called on host-relay teardown.
+    pub fn cleanup_all(&mut self) {
+        let uris: Vec<String> = self.docs.keys().cloned().collect();
+        for uri in uris {
+            self.did_close(&uri);
+        }
+        for (_, mut s) in self.servers.drain() {
+            let _ = s.child.kill();
+            let _ = s.child.wait();
+        }
+    }
+
+    /// Clone of the GUI push sink (for request replies from worker threads).
+    pub fn push_sink(&self) -> Arc<dyn Fn(String) + Send + Sync> {
+        Arc::clone(&self.push)
+    }
+
+    /// `textDocument/didOpen` — start the matching server lazily if needed.
+    pub fn did_open(
+        &mut self,
+        root: &str,
+        path: &str,
+        language_id: &str,
+        text: &str,
+    ) -> Result<(), String> {
+        let abs = abs_path(root, path)?;
+        let uri = path_to_uri(&abs);
+        if self.docs.contains_key(&uri) {
+            // Re-open: bump as full change.
+            return self.did_change(root, path, text);
+        }
+
+        let ext = abs
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        let spec = catalog::find_by_extension(&ext)
+            .ok_or_else(|| format!("no language server for .{ext}"))?;
+        let (spawn_id, binary, args) = resolve_spawn(spec, &ext)?;
+        let root_path = PathBuf::from(root);
+        if !root_path.is_absolute() {
+            return Err("workspace root must be absolute".into());
+        }
+
+        if !self.servers.contains_key(&spawn_id) {
+            let session = spawn_server(
+                &spawn_id,
+                &binary,
+                &args,
+                &root_path,
+                Arc::clone(&self.push),
+            )?;
+            self.servers.insert(spawn_id.clone(), session);
+        }
+
+        let version = 1;
+        {
+            let session = self
+                .servers
+                .get_mut(&spawn_id)
+                .ok_or_else(|| "server missing after spawn".to_string())?;
+            let params = serde_json::json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": language_id,
+                    "version": version,
+                    "text": text,
+                }
+            });
+            session.notify("textDocument/didOpen", params)?;
+        }
+
+        self.docs.insert(
+            uri,
+            OpenDoc {
+                server_id: spawn_id,
+                language_id: language_id.to_string(),
+                version,
+            },
+        );
+        Ok(())
+    }
+
+    /// Full-document `textDocument/didChange`.
+    pub fn did_change(&mut self, root: &str, path: &str, text: &str) -> Result<(), String> {
+        let abs = abs_path(root, path)?;
+        let uri = path_to_uri(&abs);
+        let doc = self
+            .docs
+            .get_mut(&uri)
+            .ok_or_else(|| "document not open".to_string())?;
+        doc.version = doc.version.saturating_add(1);
+        let version = doc.version;
+        let server_id = doc.server_id.clone();
+        let session = self
+            .servers
+            .get_mut(&server_id)
+            .ok_or_else(|| "server not running".to_string())?;
+        let params = serde_json::json!({
+            "textDocument": { "uri": uri, "version": version },
+            "contentChanges": [{ "text": text }],
+        });
+        session.notify("textDocument/didChange", params)
+    }
+
+    /// `textDocument/didSave`.
+    pub fn did_save(&mut self, root: &str, path: &str, text: Option<&str>) -> Result<(), String> {
+        let abs = abs_path(root, path)?;
+        let uri = path_to_uri(&abs);
+        let server_id = self
+            .docs
+            .get(&uri)
+            .map(|d| d.server_id.clone())
+            .ok_or_else(|| "document not open".to_string())?;
+        let session = self
+            .servers
+            .get_mut(&server_id)
+            .ok_or_else(|| "server not running".to_string())?;
+        let doc = serde_json::json!({ "uri": uri });
+        let mut params = serde_json::json!({ "textDocument": doc });
+        if let Some(t) = text {
+            params
+                .as_object_mut()
+                .unwrap()
+                .insert("text".into(), serde_json::Value::String(t.to_string()));
+        }
+        session.notify("textDocument/didSave", params)
+    }
+
+    /// `textDocument/didClose` by file URI or root+path.
+    pub fn did_close_path(&mut self, root: &str, path: &str) -> Result<(), String> {
+        let abs = abs_path(root, path)?;
+        let uri = path_to_uri(&abs);
+        self.did_close(&uri);
+        Ok(())
+    }
+
+    pub fn did_close(&mut self, uri: &str) {
+        let Some(doc) = self.docs.remove(uri) else {
+            return;
+        };
+        if let Some(session) = self.servers.get_mut(&doc.server_id) {
+            let params = serde_json::json!({
+                "textDocument": { "uri": uri }
+            });
+            let _ = session.notify("textDocument/didClose", params);
+        }
+        // Clear markers for this URI.
+        push_diagnostics(&*self.push, uri, Vec::new());
+    }
+
+    /// `textDocument/completion`.
+    pub fn completion(
+        &mut self,
+        root: &str,
+        path: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Vec<LspCompletionItem>, String> {
+        let (uri, server_id) = self.uri_server(root, path)?;
+        let session = self
+            .servers
+            .get_mut(&server_id)
+            .ok_or_else(|| "server not running".to_string())?;
+        let params = serde_json::json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+            "context": { "triggerKind": 1 }
+        });
+        let result = session.request("textDocument/completion", params)?;
+        Ok(parse_completions(&result))
+    }
+
+    /// `textDocument/hover`.
+    pub fn hover(
+        &mut self,
+        root: &str,
+        path: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<LspHover>, String> {
+        let (uri, server_id) = self.uri_server(root, path)?;
+        let session = self
+            .servers
+            .get_mut(&server_id)
+            .ok_or_else(|| "server not running".to_string())?;
+        let params = serde_json::json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+        });
+        let result = session.request("textDocument/hover", params)?;
+        if result.is_null() {
+            return Ok(None);
+        }
+        Ok(parse_hover(&result))
+    }
+
+    /// `textDocument/definition`.
+    pub fn definition(
+        &mut self,
+        root: &str,
+        path: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Vec<LspLocation>, String> {
+        let (uri, server_id) = self.uri_server(root, path)?;
+        let session = self
+            .servers
+            .get_mut(&server_id)
+            .ok_or_else(|| "server not running".to_string())?;
+        let params = serde_json::json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+        });
+        let result = session.request("textDocument/definition", params)?;
+        Ok(parse_locations(&result))
+    }
+
+    fn uri_server(&self, root: &str, path: &str) -> Result<(String, String), String> {
+        let abs = abs_path(root, path)?;
+        let uri = path_to_uri(&abs);
+        let doc = self
+            .docs
+            .get(&uri)
+            .ok_or_else(|| "document not open in LSP".to_string())?;
+        Ok((uri, doc.server_id.clone()))
+    }
+}
+
+impl ServerSession {
+    fn notify(&self, method: &str, params: serde_json::Value) -> Result<(), String> {
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        write_message(&self.stdin, &msg)
+    }
+
+    fn request(&self, method: &str, params: serde_json::Value) -> Result<serde_json::Value, String> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx): (Sender<PendingReply>, Receiver<PendingReply>) = mpsc::channel();
+        {
+            let mut map = self
+                .pending
+                .lock()
+                .map_err(|_| "pending lock poisoned".to_string())?;
+            map.insert(id, tx);
+        }
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        if let Err(e) = write_message(&self.stdin, &msg) {
+            let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+            map.remove(&id);
+            return Err(e);
+        }
+        match rx.recv_timeout(REQ_TIMEOUT) {
+            Ok(PendingReply::Ok(v)) => Ok(v),
+            Ok(PendingReply::Err(e)) => Err(e),
+            Err(RecvTimeoutError::Timeout) => {
+                let mut map = self.pending.lock().unwrap_or_else(|p| p.into_inner());
+                map.remove(&id);
+                Err(format!("LSP {method} timed out"))
+            }
+            Err(RecvTimeoutError::Disconnected) => Err("LSP server closed".into()),
+        }
+    }
+}
+
+fn write_message(stdin: &Arc<Mutex<ChildStdin>>, msg: &serde_json::Value) -> Result<(), String> {
+    let body = serde_json::to_vec(msg).map_err(|e| e.to_string())?;
+    let header = format!("Content-Length: {}\r\n\r\n", body.len());
+    let mut guard = stdin
+        .lock()
+        .map_err(|_| "stdin lock poisoned".to_string())?;
+    guard
+        .write_all(header.as_bytes())
+        .and_then(|_| guard.write_all(&body))
+        .and_then(|_| guard.flush())
+        .map_err(|e| format!("LSP stdin write failed: {e}"))
+}
+
+fn spawn_server(
+    id: &str,
+    binary: &Path,
+    args: &[&str],
+    root: &Path,
+    push: Arc<dyn Fn(String) + Send + Sync>,
+) -> Result<ServerSession, String> {
+    let mut cmd = Command::new(binary);
+    for a in args {
+        cmd.arg(a);
+    }
+    cmd.current_dir(root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    // Avoid Windows console flash (same helper family as MCP/sec).
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("spawn {} failed: {e}", binary.display()))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "child stdin missing".to_string())?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "child stdout missing".to_string())?;
+    let stderr = child.stderr.take();
+
+    let stdin = Arc::new(Mutex::new(stdin));
+    let pending: Arc<Mutex<HashMap<u64, Sender<PendingReply>>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+    let pending_reader = Arc::clone(&pending);
+    let push_reader = Arc::clone(&push);
+    let stdin_init = Arc::clone(&stdin);
+
+    // stderr drain so a chatty server never blocks.
+    if let Some(stderr) = stderr {
+        std::thread::Builder::new()
+            .name(format!("lsp-err-{id}"))
+            .spawn(move || {
+                let mut r = BufReader::new(stderr);
+                let mut buf = String::new();
+                while r.read_line(&mut buf).ok().filter(|n| *n > 0).is_some() {
+                    buf.clear();
+                }
+            })
+            .ok();
+    }
+
+    // Reader thread: Content-Length frames → pending map or diagnostics push.
+    std::thread::Builder::new()
+        .name(format!("lsp-out-{id}"))
+        .spawn(move || {
+            reader_loop(stdout, pending_reader, push_reader);
+        })
+        .map_err(|e| format!("lsp reader spawn: {e}"))?;
+
+    let session = ServerSession {
+        id: id.to_string(),
+        root: root.to_path_buf(),
+        child,
+        stdin: stdin_init,
+        next_id: AtomicU64::new(1),
+        pending,
+        language_ids: Vec::new(),
+    };
+
+    // initialize → initialized
+    let root_uri = path_to_uri(root);
+    let init_params = serde_json::json!({
+        "processId": std::process::id(),
+        "clientInfo": { "name": "koma", "version": env!("CARGO_PKG_VERSION") },
+        "rootUri": root_uri,
+        "rootPath": root.to_string_lossy(),
+        "capabilities": {
+            "textDocument": {
+                "synchronization": {
+                    "dynamicRegistration": false,
+                    "willSave": false,
+                    "willSaveWaitUntil": false,
+                    "didSave": true
+                },
+                "completion": {
+                    "completionItem": {
+                        "snippetSupport": false,
+                        "documentationFormat": ["plaintext", "markdown"]
+                    },
+                    "contextSupport": true
+                },
+                "hover": {
+                    "contentFormat": ["plaintext", "markdown"]
+                },
+                "definition": {
+                    "linkSupport": false
+                },
+                "publishDiagnostics": {
+                    "relatedInformation": false,
+                    "versionSupport": false
+                }
+            },
+            "workspace": {
+                "workspaceFolders": true
+            }
+        },
+        "workspaceFolders": [{
+            "uri": root_uri,
+            "name": root.file_name().and_then(|s| s.to_str()).unwrap_or("workspace")
+        }],
+        "initializationOptions": {}
+    });
+    let _caps = session.request("initialize", init_params)?;
+    session.notify("initialized", serde_json::json!({}))?;
+
+    // rust-analyzer: wait is not required; first didOpen triggers analysis.
+    let _ = id;
+    Ok(session)
+}
+
+fn reader_loop<R: Read>(
+    stdout: R,
+    pending: Arc<Mutex<HashMap<u64, Sender<PendingReply>>>>,
+    push: Arc<dyn Fn(String) + Send + Sync>,
+) {
+    let mut reader = BufReader::new(stdout);
+    loop {
+        let body = match read_frame(&mut reader) {
+            Ok(Some(b)) => b,
+            Ok(None) => break,
+            Err(_) => break,
+        };
+        let msg: serde_json::Value = match serde_json::from_slice(&body) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        // Response to a request we sent.
+        if let Some(id) = msg.get("id").and_then(|v| {
+            v.as_u64()
+                .or_else(|| v.as_i64().map(|i| i as u64))
+                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        }) {
+            // Server→client request (has method + id) — reply with empty result.
+            if msg.get("method").is_some() {
+                // Best-effort: we don't currently support server requests (applyEdit…).
+                continue;
+            }
+            let tx = {
+                let mut map = pending.lock().unwrap_or_else(|p| p.into_inner());
+                map.remove(&id)
+            };
+            if let Some(tx) = tx {
+                if let Some(err) = msg.get("error") {
+                    let msg = err
+                        .get("message")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("LSP error")
+                        .to_string();
+                    let _ = tx.send(PendingReply::Err(msg));
+                } else {
+                    let result = msg.get("result").cloned().unwrap_or(serde_json::Value::Null);
+                    let _ = tx.send(PendingReply::Ok(result));
+                }
+            }
+            continue;
+        }
+
+        // Notification from server.
+        if let Some(method) = msg.get("method").and_then(|m| m.as_str()) {
+            if method == "textDocument/publishDiagnostics" {
+                if let Some(params) = msg.get("params") {
+                    handle_publish_diagnostics(params, &*push);
+                }
+            }
+            // window/logMessage, $/progress, etc. — ignore for v1.
+        }
+    }
+
+    // Fail every waiter so nobody hangs after crash/EOF.
+    let mut map = pending.lock().unwrap_or_else(|p| p.into_inner());
+    for (_, tx) in map.drain() {
+        let _ = tx.send(PendingReply::Err("LSP server closed".into()));
+    }
+}
+
+fn read_frame<R: BufRead>(reader: &mut R) -> Result<Option<Vec<u8>>, String> {
+    let mut content_length: Option<usize> = None;
+    loop {
+        let mut line = String::new();
+        let n = reader
+            .read_line(&mut line)
+            .map_err(|e| format!("LSP header read: {e}"))?;
+        if n == 0 {
+            return Ok(None);
+        }
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some(rest) = trimmed
+            .strip_prefix("Content-Length:")
+            .or_else(|| trimmed.strip_prefix("content-length:"))
+        {
+            content_length = rest.trim().parse().ok();
+        }
+    }
+    let len = content_length.ok_or_else(|| "LSP frame missing Content-Length".to_string())?;
+    let mut buf = vec![0u8; len];
+    reader
+        .read_exact(&mut buf)
+        .map_err(|e| format!("LSP body read: {e}"))?;
+    Ok(Some(buf))
+}
+
+fn handle_publish_diagnostics(params: &serde_json::Value, push: &dyn Fn(String)) {
+    let uri = params
+        .get("uri")
+        .and_then(|u| u.as_str())
+        .unwrap_or("")
+        .to_string();
+    if uri.is_empty() {
+        return;
+    }
+    let empty = Vec::new();
+    let arr = params
+        .get("diagnostics")
+        .and_then(|d| d.as_array())
+        .unwrap_or(&empty);
+    let mut out = Vec::with_capacity(arr.len());
+    for d in arr {
+        let range = d.get("range");
+        let start = range.and_then(|r| r.get("start"));
+        let end = range.and_then(|r| r.get("end"));
+        let line = start
+            .and_then(|s| s.get("line"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let character = start
+            .and_then(|s| s.get("character"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let end_line = end
+            .and_then(|s| s.get("line"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(line as u64) as u32;
+        let end_character = end
+            .and_then(|s| s.get("character"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(character as u64) as u32;
+        let severity = d
+            .get("severity")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(1) as u8;
+        let message = d
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("")
+            .to_string();
+        if message.is_empty() {
+            continue;
+        }
+        let source = d
+            .get("source")
+            .and_then(|s| s.as_str())
+            .map(|s| s.to_string());
+        let code = match d.get("code") {
+            Some(serde_json::Value::String(s)) => Some(s.clone()),
+            Some(serde_json::Value::Number(n)) => Some(n.to_string()),
+            _ => None,
+        };
+        out.push(LspDiagnostic {
+            uri: uri.clone(),
+            line,
+            character,
+            end_line,
+            end_character,
+            severity,
+            message,
+            source,
+            code,
+        });
+    }
+    push_diagnostics(push, &uri, out);
+}
+
+/// Emit diagnostics via the shared push_proto helper when available; otherwise a
+/// raw envelope (used during unit-less bring-up). The real helper lives in
+/// `push_proto` and is called from a thin wrapper in `lsp_host` / here via JSON.
+pub fn push_diagnostics(push: &dyn Fn(String), uri: &str, diagnostics: Vec<LspDiagnostic>) {
+    let env = serde_json::json!({
+        "k": "LspDiagnostics",
+        "uri": uri,
+        "diagnostics": diagnostics,
+    });
+    if let Ok(s) = serde_json::to_string(&env) {
+        push(s);
+    }
+}
+
+// ─── Spawn resolution ────────────────────────────────────────────────────────
+
+/// Pick binary + args for a catalogue entry. Multi-binary packages (vscode-langservers)
+/// select the right binary from the file extension.
+fn resolve_spawn(
+    spec: &ServerSpec,
+    ext: &str,
+) -> Result<(String, PathBuf, Vec<&'static str>), String> {
+    let (binary_name, args): (&str, &[&str]) = if spec.id == "vscode-langservers" {
+        match ext {
+            "html" | "htm" | "xhtml" => ("vscode-html-language-server", &["--stdio"]),
+            "css" | "scss" | "less" => ("vscode-css-language-server", &["--stdio"]),
+            _ => ("vscode-json-language-server", &["--stdio"]),
+        }
+    } else {
+        (spec.binary, spec.args)
+    };
+
+    // For multi-binary, key the session by binary name so json/html/css can
+    // co-exist as separate processes under the same catalogue id.
+    let session_id = if spec.id == "vscode-langservers" {
+        format!("vscode-langservers:{binary_name}")
+    } else {
+        spec.id.to_string()
+    };
+
+    // Prefer managed path for the chosen binary name.
+    if let Some(p) = super::manifest::managed_binary_path(spec.id, binary_name) {
+        return Ok((session_id, p, args.to_vec()));
+    }
+
+    // Fall back to status_one path (primary binary) then PATH lookup.
+    if let Some(st) = resolve::status_one(spec.id) {
+        if st.source != Source::Missing {
+            if let Some(p) = st.path {
+                // If status points at a different binary (json default), try PATH for ours.
+                let pb = PathBuf::from(&p);
+                if pb
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with(binary_name) || n == binary_name)
+                {
+                    return Ok((session_id, pb, args.to_vec()));
+                }
+            }
+        }
+    }
+    if let Some(p) = which_binary(binary_name) {
+        return Ok((session_id, p, args.to_vec()));
+    }
+    Err(format!(
+        "language server '{binary_name}' not installed (Settings → Language servers)"
+    ))
+}
+
+fn which_binary(name: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        #[cfg(windows)]
+        {
+            let cmd = dir.join(format!("{name}.cmd"));
+            if cmd.is_file() {
+                return Some(cmd);
+            }
+            let exe = dir.join(format!("{name}.exe"));
+            if exe.is_file() {
+                return Some(exe);
+            }
+        }
+    }
+    None
+}
+
+// ─── Path / URI helpers ──────────────────────────────────────────────────────
+
+fn abs_path(root: &str, path: &str) -> Result<PathBuf, String> {
+    let root_p = PathBuf::from(root);
+    if !root_p.is_absolute() {
+        return Err("root must be absolute".into());
+    }
+    let rel = Path::new(path);
+    if rel.is_absolute() {
+        return Ok(rel.to_path_buf());
+    }
+    for c in rel.components() {
+        if matches!(c, std::path::Component::ParentDir | std::path::Component::RootDir) {
+            return Err("path escapes workspace".into());
+        }
+    }
+    Ok(root_p.join(rel))
+}
+
+fn path_to_uri(path: &Path) -> String {
+    // Manual file:// URI — avoids depending on url crate feature flags.
+    let s = path.to_string_lossy();
+    #[cfg(windows)]
+    {
+        let norm = s.replace('\\', "/");
+        if norm.starts_with('/') {
+            return format!("file://{norm}");
+        }
+        return format!("file:///{norm}");
+    }
+    #[cfg(not(windows))]
+    {
+        format!("file://{s}")
+    }
+}
+
+/// Map a file path to the Monaco / LSP language id (best-effort).
+pub fn language_id_for_path(path: &str) -> &'static str {
+    let file = path.rsplit('/').next().unwrap_or(path);
+    let ext = file
+        .rsplit_once('.')
+        .map(|(_, e)| e.to_ascii_lowercase())
+        .unwrap_or_default();
+    match ext.as_str() {
+        "rs" => "rust",
+        "ts" | "mts" | "cts" => "typescript",
+        "tsx" => "typescriptreact",
+        "js" | "mjs" | "cjs" => "javascript",
+        "jsx" => "javascriptreact",
+        "py" | "pyi" => "python",
+        "go" => "go",
+        "c" => "c",
+        "h" | "hpp" | "hh" | "cpp" | "cc" | "cxx" => "cpp",
+        "json" | "jsonc" => "json",
+        "html" | "htm" | "xhtml" => "html",
+        "css" => "css",
+        "scss" => "scss",
+        "less" => "less",
+        "sh" | "bash" | "zsh" => "shellscript",
+        "toml" => "toml",
+        "lua" => "lua",
+        "zig" | "zon" => "zig",
+        "nix" => "nix",
+        "md" | "markdown" => "markdown",
+        "yaml" | "yml" => "yaml",
+        _ => "plaintext",
+    }
+}
+
+// ─── Result parsers ──────────────────────────────────────────────────────────
+
+fn parse_completions(result: &serde_json::Value) -> Vec<LspCompletionItem> {
+    let items = if let Some(arr) = result.as_array() {
+        arr.clone()
+    } else if let Some(arr) = result.get("items").and_then(|i| i.as_array()) {
+        arr.clone()
+    } else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter_map(|it| {
+            let label = it.get("label")?.as_str()?.to_string();
+            let kind = it.get("kind").and_then(|k| k.as_u64()).map(|k| k as u32);
+            let detail = it
+                .get("detail")
+                .and_then(|d| d.as_str())
+                .map(|s| s.to_string());
+            let insert_text = it
+                .get("insertText")
+                .and_then(|d| d.as_str())
+                .map(|s| s.to_string());
+            let documentation = match it.get("documentation") {
+                Some(serde_json::Value::String(s)) => Some(s.clone()),
+                Some(obj) => obj
+                    .get("value")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                None => None,
+            };
+            Some(LspCompletionItem {
+                label,
+                kind,
+                detail,
+                insert_text,
+                documentation,
+            })
+        })
+        .take(200)
+        .collect()
+}
+
+fn parse_hover(result: &serde_json::Value) -> Option<LspHover> {
+    let contents = result.get("contents")?;
+    let text = markup_to_string(contents);
+    if text.trim().is_empty() {
+        return None;
+    }
+    let range = result.get("range").and_then(parse_range);
+    Some(LspHover {
+        contents: text,
+        range,
+    })
+}
+
+fn markup_to_string(v: &serde_json::Value) -> String {
+    if let Some(s) = v.as_str() {
+        return s.to_string();
+    }
+    if let Some(arr) = v.as_array() {
+        return arr
+            .iter()
+            .map(markup_to_string)
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+    }
+    if let Some(obj) = v.as_object() {
+        if let Some(s) = obj.get("value").and_then(|x| x.as_str()) {
+            return s.to_string();
+        }
+        if let Some(s) = obj.get("language").and_then(|x| x.as_str()) {
+            let val = obj
+                .get("value")
+                .and_then(|x| x.as_str())
+                .unwrap_or("");
+            return format!("```{s}\n{val}\n```");
+        }
+    }
+    String::new()
+}
+
+fn parse_locations(result: &serde_json::Value) -> Vec<LspLocation> {
+    if result.is_null() {
+        return Vec::new();
+    }
+    if let Some(arr) = result.as_array() {
+        return arr.iter().filter_map(parse_one_location).collect();
+    }
+    parse_one_location(result).into_iter().collect()
+}
+
+fn parse_one_location(v: &serde_json::Value) -> Option<LspLocation> {
+    // Location
+    if let (Some(uri), Some(range)) = (
+        v.get("uri").and_then(|u| u.as_str()),
+        v.get("range").and_then(parse_range),
+    ) {
+        return Some(LspLocation {
+            uri: uri.to_string(),
+            range,
+        });
+    }
+    // LocationLink
+    if let (Some(uri), Some(range)) = (
+        v.get("targetUri").and_then(|u| u.as_str()),
+        v.get("targetRange")
+            .or_else(|| v.get("targetSelectionRange"))
+            .and_then(parse_range),
+    ) {
+        return Some(LspLocation {
+            uri: uri.to_string(),
+            range,
+        });
+    }
+    None
+}
+
+fn parse_range(v: &serde_json::Value) -> Option<LspRange> {
+    let start = v.get("start")?;
+    let end = v.get("end")?;
+    Some(LspRange {
+        start_line: start.get("line")?.as_u64()? as u32,
+        start_character: start.get("character")?.as_u64()? as u32,
+        end_line: end.get("line")?.as_u64()? as u32,
+        end_character: end.get("character")?.as_u64()? as u32,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn language_id_rust() {
+        assert_eq!(language_id_for_path("src/main.rs"), "rust");
+    }
+
+    #[test]
+    fn parse_completion_list() {
+        let v = serde_json::json!({
+            "items": [
+                { "label": "foo", "kind": 3, "detail": "fn" },
+                { "label": "bar" }
+            ]
+        });
+        let items = parse_completions(&v);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].label, "foo");
+        assert_eq!(items[0].kind, Some(3));
+    }
+
+    #[test]
+    fn parse_hover_markdown() {
+        let v = serde_json::json!({
+            "contents": { "kind": "markdown", "value": "**hi**" }
+        });
+        let h = parse_hover(&v).expect("hover");
+        assert!(h.contents.contains("hi"));
+    }
+
+    #[test]
+    fn path_uri_unix() {
+        let u = path_to_uri(Path::new("/tmp/foo.rs"));
+        assert!(u.starts_with("file://"));
+        assert!(u.contains("/tmp/foo.rs"));
+    }
+}

--- a/src-agent/src/lsp/client.rs
+++ b/src-agent/src/lsp/client.rs
@@ -96,25 +96,20 @@ enum PendingReply {
 
 struct OpenDoc {
     server_id: String,
+    /// LSP languageId sent on didOpen (used to detect language switches).
     language_id: String,
-    #[allow(dead_code)]
     version: i32,
 }
 
 struct ServerSession {
-    /// Catalogue id (e.g. `rust-analyzer`).
-    #[allow(dead_code)]
+    /// Catalogue / spawn id (e.g. `rust-analyzer`).
     id: String,
     /// Workspace root this process was initialized for (absolute).
-    #[allow(dead_code)]
     root: PathBuf,
     child: Child,
     stdin: Arc<Mutex<ChildStdin>>,
     next_id: AtomicU64,
     pending: Arc<Mutex<HashMap<u64, Sender<PendingReply>>>>,
-    /// Language ids this multi-binary session was spawned for (vscode-langservers).
-    #[allow(dead_code)]
-    language_ids: Vec<String>,
 }
 
 /// Host-owned map of live language servers + open documents.
@@ -162,9 +157,19 @@ impl LspManager {
     ) -> Result<(), String> {
         let abs = abs_path(root, path)?;
         let uri = path_to_uri(&abs);
-        if self.docs.contains_key(&uri) {
-            // Re-open: bump as full change.
-            return self.did_change(root, path, text);
+        // Empty languageId from the GUI → derive from extension.
+        let language_id = if language_id.is_empty() {
+            language_id_for_path(path)
+        } else {
+            language_id
+        };
+        if let Some(existing) = self.docs.get(&uri) {
+            // Same language: treat as a full-document change. Language switch:
+            // close and fall through so the server sees a fresh didOpen.
+            if existing.language_id == language_id {
+                return self.did_change(root, path, text);
+            }
+            self.did_close(&uri);
         }
 
         let ext = abs
@@ -180,7 +185,17 @@ impl LspManager {
             return Err("workspace root must be absolute".into());
         }
 
-        if !self.servers.contains_key(&spawn_id) {
+        if let Some(session) = self.servers.get(&spawn_id) {
+            // One process per (server, root). Refuse silently-wrong roots.
+            if session.root != root_path {
+                return Err(format!(
+                    "LSP {} already running for {} (requested {})",
+                    session.id,
+                    session.root.display(),
+                    root_path.display()
+                ));
+            }
+        } else {
             let session = spawn_server(
                 &spawn_id,
                 &binary,
@@ -254,15 +269,12 @@ impl LspManager {
             .servers
             .get_mut(&server_id)
             .ok_or_else(|| "server not running".to_string())?;
-        let doc = serde_json::json!({ "uri": uri });
-        let mut params = serde_json::json!({ "textDocument": doc });
+        let mut params = serde_json::Map::new();
+        params.insert("textDocument".into(), serde_json::json!({ "uri": uri }));
         if let Some(t) = text {
-            params
-                .as_object_mut()
-                .unwrap()
-                .insert("text".into(), serde_json::Value::String(t.to_string()));
+            params.insert("text".into(), serde_json::Value::String(t.to_string()));
         }
-        session.notify("textDocument/didSave", params)
+        session.notify("textDocument/didSave", serde_json::Value::Object(params))
     }
 
     /// `textDocument/didClose` by file URI or root+path.
@@ -494,7 +506,6 @@ fn spawn_server(
         stdin: stdin_init,
         next_id: AtomicU64::new(1),
         pending,
-        language_ids: Vec::new(),
     };
 
     // initialize → initialized
@@ -543,8 +554,6 @@ fn spawn_server(
     let _caps = session.request("initialize", init_params)?;
     session.notify("initialized", serde_json::json!({}))?;
 
-    // rust-analyzer: wait is not required; first didOpen triggers analysis.
-    let _ = id;
     Ok(session)
 }
 

--- a/src-agent/src/lsp/install.rs
+++ b/src-agent/src/lsp/install.rs
@@ -164,9 +164,9 @@ fn download_bytes(url: &str, progress: &mut Option<ProgressFn>, id: &str) -> Res
         }
         buf.extend_from_slice(&tmp[..n]);
         read += n as u64;
-        if total > 0 {
-            let pct = 5 + ((read.saturating_mul(80)) / total) as u8;
-            report(progress, id, pct.min(85), None);
+        if let Some(part) = read.saturating_mul(80).checked_div(total) {
+            let pct = 5u8.saturating_add(part as u8).min(85);
+            report(progress, id, pct, None);
         }
     }
     report(progress, id, 85, None);
@@ -642,10 +642,7 @@ fn exe_name(name: &str) -> String {
 pub fn print_status() -> i32 {
     let rows = resolve::status_all();
     let mut any_missing = false;
-    println!(
-        "{:<22} {:<10} {:<10} {}",
-        "ID", "SOURCE", "VERSION", "PATH"
-    );
+    println!("{:<22} {:<10} {:<10} PATH", "ID", "SOURCE", "VERSION");
     println!("{}", "-".repeat(78));
     for r in &rows {
         if r.source == resolve::Source::Missing {

--- a/src-agent/src/lsp/manifest.rs
+++ b/src-agent/src/lsp/manifest.rs
@@ -162,10 +162,8 @@ fn find_file_named(root: &Path, name: &str) -> Option<PathBuf> {
                     }
                 }
                 stack.push(p);
-            } else if p.is_file() {
-                if p.file_name().and_then(|s| s.to_str()) == Some(name) {
-                    return Some(p);
-                }
+            } else if p.is_file() && p.file_name().and_then(|s| s.to_str()) == Some(name) {
+                return Some(p);
             }
         }
     }

--- a/src-agent/src/lsp/mod.rs
+++ b/src-agent/src/lsp/mod.rs
@@ -1,9 +1,9 @@
 //! koma-managed language servers (`~/.koma/lsp/`).
 //!
 //! Host-spawned LSP side of the coding panel: catalogue, PATH/managed resolve,
-//! install/uninstall recipes, and the `koma lsp` CLI. The actual JSON-RPC
-//! language client (completion/hover/definition/diagnostics) is a later phase;
-//! this module only provisions and discovers server binaries.
+//! install/uninstall recipes, the `koma lsp` CLI, and the stdio JSON-RPC
+//! language client ([`client::LspManager`]) that drives Monaco completion /
+//! hover / definition / diagnostics.
 //!
 //! Layout:
 //! ```text
@@ -17,14 +17,20 @@
 //! Resolution order: koma-managed → PATH → missing.
 
 pub mod catalog;
+pub mod client;
 pub mod install;
 pub mod manifest;
 pub mod resolve;
 
-// Re-exports are the stable surface for GUI host code and future LspManager.
+// Re-exports are the stable surface for GUI host code and LspManager.
 // Not every symbol is consumed by the CLI path yet — keep them public.
 #[allow(unused_imports)]
 pub use catalog::{find, find_by_extension, ServerSpec, CATALOG};
+#[allow(unused_imports)]
+pub use client::{
+    language_id_for_path, LspCompletionItem, LspDiagnostic, LspHover, LspLocation, LspManager,
+    LspRange,
+};
 #[allow(unused_imports)]
 pub use install::{install_all, install_one, print_status, uninstall_one, ProgressFn};
 #[allow(unused_imports)]

--- a/src-webgui/src/components/CodeEditorTab.tsx
+++ b/src-webgui/src/components/CodeEditorTab.tsx
@@ -2,6 +2,13 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
 import { Code2, Download, RotateCcw, Save, X } from 'lucide-react'
 import { initMonaco, applyKomaTheme, readMonoFont, langFromPath } from '../lib/monaco-setup'
+import {
+  ensureLspProviders,
+  languageIdForPath,
+  stampModelPath,
+  applyDiagnosticsToMonaco,
+  pathToUri,
+} from '../lib/monaco-lsp'
 import { useKoma, type Tab } from '../store/koma'
 import { fileKey } from '../store/coding'
 import { BrailleSpinner } from './BrailleSpinner'
@@ -9,14 +16,16 @@ import { BrailleSpinner } from './BrailleSpinner'
 type CodingTab = Extract<Tab, { kind: 'codingFile' }>
 
 const AUTOSAVE_MS = 750
+const LSP_CHANGE_MS = 300
 
 export default function CodeEditorTab({ tab }: { tab: CodingTab }) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null)
   const modelRef = useRef<monaco.editor.ITextModel | null>(null)
-  // Suppress markDirty while applying host content programmatically.
   const applyingRef = useRef(false)
   const autosaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lspChangeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lspOpenedRef = useRef(false)
 
   const fileState = useKoma((s) => s.coding.files[fileKey(tab.root, tab.path)] ?? null)
   const codingAutosave = useKoma((s) => !!s.settingsValues?.codingAutosave)
@@ -24,14 +33,22 @@ export default function CodeEditorTab({ tab }: { tab: CodingTab }) {
   const revertCodingFile = useKoma((s) => s.revertCodingFile)
   const lspServers = useKoma((s) => s.lspServers)
   const lspProgress = useKoma((s) => s.lspProgress)
+  const lspDiagnostics = useKoma((s) => s.lspDiagnostics)
   const refreshLsp = useKoma((s) => s.refreshLsp)
   const lspInstall = useKoma((s) => s.lspInstall)
+  const req = useKoma((s) => s.req)
   const [bannerDismissed, setBannerDismissed] = useState<Record<string, boolean>>({})
 
-  // Ensure we have a fresh LSP catalogue when a coding file opens.
   useEffect(() => {
     if (lspServers.length === 0) refreshLsp()
   }, [lspServers.length, refreshLsp])
+
+  useEffect(() => {
+    ensureLspProviders(
+      (body) => useKoma.getState().req(body as never),
+      () => (useKoma.getState().settingsValues?.workdir ?? []).filter(Boolean),
+    )
+  }, [])
 
   const missingServer = useMemo(() => {
     const file = tab.path.split('/').pop() ?? tab.path
@@ -67,8 +84,6 @@ export default function CodeEditorTab({ tab }: { tab: CodingTab }) {
     return 'Saved'
   }, [fileState, codingAutosave])
 
-  // Safe debounced autosave: only when enabled, dirty, editable, not already
-  // saving/conflicting, and content differs from last save.
   useEffect(() => {
     if (autosaveTimerRef.current) {
       clearTimeout(autosaveTimerRef.current)
@@ -112,7 +127,6 @@ export default function CodeEditorTab({ tab }: { tab: CodingTab }) {
     tab.path,
   ])
 
-  // Init Monaco + editor once per tab identity.
   useEffect(() => {
     const host = containerRef.current
     if (!host) return
@@ -130,33 +144,70 @@ export default function CodeEditorTab({ tab }: { tab: CodingTab }) {
       lineNumbersMinChars: 3,
       theme,
       wordWrap: 'on',
+      quickSuggestions: true,
+      suggestOnTriggerCharacters: true,
+      parameterHints: { enabled: true },
+      hover: { enabled: true, delay: 300 },
+      links: true,
+      folding: true,
+      multiCursorModifier: 'alt',
     })
     monaco.editor.setTheme(theme)
     editorRef.current = editor
 
-    // Ctrl/Cmd+S → save
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
       useKoma.getState().saveCodingFile(tab.root, tab.path)
+    })
+    editor.addCommand(monaco.KeyCode.F12, () => {
+      void editor.getAction('editor.action.revealDefinition')?.run()
     })
 
     const sub = editor.onDidChangeModelContent(() => {
       if (applyingRef.current) return
       const model = editor.getModel()
       if (!model) return
-      useKoma.getState().updateCodingContent(tab.root, tab.path, model.getValue())
+      const text = model.getValue()
+      useKoma.getState().updateCodingContent(tab.root, tab.path, text)
+      if (lspChangeTimerRef.current) clearTimeout(lspChangeTimerRef.current)
+      lspChangeTimerRef.current = setTimeout(() => {
+        lspChangeTimerRef.current = null
+        if (!lspOpenedRef.current) return
+        useKoma.getState().req({
+          r: 'LspDidChange',
+          root: tab.root,
+          path: tab.path,
+          text,
+        })
+      }, LSP_CHANGE_MS)
     })
 
+    const onReveal = (ev: Event) => {
+      const detail = (ev as CustomEvent).detail as
+        | { root: string; path: string; line: number; column: number }
+        | undefined
+      if (!detail) return
+      if (detail.root !== tab.root || detail.path !== tab.path) return
+      const ed = editorRef.current
+      if (!ed) return
+      ed.setPosition({ lineNumber: detail.line, column: detail.column })
+      ed.revealLineInCenter(detail.line)
+      ed.focus()
+    }
+    window.addEventListener('koma-reveal-line', onReveal)
+
     return () => {
+      window.removeEventListener('koma-reveal-line', onReveal)
       sub.dispose()
+      if (lspChangeTimerRef.current) clearTimeout(lspChangeTimerRef.current)
       const model = modelRef.current
       editor.dispose()
       if (model) model.dispose()
       editorRef.current = null
       modelRef.current = null
+      lspOpenedRef.current = false
     }
   }, [tab.root, tab.path])
 
-  // Sync content when file state changes from the host.
   useEffect(() => {
     if (!fileState || !editorRef.current) return
     const editor = editorRef.current
@@ -178,11 +229,12 @@ export default function CodeEditorTab({ tab }: { tab: CodingTab }) {
         }
       } else {
         const model = monaco.editor.createModel(next, lang)
+        stampModelPath(model, tab.root, tab.path)
         editor.setModel(model)
         modelRef.current = model
       }
+      if (modelRef.current) stampModelPath(modelRef.current, tab.root, tab.path)
     } finally {
-      // Defer so Monaco's own content-change event from setValue is ignored.
       queueMicrotask(() => {
         applyingRef.current = false
       })
@@ -191,6 +243,26 @@ export default function CodeEditorTab({ tab }: { tab: CodingTab }) {
     editor.updateOptions({
       readOnly: fileState.binary || fileState.tooLarge || !!fileState.error || fileState.conflict,
     })
+
+    if (
+      !lspOpenedRef.current &&
+      !fileState.binary &&
+      !fileState.tooLarge &&
+      !fileState.error &&
+      fileState.content != null
+    ) {
+      lspOpenedRef.current = true
+      req({
+        r: 'LspDidOpen',
+        root: tab.root,
+        path: tab.path,
+        languageId: languageIdForPath(tab.path),
+        text: fileState.content,
+      })
+      const uri = pathToUri(tab.root, tab.path)
+      const diags = useKoma.getState().lspDiagnostics[uri]
+      if (diags) applyDiagnosticsToMonaco(uri, diags)
+    }
   }, [
     fileState?.content,
     fileState?.loading,
@@ -200,7 +272,15 @@ export default function CodeEditorTab({ tab }: { tab: CodingTab }) {
     fileState?.conflict,
     fileState?.fingerprint,
     tab.path,
+    tab.root,
+    req,
   ])
+
+  useEffect(() => {
+    const uri = pathToUri(tab.root, tab.path)
+    const diags = lspDiagnostics[uri]
+    if (diags) applyDiagnosticsToMonaco(uri, diags)
+  }, [lspDiagnostics, tab.root, tab.path])
 
   if (fileState?.conflict) {
     return (
@@ -230,15 +310,7 @@ export default function CodeEditorTab({ tab }: { tab: CodingTab }) {
   if (fileState?.binary) {
     return (
       <div className="flex h-full w-full flex-col">
-        <EditorChrome
-          path={tab.path}
-          status={status}
-          canSave={false}
-          canRevert={false}
-          saving={false}
-          onSave={() => {}}
-          onRevert={() => {}}
-        />
+        <EditorChrome path={tab.path} status={status} canSave={false} canRevert={false} saving={false} onSave={() => {}} onRevert={() => {}} />
         <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center text-[12px] text-koma-dim">
           Binary file — no preview
         </div>
@@ -248,15 +320,7 @@ export default function CodeEditorTab({ tab }: { tab: CodingTab }) {
   if (fileState?.tooLarge) {
     return (
       <div className="flex h-full w-full flex-col">
-        <EditorChrome
-          path={tab.path}
-          status={status}
-          canSave={false}
-          canRevert={false}
-          saving={false}
-          onSave={() => {}}
-          onRevert={() => {}}
-        />
+        <EditorChrome path={tab.path} status={status} canSave={false} canRevert={false} saving={false} onSave={() => {}} onRevert={() => {}} />
         <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center text-[12px] text-koma-dim">
           File too large to edit
         </div>
@@ -266,15 +330,7 @@ export default function CodeEditorTab({ tab }: { tab: CodingTab }) {
   if (fileState?.error && fileState.content === null) {
     return (
       <div className="flex h-full w-full flex-col">
-        <EditorChrome
-          path={tab.path}
-          status={status}
-          canSave={false}
-          canRevert={false}
-          saving={false}
-          onSave={() => {}}
-          onRevert={() => {}}
-        />
+        <EditorChrome path={tab.path} status={status} canSave={false} canRevert={false} saving={false} onSave={() => {}} onRevert={() => {}} />
         <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center text-[12px] text-koma-dim">
           {fileState.error}
         </div>
@@ -314,9 +370,7 @@ export default function CodeEditorTab({ tab }: { tab: CodingTab }) {
           </button>
           <button
             type="button"
-            onClick={() =>
-              setBannerDismissed((m) => ({ ...m, [missingServer.id]: true }))
-            }
+            onClick={() => setBannerDismissed((m) => ({ ...m, [missingServer.id]: true }))}
             aria-label="Dismiss"
             className="flex h-6 w-6 flex-none items-center justify-center rounded text-koma-fg opacity-50 hover:bg-koma-hover hover:opacity-100"
           >
@@ -353,41 +407,30 @@ function EditorChrome({
   onSave: () => void
   onRevert: () => void
 }) {
-  const segments = path.split('/').filter(Boolean)
-
   return (
-    <div className="flex flex-none items-center gap-2 border-b border-koma-border bg-koma-panel2 px-3 py-1.5">
-      <Code2 size={14} className="flex-none text-koma-fg opacity-70" />
-      <nav aria-label="File path" className="flex min-w-0 flex-1 items-center truncate font-mono text-[12px] text-koma-fg" title={path}>
-        {segments.map((segment, index) => (
-          <span key={`${segment}-${index}`} className="flex min-w-0 items-center">
-            {index > 0 && <span className="mx-1 flex-none text-koma-dim">/</span>}
-            <span className="truncate">{segment}</span>
-          </span>
-        ))}
-      </nav>
+    <div className="flex h-8 flex-none items-center gap-2 border-b border-koma-border bg-koma-panel px-3 text-[12px]">
+      <Code2 size={13} className="flex-none text-koma-dim" />
+      <span className="min-w-0 flex-1 truncate font-mono text-koma-fg" title={path}>
+        {path}
+      </span>
       <span className="flex-none text-[11px] text-koma-dim">{status}</span>
       <button
         type="button"
         onClick={onRevert}
-        disabled={!canRevert}
+        disabled={!canRevert || saving}
         title="Revert"
-        aria-label="Revert"
-        className="flex h-6 items-center gap-1 rounded px-1.5 text-[11px] text-koma-fg opacity-70 hover:bg-koma-hover hover:opacity-100 disabled:cursor-default disabled:opacity-30"
+        className="flex h-6 w-6 flex-none items-center justify-center rounded text-koma-dim hover:bg-koma-hover hover:text-koma-fg disabled:opacity-30"
       >
-        <RotateCcw size={12} />
-        Revert
+        <RotateCcw size={13} />
       </button>
       <button
         type="button"
         onClick={onSave}
         disabled={!canSave}
         title="Save"
-        aria-label="Save"
-        className="flex h-6 items-center gap-1 rounded bg-koma-accent/15 px-1.5 text-[11px] font-semibold text-koma-accent hover:bg-koma-accent/25 disabled:cursor-default disabled:bg-transparent disabled:opacity-30"
+        className="flex h-6 w-6 flex-none items-center justify-center rounded text-koma-dim hover:bg-koma-hover hover:text-koma-fg disabled:opacity-30"
       >
-        {saving ? <BrailleSpinner size={12} /> : <Save size={12} />}
-        Save
+        <Save size={13} />
       </button>
     </div>
   )

--- a/src-webgui/src/components/ProblemsDrawer.tsx
+++ b/src-webgui/src/components/ProblemsDrawer.tsx
@@ -1,0 +1,106 @@
+// Cross-tab Problems drawer — sits above UsageFooter, visible across every
+// TabbedMain tab when expanded. Lists LSP diagnostics; click jumps to file:line.
+
+import { useMemo } from 'react'
+import { AlertCircle, AlertTriangle, ChevronDown, Info, X } from 'lucide-react'
+import { useKoma, type LspDiagnostic } from '../store/koma'
+import { uriToPath } from '../lib/monaco-lsp'
+
+type Row = LspDiagnostic & { fileLabel: string }
+
+function severityRank(s: number): number {
+  if (s === 1) return 0
+  if (s === 2) return 1
+  if (s === 3) return 2
+  return 3
+}
+
+function SeverityIcon({ severity }: { severity: number }) {
+  if (severity === 1) return <AlertCircle size={12} className="flex-none text-red-400" />
+  if (severity === 2) return <AlertTriangle size={12} className="flex-none text-amber-400" />
+  return <Info size={12} className="flex-none text-sky-400" />
+}
+
+export function ProblemsDrawer() {
+  const open = useKoma((s) => s.problemsOpen)
+  const diagnostics = useKoma((s) => s.lspDiagnostics)
+  const setProblemsOpen = useKoma((s) => s.setProblemsOpen)
+  const openDiagnostic = useKoma((s) => s.openDiagnostic)
+
+  const rows = useMemo(() => {
+    const out: Row[] = []
+    for (const [uri, list] of Object.entries(diagnostics)) {
+      const abs = uriToPath(uri) ?? uri
+      const fileLabel = abs.split('/').pop() ?? abs
+      for (const d of list) {
+        out.push({ ...d, uri: d.uri || uri, fileLabel })
+      }
+    }
+    out.sort((a, b) => {
+      const sr = severityRank(a.severity) - severityRank(b.severity)
+      if (sr !== 0) return sr
+      const f = a.fileLabel.localeCompare(b.fileLabel)
+      if (f !== 0) return f
+      return a.line - b.line
+    })
+    return out
+  }, [diagnostics])
+
+  if (!open) return null
+
+  return (
+    <div className="flex h-44 max-h-[40%] w-full flex-none flex-col border-t border-koma-border bg-koma-panel">
+      <div className="flex h-7 flex-none items-center gap-2 border-b border-koma-border px-3 text-[11px] text-koma-dim">
+        <span className="font-medium uppercase tracking-wide text-koma-fg/80">Problems</span>
+        <span className="opacity-70">{rows.length}</span>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={() => setProblemsOpen(false)}
+          title="Collapse"
+          className="flex h-5 w-5 items-center justify-center rounded text-koma-dim hover:bg-koma-hover hover:text-koma-fg"
+        >
+          <ChevronDown size={14} />
+        </button>
+        <button
+          type="button"
+          onClick={() => setProblemsOpen(false)}
+          title="Close"
+          className="flex h-5 w-5 items-center justify-center rounded text-koma-dim hover:bg-koma-hover hover:text-koma-fg"
+        >
+          <X size={13} />
+        </button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto font-mono text-[11px]">
+        {rows.length === 0 ? (
+          <div className="px-3 py-4 text-koma-dim">No problems</div>
+        ) : (
+          <ul className="divide-y divide-koma-border/60">
+            {rows.map((r, i) => (
+              <li key={`${r.uri}:${r.line}:${r.character}:${i}`}>
+                <button
+                  type="button"
+                  onClick={() => openDiagnostic(r.uri, r.line, r.character)}
+                  className="flex w-full items-start gap-2 px-3 py-1.5 text-left hover:bg-koma-hover"
+                >
+                  <SeverityIcon severity={r.severity} />
+                  <span className="min-w-0 flex-1 truncate text-koma-fg">
+                    <span className="text-koma-accent">{r.fileLabel}</span>
+                    <span className="text-koma-dim">
+                      :{r.line + 1}:{r.character + 1}
+                    </span>
+                    <span className="mx-1.5 text-koma-dim">·</span>
+                    <span className="opacity-90">{r.message}</span>
+                  </span>
+                  {r.source && (
+                    <span className="flex-none text-[10px] text-koma-dim opacity-70">{r.source}</span>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src-webgui/src/components/UsageFooter.tsx
+++ b/src-webgui/src/components/UsageFooter.tsx
@@ -1,4 +1,4 @@
-import { Activity, FoldVertical, Server } from 'lucide-react'
+import { Activity, AlertCircle, AlertTriangle, FoldVertical, Server } from 'lucide-react'
 import { useKoma, visiblePlanTodos } from '../store/koma'
 import { BranchSwitcher } from './BranchSwitcher'
 
@@ -36,6 +36,18 @@ export function UsageFooter() {
   const gitDetached = useKoma((s) => s.git.detached)
   const gitError = useKoma((s) => s.git.error)
   const remoteState = useKoma((s) => s.remoteState)
+  const lspDiagnostics = useKoma((s) => s.lspDiagnostics)
+  const problemsOpen = useKoma((s) => s.problemsOpen)
+  const toggleProblemsOpen = useKoma((s) => s.toggleProblemsOpen)
+  let errCount = 0
+  let warnCount = 0
+  for (const list of Object.values(lspDiagnostics)) {
+    for (const d of list) {
+      if (d.severity === 1) errCount += 1
+      else if (d.severity === 2) warnCount += 1
+    }
+  }
+  const problemTotal = errCount + warnCount
   // Live remote target for the statusline chip (hub-ready OR attached-connected).
   const remoteTarget =
     (remoteState.state === 'ready' || remoteState.state === 'connected') &&
@@ -113,6 +125,28 @@ export function UsageFooter() {
         }`}
       >
         <FoldVertical size={12} />
+      </button>
+
+      {/* Problems badge — always visible; expands the cross-tab drawer */}
+      <button
+        type="button"
+        onClick={toggleProblemsOpen}
+        aria-label="Problems"
+        title={problemTotal ? `${errCount} errors, ${warnCount} warnings` : 'No problems'}
+        className={`flex h-4 flex-none items-center gap-1 rounded px-1 transition-colors ${
+          problemsOpen
+            ? 'bg-koma-accent/15 text-koma-accent'
+            : problemTotal
+              ? 'text-koma-fg hover:bg-koma-hover'
+              : 'text-koma-dim hover:bg-koma-hover hover:text-koma-fg'
+        }`}
+      >
+        {errCount > 0 ? (
+          <AlertCircle size={11} className="text-red-400" />
+        ) : (
+          <AlertTriangle size={11} className={warnCount ? 'text-amber-400' : ''} />
+        )}
+        <span className="tabular-nums">{problemTotal}</span>
       </button>
     </div>
   )

--- a/src-webgui/src/components/panels/CodingPanel.tsx
+++ b/src-webgui/src/components/panels/CodingPanel.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEvent } from 'react'
+import { useEffect, useMemo, useRef, useState, type DragEvent, type FormEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent } from 'react'
 import {
   Check,
   ChevronDown,
   ChevronRight,
+  Download,
   File,
   Folder,
   FolderOpen,
@@ -54,16 +55,22 @@ type TreeNodeProps = {
   depth: number
   expanded: Set<string>
   draft: Draft | null
+  dropTargetPath: string | null
   onToggle: (path: string) => void
   onOpenFile: (path: string) => void
   onRefresh: (path: string) => void
   onStartCreate: (dirPath: string, item: 'file' | 'dir') => void
   onStartRename: (path: string) => void
   onStartDelete: (path: string, isDir: boolean) => void
+  onDownload: (path: string) => void
   onCancelDraft: () => void
   onSubmitCreate: (dirPath: string, item: 'file' | 'dir', name: string) => void
   onSubmitRename: (path: string, name: string) => void
   onConfirmDelete: (path: string) => void
+  onExternalDragOver: (e: DragEvent, dirPath: string) => void
+  onExternalDrop: (e: DragEvent, dirPath: string) => void
+  onExternalDragLeave: (e: DragEvent, dirPath: string) => void
+  onOpenContextMenu: (e: ReactMouseEvent, path: string, isDir: boolean) => void
 }
 
 function InlineNameInput({
@@ -170,16 +177,22 @@ function TreeNode({
   depth,
   expanded,
   draft,
+  dropTargetPath,
   onToggle,
   onOpenFile,
   onRefresh,
   onStartCreate,
   onStartRename,
   onStartDelete,
+  onDownload,
   onCancelDraft,
   onSubmitCreate,
   onSubmitRename,
   onConfirmDelete,
+  onExternalDragOver,
+  onExternalDrop,
+  onExternalDragLeave,
+  onOpenContextMenu,
 }: TreeNodeProps) {
   const key = fileKey(root, entry.path)
   const dirState = useKoma((s) => (entry.isDir ? s.coding.dirs[key] : null))
@@ -195,6 +208,9 @@ function TreeNode({
   const deleting = draft?.kind === 'delete' && draft.path === entry.path
   const createHere =
     draft?.kind === 'create' && draft.dirPath === entry.path && entry.isDir ? draft : null
+  // Drop target is the directory itself, or the parent dir when hovering a file.
+  const dropDir = entry.isDir ? entry.path : parentDirPath(entry.path)
+  const isDropTarget = dropTargetPath !== null && dropTargetPath === dropDir
 
   if (deleting) {
     return (
@@ -232,8 +248,15 @@ function TreeNode({
   return (
     <div>
       <div
-        className="group flex h-7 min-w-0 items-center gap-1 pr-1 text-[12px] text-koma-fg hover:bg-koma-hover"
+        className={`group flex h-7 min-w-0 items-center gap-1 pr-1 text-[12px] text-koma-fg hover:bg-koma-hover ${
+          isDropTarget ? 'bg-koma-accent/15 ring-1 ring-inset ring-koma-accent/40' : ''
+        }`}
         style={{ paddingLeft: pad }}
+        data-coding-row=""
+        onDragOver={(e) => onExternalDragOver(e, dropDir)}
+        onDrop={(e) => onExternalDrop(e, dropDir)}
+        onDragLeave={(e) => onExternalDragLeave(e, dropDir)}
+        onContextMenu={(e) => onOpenContextMenu(e, entry.path, entry.isDir)}
       >
         {entry.isDir ? (
           <button
@@ -288,7 +311,7 @@ function TreeNode({
             {/* Idle: max-w-0 so actions take no flex width (no premature ellipsis).
                 Hover: expand and show. opacity alone would still reserve space. */}
             {!draft ? (
-              <div className="flex max-w-0 flex-none items-center overflow-hidden opacity-0 transition-[max-width,opacity] duration-100 group-hover:max-w-[140px] group-hover:opacity-100">
+              <div className="flex max-w-0 flex-none items-center overflow-hidden opacity-0 transition-[max-width,opacity] duration-100 group-hover:max-w-[168px] group-hover:opacity-100">
                 {entry.isDir && (
                   <>
                     <IconBtn label="New file" onClick={() => onStartCreate(entry.path, 'file')}>
@@ -301,6 +324,11 @@ function TreeNode({
                       <RefreshCw size={12} />
                     </IconBtn>
                   </>
+                )}
+                {!entry.isDir && (
+                  <IconBtn label="Download" onClick={() => onDownload(entry.path)}>
+                    <Download size={12} />
+                  </IconBtn>
                 )}
                 <IconBtn label="Rename" onClick={() => onStartRename(entry.path)}>
                   <Pencil size={12} />
@@ -359,16 +387,22 @@ function TreeNode({
                 depth={depth + 1}
                 expanded={expanded}
                 draft={draft}
+                dropTargetPath={dropTargetPath}
                 onToggle={onToggle}
                 onOpenFile={onOpenFile}
                 onRefresh={onRefresh}
                 onStartCreate={onStartCreate}
                 onStartRename={onStartRename}
                 onStartDelete={onStartDelete}
+                onDownload={onDownload}
                 onCancelDraft={onCancelDraft}
                 onSubmitCreate={onSubmitCreate}
                 onSubmitRename={onSubmitRename}
                 onConfirmDelete={onConfirmDelete}
+                onExternalDragOver={onExternalDragOver}
+                onExternalDrop={onExternalDrop}
+                onExternalDragLeave={onExternalDragLeave}
+                onOpenContextMenu={onOpenContextMenu}
               />
             ))
           ) : dirState && !dirState.loading && !createHere ? (
@@ -400,10 +434,19 @@ export function CodingPanel() {
   const createCodingItem = useKoma((s) => s.createCodingItem)
   const renameCodingItem = useKoma((s) => s.renameCodingItem)
   const deleteCodingItem = useKoma((s) => s.deleteCodingItem)
+  const uploadCodingFile = useKoma((s) => s.uploadCodingFile)
+  const downloadCodingFile = useKoma((s) => s.downloadCodingFile)
   const req = useKoma((s) => s.req)
 
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set(['']))
   const [draft, setDraft] = useState<Draft | null>(null)
+  const [dropTargetPath, setDropTargetPath] = useState<string | null>(null)
+  const [ctxMenu, setCtxMenu] = useState<null | {
+    x: number
+    y: number
+    path: string
+    isDir: boolean
+  }>(null)
 
   useEffect(() => {
     req({ r: 'GetSettings' })
@@ -432,10 +475,28 @@ export function CodingPanel() {
   }, [draft])
 
   useEffect(() => {
+    if (!ctxMenu) return
+    const close = () => setCtxMenu(null)
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape') close()
+    }
+    window.addEventListener('click', close)
+    window.addEventListener('keydown', onKey)
+    window.addEventListener('blur', close)
+    return () => {
+      window.removeEventListener('click', close)
+      window.removeEventListener('keydown', onKey)
+      window.removeEventListener('blur', close)
+    }
+  }, [ctxMenu])
+
+  useEffect(() => {
     if (!activeRoot) return
     refreshCodingDir(activeRoot, '')
     setExpanded(new Set(['']))
     setDraft(null)
+    setDropTargetPath(null)
+    setCtxMenu(null)
   }, [activeRoot, refreshCodingDir])
 
   const rootKey = activeRoot ? fileKey(activeRoot, '') : null
@@ -443,6 +504,61 @@ export function CodingPanel() {
   const roots = useMemo(() => workdir.slice(), [workdir])
   const rootCreate =
     draft?.kind === 'create' && draft.dirPath === '' ? draft : null
+
+  const hasExternalFiles = (e: DragEvent) => {
+    const dt = e.dataTransfer
+    if (!dt) return false
+    if (dt.files && dt.files.length > 0) return true
+    if (dt.types) {
+      for (let i = 0; i < dt.types.length; i++) {
+        if (dt.types[i] === 'Files') return true
+      }
+    }
+    return false
+  }
+
+  const onExternalDragOver = (e: DragEvent, dirPath: string) => {
+    if (!hasExternalFiles(e)) return
+    e.preventDefault()
+    e.stopPropagation()
+    try {
+      e.dataTransfer.dropEffect = 'copy'
+    } catch {
+      /* ignore */
+    }
+    setDropTargetPath(dirPath)
+  }
+
+  const onExternalDragLeave = (e: DragEvent, dirPath: string) => {
+    e.stopPropagation()
+    // Only clear when leaving the current target (not entering a child).
+    const related = e.relatedTarget as Node | null
+    if (related && (e.currentTarget as HTMLElement).contains(related)) return
+    setDropTargetPath((cur) => (cur === dirPath ? null : cur))
+  }
+
+  const onExternalDrop = (e: DragEvent, dirPath: string) => {
+    if (!hasExternalFiles(e)) return
+    e.preventDefault()
+    e.stopPropagation()
+    setDropTargetPath(null)
+    if (!activeRoot) return
+    const files = Array.from(e.dataTransfer?.files ?? [])
+    for (const file of files) {
+      // Skip directory-like entries (webkit relative path empty folders, zero-size no-type).
+      if (!file.name || file.name === '.' || file.name === '..') continue
+      void uploadCodingFile(activeRoot, dirPath, file, true)
+    }
+    if (dirPath) {
+      setExpanded((prev) => new Set(prev).add(dirPath))
+    }
+  }
+
+  const onOpenContextMenu = (e: ReactMouseEvent, path: string, isDir: boolean) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setCtxMenu({ x: e.clientX, y: e.clientY, path, isDir })
+  }
 
   const onToggle = (path: string) => {
     if (!activeRoot) return
@@ -469,6 +585,11 @@ export function CodingPanel() {
   const onRefresh = (path: string) => {
     if (!activeRoot) return
     refreshCodingDir(activeRoot, path)
+  }
+
+  const onDownload = (path: string) => {
+    if (!activeRoot) return
+    downloadCodingFile(activeRoot, path)
   }
 
   const onStartCreate = (dirPath: string, item: 'file' | 'dir') => {
@@ -571,7 +692,19 @@ export function CodingPanel() {
         </> : null}
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto py-1">
+      <div
+        className={`min-h-0 flex-1 overflow-y-auto py-1 ${
+          dropTargetPath === '' ? 'bg-koma-accent/5' : ''
+        }`}
+        onDragOver={(e) => onExternalDragOver(e, '')}
+        onDrop={(e) => onExternalDrop(e, '')}
+        onDragLeave={(e) => onExternalDragLeave(e, '')}
+        onContextMenu={(e) => {
+          // Empty-area right-click → root context (upload target only; no download).
+          if ((e.target as HTMLElement).closest('[data-coding-row]')) return
+          onOpenContextMenu(e, '', true)
+        }}
+      >
         {!activeRoot ? (
           <Empty>Select a workspace root</Empty>
         ) : rootDir?.loading && !rootDir.entries.length && !rootCreate ? (
@@ -600,24 +733,119 @@ export function CodingPanel() {
                   depth={0}
                   expanded={expanded}
                   draft={draft}
+                  dropTargetPath={dropTargetPath}
                   onToggle={onToggle}
                   onOpenFile={onOpenFile}
                   onRefresh={onRefresh}
                   onStartCreate={onStartCreate}
                   onStartRename={onStartRename}
                   onStartDelete={onStartDelete}
+                  onDownload={onDownload}
                   onCancelDraft={onCancelDraft}
                   onSubmitCreate={onSubmitCreate}
                   onSubmitRename={onSubmitRename}
                   onConfirmDelete={onConfirmDelete}
+                  onExternalDragOver={onExternalDragOver}
+                  onExternalDrop={onExternalDrop}
+                  onExternalDragLeave={onExternalDragLeave}
+                  onOpenContextMenu={onOpenContextMenu}
                 />
               ))
             ) : !rootCreate ? (
-              <Empty>Empty workspace</Empty>
+              <Empty>
+                {dropTargetPath === '' ? 'Drop files to upload' : 'Empty workspace'}
+              </Empty>
             ) : null}
           </>
         )}
       </div>
+
+      {ctxMenu && activeRoot ? (
+        <div
+          className="fixed z-[80] min-w-[140px] rounded border border-koma-border bg-koma-panel py-1 shadow-lg"
+          style={{ left: ctxMenu.x, top: ctxMenu.y }}
+          onClick={(e) => e.stopPropagation()}
+          onContextMenu={(e) => e.preventDefault()}
+        >
+          {!ctxMenu.isDir ? (
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[12px] text-koma-fg opacity-90 hover:bg-koma-hover"
+              onClick={() => {
+                onDownload(ctxMenu.path)
+                setCtxMenu(null)
+              }}
+            >
+              <Download size={12} className="opacity-70" />
+              Download
+            </button>
+          ) : null}
+          {ctxMenu.isDir ? (
+            <>
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[12px] text-koma-fg opacity-90 hover:bg-koma-hover"
+                onClick={() => {
+                  onStartCreate(ctxMenu.path, 'file')
+                  setCtxMenu(null)
+                }}
+              >
+                <FilePlus size={12} className="opacity-70" />
+                New file
+              </button>
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[12px] text-koma-fg opacity-90 hover:bg-koma-hover"
+                onClick={() => {
+                  onStartCreate(ctxMenu.path, 'dir')
+                  setCtxMenu(null)
+                }}
+              >
+                <FolderPlus size={12} className="opacity-70" />
+                New folder
+              </button>
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[12px] text-koma-fg opacity-90 hover:bg-koma-hover"
+                onClick={() => {
+                  onRefresh(ctxMenu.path)
+                  setCtxMenu(null)
+                }}
+              >
+                <RefreshCw size={12} className="opacity-70" />
+                Refresh
+              </button>
+            </>
+          ) : null}
+          {ctxMenu.path !== '' ? (
+            <>
+              <div className="my-1 border-t border-koma-border" />
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[12px] text-koma-fg opacity-90 hover:bg-koma-hover"
+                onClick={() => {
+                  onStartRename(ctxMenu.path)
+                  setCtxMenu(null)
+                }}
+              >
+                <Pencil size={12} className="opacity-70" />
+                Rename
+              </button>
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[12px] text-koma-error opacity-90 hover:bg-koma-error/15"
+                onClick={() => {
+                  onStartDelete(ctxMenu.path, ctxMenu.isDir)
+                  setCtxMenu(null)
+                }}
+              >
+                <Trash2 size={12} className="opacity-70" />
+                Delete
+              </button>
+            </>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src-webgui/src/koma.d.ts
+++ b/src-webgui/src/koma.d.ts
@@ -513,6 +513,11 @@ declare global {
     | { r: 'FileRename'; root: string; oldPath: string; newPath: string; requestId: string }
     // Delete a file or directory (recursive for dirs). Reply lands as FileDelete push.
     | { r: 'FileDelete'; root: string; path: string; requestId: string }
+    // Write raw bytes (drag-upload / remote upload). bytesB64 is standard base64.
+    // overwrite=false rejects existing paths. Reply: FileWriteBytes.
+    | { r: 'FileWriteBytes'; root: string; path: string; bytesB64: string; overwrite?: boolean; requestId: string }
+    // Read raw bytes for download / save-as. Reply: FileDownloadBytes.
+    | { r: 'FileDownloadBytes'; root: string; path: string; requestId: string }
     // ─── Language servers (Settings + editor banner) ─────────────────────
     // Full catalogue status (managed / PATH / missing). Reply: LspStatus.
     | { r: 'LspStatus' }
@@ -521,6 +526,14 @@ declare global {
     | { r: 'LspInstall'; id?: string | null; all?: boolean; force?: boolean }
     // Remove a koma-managed install. Never touches PATH copies.
     | { r: 'LspUninstall'; id: string }
+    // ─── Language client (Monaco providers + doc sync) ────────────────
+    | { r: 'LspDidOpen'; root: string; path: string; languageId: string; text: string }
+    | { r: 'LspDidChange'; root: string; path: string; text: string }
+    | { r: 'LspDidSave'; root: string; path: string; text?: string | null }
+    | { r: 'LspDidClose'; root: string; path: string }
+    | { r: 'LspCompletion'; root: string; path: string; line: number; character: number; requestId: string }
+    | { r: 'LspHover'; root: string; path: string; line: number; character: number; requestId: string }
+    | { r: 'LspDefinition'; root: string; path: string; line: number; character: number; requestId: string }
     // Write an error message to the global error log (`~/.koma/error.log`). Used by
     // the React error boundary to log runtime errors that only occur in the built
     // app (not in dev mode). No reply, no session needed.
@@ -603,6 +616,17 @@ declare global {
     | { k: 'FileCreate'; root: string; path: string; requestId: string; error: string | null }
     | { k: 'FileRename'; root: string; oldPath: string; newPath: string; requestId: string; error: string | null }
     | { k: 'FileDelete'; root: string; path: string; requestId: string; error: string | null }
+    | { k: 'FileWriteBytes'; root: string; path: string; requestId: string; error: string | null }
+    | {
+        k: 'FileDownloadBytes'
+        root: string
+        path: string
+        requestId: string
+        bytesB64: string | null
+        size: number
+        tooLarge: boolean
+        error: string | null
+      }
 
   type LspServerStatus = {
     id: string
@@ -619,6 +643,47 @@ declare global {
   type LspPush =
     | { k: 'LspStatus'; servers: LspServerStatus[] }
     | { k: 'LspInstall'; id: string; pct: number; error: string | null }
+    | { k: 'LspDiagnostics'; uri: string; diagnostics: LspDiagnostic[] }
+    | { k: 'LspCompletion'; requestId: string; items: LspCompletionItem[]; error: string | null }
+    | { k: 'LspHover'; requestId: string; hover: LspHover | null; error: string | null }
+    | { k: 'LspDefinition'; requestId: string; locations: LspLocation[]; error: string | null }
+
+  type LspDiagnostic = {
+    uri: string
+    line: number
+    character: number
+    endLine: number
+    endCharacter: number
+    severity: number
+    message: string
+    source?: string
+    code?: string
+  }
+
+  type LspCompletionItem = {
+    label: string
+    kind?: number
+    detail?: string
+    insertText?: string
+    documentation?: string
+  }
+
+  type LspRange = {
+    startLine: number
+    startCharacter: number
+    endLine: number
+    endCharacter: number
+  }
+
+  type LspHover = {
+    contents: string
+    range?: LspRange
+  }
+
+  type LspLocation = {
+    uri: string
+    range: LspRange
+  }
 
   type RemoteHost = {
     id: string

--- a/src-webgui/src/lib/monaco-lsp.ts
+++ b/src-webgui/src/lib/monaco-lsp.ts
@@ -1,0 +1,408 @@
+// Monaco ↔ host LSP bridge: pending request map + provider registration +
+// diagnostic markers. Providers talk JSON-RPC through GuiReq; replies land as
+// PushEnvelope variants handled in the koma store, which resolves the matching
+// Promise here.
+
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
+import { langFromPath } from './monaco-setup'
+
+export type LspDiagnostic = {
+  uri: string
+  line: number
+  character: number
+  endLine: number
+  endCharacter: number
+  severity: number
+  message: string
+  source?: string
+  code?: string
+}
+
+export type LspCompletionItem = {
+  label: string
+  kind?: number
+  detail?: string
+  insertText?: string
+  documentation?: string
+}
+
+export type LspHover = {
+  contents: string
+  range?: {
+    startLine: number
+    startCharacter: number
+    endLine: number
+    endCharacter: number
+  }
+}
+
+export type LspLocation = {
+  uri: string
+  range: {
+    startLine: number
+    startCharacter: number
+    endLine: number
+    endCharacter: number
+  }
+}
+
+type Pending<T> = {
+  resolve: (v: T) => void
+  reject: (e: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+const PENDING_MS = 12_000
+
+const pendingCompletion = new Map<string, Pending<LspCompletionItem[]>>()
+const pendingHover = new Map<string, Pending<LspHover | null>>()
+const pendingDefinition = new Map<string, Pending<LspLocation[]>>()
+
+let reqCounter = 0
+function mintId(prefix: string): string {
+  reqCounter += 1
+  return `${prefix}-${Date.now().toString(36)}-${reqCounter}`
+}
+
+function track<T>(
+  map: Map<string, Pending<T>>,
+  id: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      map.delete(id)
+      reject(new Error('LSP request timed out'))
+    }, PENDING_MS)
+    map.set(id, { resolve, reject, timer })
+  })
+}
+
+function settle<T>(
+  map: Map<string, Pending<T>>,
+  id: string,
+  value: T,
+  error: string | null | undefined,
+): void {
+  const p = map.get(id)
+  if (!p) return
+  map.delete(id)
+  clearTimeout(p.timer)
+  if (error) p.reject(new Error(error))
+  else p.resolve(value)
+}
+
+/** Called from the store push reducer. */
+export function resolveLspCompletion(
+  requestId: string,
+  items: LspCompletionItem[],
+  error: string | null,
+): void {
+  settle(pendingCompletion, requestId, items ?? [], error)
+}
+
+export function resolveLspHover(
+  requestId: string,
+  hover: LspHover | null,
+  error: string | null,
+): void {
+  settle(pendingHover, requestId, hover, error)
+}
+
+export function resolveLspDefinition(
+  requestId: string,
+  locations: LspLocation[],
+  error: string | null,
+): void {
+  settle(pendingDefinition, requestId, locations ?? [], error)
+}
+
+// ─── URI helpers ─────────────────────────────────────────────────────────────
+
+/** file:// URI matching the host's path_to_uri. */
+export function pathToUri(root: string, path: string): string {
+  const abs = path.startsWith('/') || /^[A-Za-z]:[\\/]/.test(path)
+    ? path
+    : `${root.replace(/\/$/, '')}/${path.replace(/^\//, '')}`
+  const norm = abs.replace(/\\/g, '/')
+  if (norm.startsWith('/')) return `file://${norm}`
+  return `file:///${norm}`
+}
+
+/** Best-effort parse of file:// URI → absolute filesystem path. */
+export function uriToPath(uri: string): string | null {
+  if (!uri.startsWith('file://')) return null
+  let rest = uri.slice('file://'.length)
+  // Windows file:///C:/...
+  if (/^\/[A-Za-z]:\//.test(rest)) rest = rest.slice(1)
+  try {
+    return decodeURIComponent(rest)
+  } catch {
+    return rest
+  }
+}
+
+/** Split absolute path into workspace root + relative path using open roots. */
+export function splitRootPath(
+  absPath: string,
+  roots: string[],
+): { root: string; path: string } | null {
+  const norm = absPath.replace(/\\/g, '/')
+  const sorted = [...roots].sort((a, b) => b.length - a.length)
+  for (const root of sorted) {
+    const r = root.replace(/\\/g, '/').replace(/\/$/, '')
+    if (norm === r) return { root, path: '' }
+    if (norm.startsWith(r + '/')) {
+      return { root, path: norm.slice(r.length + 1) }
+    }
+  }
+  return null
+}
+
+// ─── Markers ─────────────────────────────────────────────────────────────────
+
+const MARKER_OWNER = 'koma-lsp'
+
+export function applyDiagnosticsToMonaco(uri: string, diagnostics: LspDiagnostic[]): void {
+  const models = monaco.editor.getModels()
+  // Match by path suffix — Monaco models may use inmemory: or file:// URIs.
+  const abs = uriToPath(uri)
+  const model = models.find((m) => {
+    const mu = m.uri.toString()
+    if (mu === uri) return true
+    if (abs && (mu.endsWith(abs) || mu.includes(abs))) return true
+    return false
+  })
+  if (!model) {
+    // No open model — Problems drawer still has the list; markers apply on next open.
+    return
+  }
+  const markers: monaco.editor.IMarkerData[] = diagnostics.map((d) => ({
+    severity: lspSeverityToMonaco(d.severity),
+    message: d.message,
+    startLineNumber: d.line + 1,
+    startColumn: d.character + 1,
+    endLineNumber: (d.endLine ?? d.line) + 1,
+    endColumn: (d.endCharacter ?? d.character) + 1,
+    source: d.source,
+    code: d.code,
+  }))
+  monaco.editor.setModelMarkers(model, MARKER_OWNER, markers)
+}
+
+function lspSeverityToMonaco(s: number): monaco.MarkerSeverity {
+  // 1 Error, 2 Warning, 3 Info, 4 Hint
+  if (s === 1) return monaco.MarkerSeverity.Error
+  if (s === 2) return monaco.MarkerSeverity.Warning
+  if (s === 3) return monaco.MarkerSeverity.Info
+  return monaco.MarkerSeverity.Hint
+}
+
+// ─── Provider registration (once) ────────────────────────────────────────────
+
+let providersReady = false
+
+type ReqFn = (body: object) => void
+type RootsFn = () => string[]
+
+/**
+ * Register completion / hover / definition providers for all languages.
+ * Safe to call multiple times; only the first registration sticks.
+ */
+export function ensureLspProviders(req: ReqFn, getRoots: RootsFn): void {
+  if (providersReady) return
+  providersReady = true
+
+  const selector: monaco.languages.LanguageSelector = { language: '*' }
+
+  monaco.languages.registerCompletionItemProvider(selector, {
+    triggerCharacters: ['.', ':', '<', '"', "'", '/', '@'],
+    provideCompletionItems: async (model, position) => {
+      const loc = modelToRootPath(model, getRoots())
+      if (!loc) return { suggestions: [] }
+      const requestId = mintId('cmp')
+      const p = track(pendingCompletion, requestId)
+      req({
+        r: 'LspCompletion',
+        root: loc.root,
+        path: loc.path,
+        line: position.lineNumber - 1,
+        character: position.column - 1,
+        requestId,
+      })
+      try {
+        const items = await p
+        const suggestions: monaco.languages.CompletionItem[] = items.map((it, i) => {
+          const range = {
+            startLineNumber: position.lineNumber,
+            startColumn: position.column,
+            endLineNumber: position.lineNumber,
+            endColumn: position.column,
+          }
+          // Expand range to word under cursor when possible.
+          const word = model.getWordUntilPosition(position)
+          if (word) {
+            range.startColumn = word.startColumn
+            range.endColumn = word.endColumn
+          }
+          return {
+            label: it.label,
+            kind: lspCompletionKind(it.kind),
+            detail: it.detail,
+            documentation: it.documentation,
+            insertText: it.insertText ?? it.label,
+            range,
+            sortText: String(i).padStart(5, '0'),
+          }
+        })
+        return { suggestions }
+      } catch {
+        return { suggestions: [] }
+      }
+    },
+  })
+
+  monaco.languages.registerHoverProvider(selector, {
+    provideHover: async (model, position) => {
+      const loc = modelToRootPath(model, getRoots())
+      if (!loc) return null
+      const requestId = mintId('hov')
+      const p = track(pendingHover, requestId)
+      req({
+        r: 'LspHover',
+        root: loc.root,
+        path: loc.path,
+        line: position.lineNumber - 1,
+        character: position.column - 1,
+        requestId,
+      })
+      try {
+        const hover = await p
+        if (!hover?.contents) return null
+        const range = hover.range
+          ? {
+              startLineNumber: hover.range.startLine + 1,
+              startColumn: hover.range.startCharacter + 1,
+              endLineNumber: hover.range.endLine + 1,
+              endColumn: hover.range.endCharacter + 1,
+            }
+          : undefined
+        return {
+          contents: [{ value: hover.contents }],
+          range,
+        }
+      } catch {
+        return null
+      }
+    },
+  })
+
+  monaco.languages.registerDefinitionProvider(selector, {
+    provideDefinition: async (model, position) => {
+      const loc = modelToRootPath(model, getRoots())
+      if (!loc) return null
+      const requestId = mintId('def')
+      const p = track(pendingDefinition, requestId)
+      req({
+        r: 'LspDefinition',
+        root: loc.root,
+        path: loc.path,
+        line: position.lineNumber - 1,
+        character: position.column - 1,
+        requestId,
+      })
+      try {
+        const locations = await p
+        if (!locations.length) return null
+        const roots = getRoots()
+        return locations.map((l) => {
+          const abs = uriToPath(l.uri)
+          // Prefer opening via coding tab when we can map to a workspace path.
+          if (abs) {
+            const split = splitRootPath(abs, roots)
+            if (split) {
+              // Side-effect open is done by the consumer via store; here we
+              // return a Monaco location. CodeEditorTab wires go-to via a
+              // custom command when the target isn't the current model.
+              void split
+            }
+          }
+          return {
+            uri: monaco.Uri.parse(l.uri),
+            range: {
+              startLineNumber: l.range.startLine + 1,
+              startColumn: l.range.startCharacter + 1,
+              endLineNumber: l.range.endLine + 1,
+              endColumn: l.range.endCharacter + 1,
+            },
+          }
+        })
+      } catch {
+        return null
+      }
+    },
+  })
+}
+
+function modelToRootPath(
+  model: monaco.editor.ITextModel,
+  roots: string[],
+): { root: string; path: string } | null {
+  // Prefer metadata stamped by CodeEditorTab.
+  const meta = (model as unknown as { __komaRoot?: string; __komaPath?: string })
+  if (meta.__komaRoot && meta.__komaPath != null) {
+    return { root: meta.__komaRoot, path: meta.__komaPath }
+  }
+  const u = model.uri.toString()
+  const abs = uriToPath(u)
+  if (!abs) return null
+  return splitRootPath(abs, roots)
+}
+
+function lspCompletionKind(kind?: number): monaco.languages.CompletionItemKind {
+  // LSP CompletionItemKind → Monaco (values mostly align 1..25).
+  const K = monaco.languages.CompletionItemKind
+  switch (kind) {
+    case 1: return K.Text
+    case 2: return K.Method
+    case 3: return K.Function
+    case 4: return K.Constructor
+    case 5: return K.Field
+    case 6: return K.Variable
+    case 7: return K.Class
+    case 8: return K.Interface
+    case 9: return K.Module
+    case 10: return K.Property
+    case 11: return K.Unit
+    case 12: return K.Value
+    case 13: return K.Enum
+    case 14: return K.Keyword
+    case 15: return K.Snippet
+    case 16: return K.Color
+    case 17: return K.File
+    case 18: return K.Reference
+    case 19: return K.Folder
+    case 20: return K.EnumMember
+    case 21: return K.Constant
+    case 22: return K.Struct
+    case 23: return K.Event
+    case 24: return K.Operator
+    case 25: return K.TypeParameter
+    default: return K.Text
+  }
+}
+
+/** Stamp root/path on a model so providers can reverse-map without URI hacks. */
+export function stampModelPath(
+  model: monaco.editor.ITextModel,
+  root: string,
+  path: string,
+): void {
+  const m = model as unknown as { __komaRoot?: string; __komaPath?: string }
+  m.__komaRoot = root
+  m.__komaPath = path
+}
+
+export function languageIdForPath(path: string): string {
+  // Prefer Monaco's mapped id; host accepts the same strings.
+  return langFromPath(path)
+}

--- a/src-webgui/src/routes/index.tsx
+++ b/src-webgui/src/routes/index.tsx
@@ -16,6 +16,7 @@ import { RemotePasswordPrompt } from '../components/RemotePasswordPrompt'
 import { RemotePathPicker } from '../components/RemotePathPicker'
 import { ToastContainer } from '../components/ToastContainer'
 import { UsageFooter } from '../components/UsageFooter'
+import { ProblemsDrawer } from '../components/ProblemsDrawer'
 import { useKoma } from '../store/koma'
 import { BrailleSpinner } from '../components/BrailleSpinner'
 import { ExtensionPanelFrame } from '../components/ExtensionPanelFrame'
@@ -487,6 +488,7 @@ function TabbedMain() {
           ) : null,
         )}
       </div>
+      <ProblemsDrawer />
       <UsageFooter />
     </div>
   )

--- a/src-webgui/src/store/coding.ts
+++ b/src-webgui/src/store/coding.ts
@@ -131,6 +131,23 @@ export type FileDeletePush = {
   requestId: string
   error: string | null
 }
+export type FileWriteBytesPush = {
+  k: 'FileWriteBytes'
+  root: string
+  path: string
+  requestId: string
+  error: string | null
+}
+export type FileDownloadBytesPush = {
+  k: 'FileDownloadBytes'
+  root: string
+  path: string
+  requestId: string
+  bytesB64: string | null
+  size: number
+  tooLarge: boolean
+  error: string | null
+}
 
 export type CodingPush =
   | FileTreePush
@@ -139,6 +156,8 @@ export type CodingPush =
   | FileCreatePush
   | FileRenamePush
   | FileDeletePush
+  | FileWriteBytesPush
+  | FileDownloadBytesPush
 
 /** Apply a FileTree push into the coding slice (stale-reply guarded). */
 export function reduceFileTree(coding: CodingSlice, env: FileTreePush): CodingSlice {
@@ -369,4 +388,9 @@ export function reduceFileDelete(coding: CodingSlice, env: FileDeletePush): Codi
   let next = dropPathAndDescendants(coding, env.root, env.path)
   next = invalidateDir(next, env.root, env.path)
   return next
+}
+
+export function reduceFileWriteBytes(coding: CodingSlice, env: FileWriteBytesPush): CodingSlice {
+  if (env.error) return coding
+  return invalidateDir(coding, env.root, env.path)
 }

--- a/src-webgui/src/store/koma.ts
+++ b/src-webgui/src/store/koma.ts
@@ -13,12 +13,23 @@ import {
   reduceFileCreate,
   reduceFileRename,
   reduceFileDelete,
+  reduceFileWriteBytes,
   remapPath as codingRemapPath,
   type CodingSlice,
   type FileTreeEntry,
 } from './coding'
 
+import {
+  applyDiagnosticsToMonaco,
+  resolveLspCompletion,
+  resolveLspDefinition,
+  resolveLspHover,
+  uriToPath,
+  type LspDiagnostic,
+} from '../lib/monaco-lsp'
+
 export type { CodingSlice, CodingFileState, DirState, FileTreeEntry } from './coding'
+export type { LspDiagnostic }
 export { fileKey, initialCoding } from './coding'
 import { postToPanel, broadcastThemeToPanels } from '../lib/panelBridge'
 
@@ -1275,6 +1286,29 @@ export type PushEnvelope =
       pct: number
       error: string | null
     }
+  | {
+      k: 'LspDiagnostics'
+      uri: string
+      diagnostics: LspDiagnostic[]
+    }
+  | {
+      k: 'LspCompletion'
+      requestId: string
+      items: import('../lib/monaco-lsp').LspCompletionItem[]
+      error: string | null
+    }
+  | {
+      k: 'LspHover'
+      requestId: string
+      hover: import('../lib/monaco-lsp').LspHover | null
+      error: string | null
+    }
+  | {
+      k: 'LspDefinition'
+      requestId: string
+      locations: import('../lib/monaco-lsp').LspLocation[]
+      error: string | null
+    }
   // Reply to GuiReq GitBranchList (G4) — every local + remote-tracking branch
   // for the branch-switcher popover / graph context menu. Carries
   // `BranchListResult` verbatim (already camelCase) flattened onto the
@@ -1377,6 +1411,23 @@ export type PushEnvelope =
       root: string
       path: string
       requestId: string
+      error: string | null
+    }
+  | {
+      k: 'FileWriteBytes'
+      root: string
+      path: string
+      requestId: string
+      error: string | null
+    }
+  | {
+      k: 'FileDownloadBytes'
+      root: string
+      path: string
+      requestId: string
+      bytesB64: string | null
+      size: number
+      tooLarge: boolean
       error: string | null
     }
   // Reply to GuiReq ImportGraphImpact — transitive impact paths.
@@ -2011,6 +2062,10 @@ type KomaState = {
   lspServers: LspServerStatus[]
   // Per-id install progress (latest LspInstall). Cleared when status lands idle.
   lspProgress: Record<string, LspInstallProgress>
+  // Diagnostics keyed by file URI (latest LspDiagnostics per uri).
+  lspDiagnostics: Record<string, LspDiagnostic[]>
+  // Cross-tab Problems drawer (above UsageFooter).
+  problemsOpen: boolean
   // The SSH Keys section's transient "Copy public key" / "Reveal private key"
   // result (latest KeyReveal push), or `null` when nothing has been revealed
   // yet / the reveal box was dismissed. Kept separate from `keys` (the list
@@ -2389,6 +2444,11 @@ type KomaState = {
   lspInstall: (id: string | null, all?: boolean, force?: boolean) => void
   // Uninstall a koma-managed server (never touches PATH copies).
   lspUninstall: (id: string) => void
+  // Toggle the cross-tab Problems drawer above the footer.
+  setProblemsOpen: (open: boolean) => void
+  toggleProblemsOpen: () => void
+  // Open coding file at a diagnostic location (uri may be file://).
+  openDiagnostic: (uri: string, line: number, character: number) => void
   // Open (or focus) a read-only STREAM tab for a sub-agent (`kind:'subagent'`) or bash
   // job (`kind:'bash'`) by its numeric id: find-or-create (dedup by the stable
   // `sa:`/`bash:` id), activate it, and sync the stream view so the host starts streaming
@@ -2467,6 +2527,10 @@ type KomaState = {
   createCodingItem: (root: string, path: string, kind: 'file' | 'dir') => void
   renameCodingItem: (root: string, oldPath: string, newPath: string) => void
   deleteCodingItem: (root: string, path: string) => void
+  /** Drag-upload / remote upload: write raw file bytes under root/path. */
+  uploadCodingFile: (root: string, dirPath: string, file: File, overwrite?: boolean) => Promise<void>
+  /** Download / save-as: fetch bytes and trigger a browser download. */
+  downloadCodingFile: (root: string, path: string) => void
   refreshCodingDir: (root: string, path: string) => void
   clearCodingConflict: (root: string, path: string) => void
 }
@@ -2804,6 +2868,8 @@ export const useKoma = create<KomaState>((set, get) => ({
   keys: initialKeys,
   lspServers: [],
   lspProgress: {},
+  lspDiagnostics: {},
+  problemsOpen: false,
   keyRevealResult: null,
   branches: [],
   branchesLoading: false,
@@ -4088,6 +4154,21 @@ export const useKoma = create<KomaState>((set, get) => ({
           }
         })
         break
+      case 'LspDiagnostics':
+        set((s) => ({
+          lspDiagnostics: { ...s.lspDiagnostics, [env.uri]: env.diagnostics ?? [] },
+        }))
+        applyDiagnosticsToMonaco(env.uri, env.diagnostics ?? [])
+        break
+      case 'LspCompletion':
+        resolveLspCompletion(env.requestId, env.items ?? [], env.error)
+        break
+      case 'LspHover':
+        resolveLspHover(env.requestId, env.hover ?? null, env.error)
+        break
+      case 'LspDefinition':
+        resolveLspDefinition(env.requestId, env.locations ?? [], env.error)
+        break
       case 'FileTree':
         set((s) => ({ coding: reduceFileTree(s.coding, env) }))
         break
@@ -4096,6 +4177,16 @@ export const useKoma = create<KomaState>((set, get) => ({
         break
       case 'FileSave':
         set((s) => ({ coding: reduceFileSave(s.coding, env) }))
+        if (!env.error) {
+          const key = fileKey(env.root, env.path)
+          const content = get().coding.files[key]?.content
+          get().req({
+            r: 'LspDidSave',
+            root: env.root,
+            path: env.path,
+            text: content ?? null,
+          })
+        }
         break
       case 'FileCreate':
         set((s) => {
@@ -4215,6 +4306,75 @@ export const useKoma = create<KomaState>((set, get) => ({
           return { coding, ui: { ...s.ui, tabs, activeTabId } }
         })
         break
+      case 'FileWriteBytes':
+        set((s) => {
+          const coding = reduceFileWriteBytes(s.coding, env)
+          if (env.error) {
+            const seq = s.ui.toastSeq + 1
+            return {
+              coding,
+              ui: {
+                ...s.ui,
+                toastSeq: seq,
+                toast: { id: seq, text: env.error, kind: 'error' },
+              },
+            }
+          }
+          queueMicrotask(() => {
+            const parent = env.path.includes('/')
+              ? env.path.slice(0, env.path.lastIndexOf('/'))
+              : ''
+            get().refreshCodingDir(env.root, parent)
+          })
+          return { coding }
+        })
+        break
+      case 'FileDownloadBytes': {
+        if (env.error || env.tooLarge || !env.bytesB64) {
+          const text =
+            env.error ||
+            (env.tooLarge ? 'file too large to download' : 'download failed')
+          set((s) => {
+            const seq = s.ui.toastSeq + 1
+            return {
+              ui: {
+                ...s.ui,
+                toastSeq: seq,
+                toast: { id: seq, text, kind: 'error' },
+              },
+            }
+          })
+          break
+        }
+        try {
+          const bin = atob(env.bytesB64)
+          const bytes = new Uint8Array(bin.length)
+          for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+          const blob = new Blob([bytes])
+          const name = codingBaseName(env.path) || 'download'
+          const url = URL.createObjectURL(blob)
+          const a = document.createElement('a')
+          a.href = url
+          a.download = name
+          a.rel = 'noopener'
+          document.body.appendChild(a)
+          a.click()
+          a.remove()
+          URL.revokeObjectURL(url)
+        } catch {
+          set((s) => {
+            const seq = s.ui.toastSeq + 1
+            return {
+              ui: {
+                ...s.ui,
+                toastSeq: seq,
+                toast: { id: seq, text: 'failed to save download', kind: 'error' },
+              },
+            }
+          })
+        }
+        break
+      }
       case 'AgentOp': {
         // Daemon SetAgent/DeleteAgent result — surface the error as a toast
         // and clear the pending saving state. Success is authoritative via
@@ -4339,7 +4499,9 @@ export const useKoma = create<KomaState>((set, get) => ({
       g.r === 'FileSave' ||
       g.r === 'FileCreate' ||
       g.r === 'FileRename' ||
-      g.r === 'FileDelete'
+      g.r === 'FileDelete' ||
+      g.r === 'FileWriteBytes' ||
+      g.r === 'FileDownloadBytes'
     const ipc = window.ipc
     if (!ipc || typeof ipc.postMessage !== 'function') {
       if (isCodingReq) {
@@ -5146,6 +5308,47 @@ export const useKoma = create<KomaState>((set, get) => ({
   lspUninstall: (id) => {
     get().req({ r: 'LspUninstall', id })
   },
+  setProblemsOpen: (open) => set({ problemsOpen: !!open }),
+  toggleProblemsOpen: () => set((s) => ({ problemsOpen: !s.problemsOpen })),
+  openDiagnostic: (uri, line, character) => {
+    const abs = uriToPath(uri)
+    if (!abs) return
+    const roots = (get().settingsValues?.workdir ?? []).filter(Boolean)
+    const sorted = [...roots].sort((a, b) => b.length - a.length)
+    let root: string | null = get().coding.activeRoot
+    let rel = abs
+    const aa = abs.replace(/\\/g, '/')
+    for (const r of sorted) {
+      const rr = r.replace(/\\/g, '/').replace(/\/$/, '')
+      if (aa === rr || aa.startsWith(rr + '/')) {
+        root = r
+        rel = aa === rr ? '' : aa.slice(rr.length + 1)
+        break
+      }
+    }
+    if (!root) {
+      for (const tab of get().ui.tabs) {
+        if (tab.kind !== 'codingFile') continue
+        const rr = tab.root.replace(/\\/g, '/').replace(/\/$/, '')
+        if (aa === rr || aa.startsWith(rr + '/')) {
+          root = tab.root
+          rel = aa === rr ? '' : aa.slice(rr.length + 1)
+          break
+        }
+      }
+    }
+    if (!root) return
+    get().openCodingFile(root, rel)
+    const targetLine = line + 1
+    const targetCol = character + 1
+    setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent('koma-reveal-line', {
+          detail: { root, path: rel, line: targetLine, column: targetCol },
+        }),
+      )
+    }, 80)
+  },
   openStreamTab: (kind, targetId, title) => {
     const id = kind === 'subagent' ? `sa:${targetId}` : `bash:${targetId}`
     set((s) => {
@@ -5206,6 +5409,9 @@ export const useKoma = create<KomaState>((set, get) => ({
       if (closing && closing.kind === 'codingFile' && !opts?.force) {
         const f = get().coding.files[fileKey(closing.root, closing.path)]
         if (f?.dirty) return
+      }
+      if (closing && closing.kind === 'codingFile') {
+        get().req({ r: 'LspDidClose', root: closing.root, path: closing.path })
       }
     }
     const closedAnalytics = id === 'analytics'
@@ -5466,6 +5672,61 @@ export const useKoma = create<KomaState>((set, get) => ({
   },
   deleteCodingItem: (root, path) => {
     get().req({ r: 'FileDelete', root, path, requestId: mintRequestId() })
+  },
+  uploadCodingFile: async (root, dirPath, file, overwrite = true) => {
+    const name = (file.name || 'upload').replace(/^.*[/\\]/, '')
+    if (!name || name.includes('..')) {
+      const text = 'invalid file name'
+      set((s) => {
+        const seq = s.ui.toastSeq + 1
+        return {
+          ui: { ...s.ui, toastSeq: seq, toast: { id: seq, text, kind: 'error' } },
+        }
+      })
+      return
+    }
+    // Match host FILE_BYTES_SIZE_CAP (25 MiB) before shipping base64 over IPC.
+    const MAX = 25 * 1024 * 1024
+    if (file.size > MAX) {
+      const text = `file too large (max 25 MiB): ${name}`
+      set((s) => {
+        const seq = s.ui.toastSeq + 1
+        return {
+          ui: { ...s.ui, toastSeq: seq, toast: { id: seq, text, kind: 'error' } },
+        }
+      })
+      return
+    }
+    const path = dirPath ? `${dirPath.replace(/\/+$/, '')}/${name}` : name
+    try {
+      const buf = await file.arrayBuffer()
+      const bytes = new Uint8Array(buf)
+      let binary = ''
+      const chunk = 0x8000
+      for (let i = 0; i < bytes.length; i += chunk) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+      }
+      const bytesB64 = btoa(binary)
+      get().req({
+        r: 'FileWriteBytes',
+        root,
+        path,
+        bytesB64,
+        overwrite: overwrite !== false,
+        requestId: mintRequestId(),
+      })
+    } catch {
+      const text = `failed to read file: ${name}`
+      set((s) => {
+        const seq = s.ui.toastSeq + 1
+        return {
+          ui: { ...s.ui, toastSeq: seq, toast: { id: seq, text, kind: 'error' } },
+        }
+      })
+    }
+  },
+  downloadCodingFile: (root, path) => {
+    get().req({ r: 'FileDownloadBytes', root, path, requestId: mintRequestId() })
   },
   refreshCodingDir: (root, path) => {
     const key = fileKey(root, path)


### PR DESCRIPTION
Wire host-spawned language servers end-to-end: LspManager stdio client, GuiReq/HostCtl/Push for doc sync and providers, Monaco LspBridge, diagnostics markers, and Problems drawer.

Add Coding-panel binary transfer: FileWriteBytes / FileDownloadBytes through local host and remote-fs (base64, 25 MiB cap). Drag-drop files onto the tree to upload; right-click Download (and hover icon) to save.