### PR TITLE
fix(agent): mark TOOL_NUDGE as auto message (v0.3.29)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent"
-version = "0.3.28"
+version = "0.3.29"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       systems = [ "x86_64-linux" "aarch64-linux" ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
 
-      version = "0.3.28";
+      version = "0.3.29";
 
       mkPackages = system:
         let

--- a/src-agent/Cargo.toml
+++ b/src-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent"
-version = "0.3.28"
+version = "0.3.29"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src-agent/src/app/runtime/stream/run.rs
+++ b/src-agent/src/app/runtime/stream/run.rs
@@ -11,7 +11,7 @@ use crate::service::openrouter::OpenRouterClient;
 
 /// Wire-only tool-nudge appended to the last User message on first hop.
 /// Never persisted — only mutates the local `history` Vec before POST.
-const TOOL_NUDGE: &str = "\n\nIMPORTANT:\n\
+const TOOL_NUDGE: &str = "\n\nIMPORTANT (auto message, ignore if no need):\n\
 - If unsure (for example does not know how to implement, or does not know what is this or you really unsure what does the code mean or there is unclear documentation of certain module or api and other thing that IS UNSURE but NON BLOCKING), USE web_search/web_fetch rather than guessing.\n\
 - If you need prior conversation context, use message_find.\n\
 - If internet and history having zero result, STOP and ASK me.";

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.3.28",
+  "version": "0.3.29",
   "message": "fix: hard-warn + error.log when Main auto-routes to koma/apple"
 }


### PR DESCRIPTION
Clarify the wire-only first-hop nudge so models treat it as optional injected guidance rather than user-authored IMPORTANT content. Bump 0.3.28 → 0.3.29.